### PR TITLE
Storybook build target

### DIFF
--- a/libs/design-system/project.json
+++ b/libs/design-system/project.json
@@ -4,6 +4,19 @@
   "sourceRoot": "libs/design-system/src",
   "projectType": "library",
   "tags": [],
-  "// targets": "to see all targets run: nx show project design-system --web",
-  "targets": {}
+  "targets": {
+    "build-storybook": {
+      "executor": "@nx/storybook:build",
+      "outputs": ["{options.outputDir}"],
+      "options": {
+        "outputDir": "libs/design-system/dist/storybook",
+        "configDir": "libs/design-system/.storybook"
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Summary

Adds a build target for the design system

### Notes

Now that there are multiple Vercel projects for this repo, it would be good to create an ignore step. While `web-main` should build if there are changes in the `design-system` library, the reverse is not true.