### PR TITLE
Integrate Block Editor

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/publications/[slug]/editor/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/[slug]/editor/page.tsx
@@ -8,10 +8,9 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
-  Separator,
-  Titles,
-  passageComponentForType,
+  Title,
 } from '@design-system';
+import { TranslationBodyEditor } from '../../../../../components/ui/TranslationBodyEditor';
 import { notFound } from 'next/navigation';
 
 export const revalidate = 60;
@@ -31,21 +30,14 @@ const page = async ({ params }: { params: Promise<{ slug: string }> }) => {
       <Card>
         <CardHeader>
           <CardTitle>
-            <Titles titles={publication.frontMatter.titles} />
+            <Title language={'en'}>
+              {publication.frontMatter.titles.find((t) => t.language === 'en')
+                ?.title || 'Untitled'}
+            </Title>
           </CardTitle>
         </CardHeader>
         <CardContent>
-          {publication?.frontMatter.introductions.map(
-            ({ type, content }, index) => {
-              const Component = passageComponentForType[type];
-              return <Component key={index}>{content}</Component>;
-            },
-          )}
-          <Separator className="my-8" />
-          {publication?.body.map(({ type, content }, index) => {
-            const Component = passageComponentForType[type];
-            return <Component key={index}>{content}</Component>;
-          })}
+          <TranslationBodyEditor translation={publication} />
         </CardContent>
       </Card>
     </>

--- a/apps/web-main/src/components/ui/TranslationBodyEditor.tsx
+++ b/apps/web-main/src/components/ui/TranslationBodyEditor.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Translation } from '@data-access';
+import { BlockEditor } from '@design-system';
+import type { BlockEditorContent } from '@design-system';
+import { useEffect, useState } from 'react';
+
+export const TranslationBodyEditor = ({
+  translation,
+}: {
+  translation: Translation;
+}) => {
+  const [content, setContent] = useState<BlockEditorContent>([]);
+
+  useEffect(() => {
+    const nodeTemplateForBlockType: {
+      [key: string]: (text: string) => BlockEditorContent;
+    } = {
+      translation: (text: string) => ({
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text,
+          },
+        ],
+      }),
+      translationHeader: (text: string) => ({
+        type: 'heading',
+        attrs: { level: 3 },
+        content: [
+          {
+            type: 'text',
+            text,
+          },
+        ],
+      }),
+    };
+
+    const blocks: BlockEditorContent = [];
+    translation.body.forEach((passage) => {
+      if (!passage.content) {
+        console.warn('passage has no content');
+        console.warn(passage);
+        return;
+      }
+
+      const block = nodeTemplateForBlockType[passage.type]?.(passage.content);
+
+      if (!block) {
+        console.warn('unknown block type');
+        console.warn(passage);
+        return;
+      }
+
+      blocks.push(block);
+    });
+
+    setContent(blocks);
+  }, [translation.body]);
+
+  return <BlockEditor content={content} />;
+};

--- a/libs/design-system/src/lib/Editor/BlockEditor.tsx
+++ b/libs/design-system/src/lib/Editor/BlockEditor.tsx
@@ -5,6 +5,8 @@ import { useBlockEditor } from './hooks/useBlockEditor';
 import { useExtensions } from './hooks/useExtensions';
 import { MainBubbleMenu } from './menus/MainBubbleMenu';
 
+export type BlockEditorContent = Content;
+
 export const BlockEditor = ({
   content,
   isEditable = true,
@@ -20,7 +22,7 @@ export const BlockEditor = ({
   });
   return (
     <div className="flex h-full">
-      <div className="relative flex flex-col flex-1 h-full overflow-hidden">
+      <div className="relative flex flex-col flex-1 h-full">
         <EditorContent className="flex-1 overflow-y-auto" editor={editor} />
         <MainBubbleMenu editor={editor} />
       </div>


### PR DESCRIPTION
### Summary

- Adds the `BlockEditor` to editor page. This allows users to make local edits to a translation body (but not synced to the database)

### Linear

[840-58](https://linear.app/84000/issue/840-58/allow-local-only-edits)