### PR TITLE
Translation passage blocks

### DIFF
--- a/libs/design-system/src/lib/Editor/BlockEditor.stories.tsx
+++ b/libs/design-system/src/lib/Editor/BlockEditor.stories.tsx
@@ -5,32 +5,56 @@ const content = {
   type: 'doc',
   content: [
     {
-      type: 'heading',
-      attrs: { level: 1 },
+      sort: 136,
+      type: 'translationHeader',
+      uuid: '54a251d8-e074-4516-973b-b353bfe385ed',
+      xmlId: 'UT22084-066-009-section-1',
       content: [
         {
           type: 'text',
-          text: 'A heading',
+          text: 'The Translation',
         },
       ],
+      work_uuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     },
     {
-      type: 'translationTitle',
+      sort: 141,
+      type: 'translation',
+      uuid: '31a821e6-9a69-4950-a32d-52645ef0fbe5',
+      xmlId: 'UT22084-066-009-26',
       content: [
         {
           type: 'text',
-          text: 'A Translation Title',
+          text: 'Homage to all the buddhas and bodhisattvas!',
         },
       ],
+      work_uuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     },
     {
-      type: 'paragraph',
+      sort: 146,
+      type: 'translation',
+      uuid: '09d19c19-a9da-450b-be90-c517f106469b',
+      xmlId: 'UT22084-066-009-226',
       content: [
         {
           type: 'text',
-          text: 'A line of text',
+          text: 'Thus did I hear at one time. The Buddha was residing in Śrāvastī, in Jeta’s Grove, Anāthapiṇḍada’s park, together with a great community of monks, consisting of 1,250 monks, and a great assembly of bodhisattvas. At that time, the Blessed One addressed the monks:',
         },
       ],
+      work_uuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    },
+    {
+      sort: 151,
+      type: 'translation',
+      uuid: 'e2876129-3034-4bbe-a4fb-3049e38909ec',
+      xmlId: 'UT22084-066-009-30',
+      content: [
+        {
+          type: 'text',
+          text: '“Monks, for as long as they live, bodhisattvas, great beings, should not abandon four factors even at the cost of their lives. What are these four?',
+        },
+      ],
+      work_uuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     },
   ],
 };

--- a/libs/design-system/src/lib/Editor/extensions/Paragraph/Component.tsx
+++ b/libs/design-system/src/lib/Editor/extensions/Paragraph/Component.tsx
@@ -3,9 +3,9 @@ import { P } from '../../../Typography/Typography';
 
 export default ({ node }: NodeViewProps) => {
   return (
-    <NodeViewWrapper className="heading">
+    <NodeViewWrapper className="paragraph">
       <P>
-        <NodeViewContent className="heading-content" />
+        <NodeViewContent className="paragraph-content" />
       </P>
     </NodeViewWrapper>
   );

--- a/libs/design-system/src/lib/Editor/extensions/Translation/Component.tsx
+++ b/libs/design-system/src/lib/Editor/extensions/Translation/Component.tsx
@@ -1,0 +1,12 @@
+import { NodeViewContent, NodeViewProps, NodeViewWrapper } from '@tiptap/react';
+import { P } from '../../../Typography/Typography';
+
+export default (_props: NodeViewProps) => {
+  return (
+    <NodeViewWrapper className="passage-translation">
+      <P className="pt-4">
+        <NodeViewContent className="passage-translation-content" />
+      </P>
+    </NodeViewWrapper>
+  );
+};

--- a/libs/design-system/src/lib/Editor/extensions/Translation/Translation.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Translation/Translation.ts
@@ -1,0 +1,32 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import Component from './Component';
+
+export default Node.create({
+  name: 'translation',
+  group: 'block',
+  content: 'inline*',
+  defining: true,
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: 'passage-translation',
+      },
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'passage-translation',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      0,
+    ];
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(Component);
+  },
+});

--- a/libs/design-system/src/lib/Editor/extensions/TranslationHeader/Component.tsx
+++ b/libs/design-system/src/lib/Editor/extensions/TranslationHeader/Component.tsx
@@ -1,0 +1,12 @@
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
+import { H3 } from '../../../Typography/Typography';
+
+export default () => {
+  return (
+    <NodeViewWrapper className="passage-translation-header">
+      <H3>
+        <NodeViewContent className="passage-translation-header-content" />
+      </H3>
+    </NodeViewWrapper>
+  );
+};

--- a/libs/design-system/src/lib/Editor/extensions/TranslationHeader/TranslationHeader.ts
+++ b/libs/design-system/src/lib/Editor/extensions/TranslationHeader/TranslationHeader.ts
@@ -1,0 +1,32 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import Component from './Component';
+
+export default Node.create({
+  name: 'translationHeader',
+  group: 'block',
+  content: 'inline*',
+  defining: true,
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: 'passage-translation-header',
+      },
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'paggage-translation-header',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      0,
+    ];
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(Component);
+  },
+});

--- a/libs/design-system/src/lib/Editor/extensions/TranslationTitle/Component.tsx
+++ b/libs/design-system/src/lib/Editor/extensions/TranslationTitle/Component.tsx
@@ -3,9 +3,9 @@ import { Title } from '../../../Translation';
 
 export default () => {
   return (
-    <NodeViewWrapper className="heading">
+    <NodeViewWrapper className="translation-title">
       <Title>
-        <NodeViewContent className="heading-content" />
+        <NodeViewContent className="translation-title-content" />
       </Title>
     </NodeViewWrapper>
   );

--- a/libs/design-system/src/lib/Editor/hooks/useExtensions.ts
+++ b/libs/design-system/src/lib/Editor/hooks/useExtensions.ts
@@ -3,6 +3,8 @@ import { Document } from '../extensions/Document';
 import Heading from '../extensions/Heading/Heading';
 import Paragraph from '../extensions/Paragraph/Paragraph';
 import TranslationTitle from '../extensions/TranslationTitle/TranslationTitle';
+import Translation from '../extensions/Translation/Translation';
+import TranslationHeader from '../extensions/TranslationHeader/TranslationHeader';
 
 export const useExtensions = () => {
   return {
@@ -15,6 +17,8 @@ export const useExtensions = () => {
         heading: false,
         paragraph: false,
       }),
+      Translation,
+      TranslationHeader,
       TranslationTitle,
     ],
   };

--- a/libs/design-system/src/lib/Typography/Typography.tsx
+++ b/libs/design-system/src/lib/Typography/Typography.tsx
@@ -8,7 +8,7 @@ export function H1({
   return (
     <h1
       className={cn(
-        'mt-8 scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl',
+        'mt-8 scroll-m-20 pb-2 text-4xl font-extrabold tracking-tight lg:text-5xl',
         className,
       )}
       {...props}
@@ -39,11 +39,11 @@ export function H3({
   children,
   className,
   ...props
-}: React.ComponentProps<'h4'>) {
+}: React.ComponentProps<'h3'>) {
   return (
     <h3
       className={cn(
-        'mt-6 scroll-m-20 text-2xl font-semibold tracking-tight',
+        'mt-6 scroll-m-20 pb-2 text-2xl font-semibold tracking-tight',
         className,
       )}
       {...props}
@@ -61,7 +61,7 @@ export function H4({
   return (
     <h4
       className={cn(
-        'mt-4 scroll-m-20 text-xl font-semibold tracking-tight',
+        'mt-4 scroll-m-20 pb-1 text-xl font-semibold tracking-tight',
         className,
       )}
       {...props}


### PR DESCRIPTION
### Summary

TipTap editor extensions for rendering `translation` and `translationHeader` passages.