### PR TITLE
Load editor content dynamically

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/publications/editor/[slug]/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/editor/[slug]/page.tsx
@@ -1,9 +1,4 @@
-import {
-  createBrowserClient,
-  getTranslationByUuid,
-  getTranslationUuids,
-} from '@data-access';
-import { notFound } from 'next/navigation';
+import { createBrowserClient, getTranslationUuids } from '@data-access';
 import { EditorPage } from '../../../../../components/ui/EditorPage';
 
 export const revalidate = 60;
@@ -11,14 +6,8 @@ export const dynamicParams = true;
 
 const page = async ({ params }: { params: Promise<{ slug: string }> }) => {
   const { slug } = await params;
-  const client = createBrowserClient();
-  const publication = await getTranslationByUuid({ client, uuid: slug });
 
-  if (!publication) {
-    return notFound();
-  }
-
-  return <EditorPage publication={publication} />;
+  return <EditorPage uuid={slug} />;
 };
 
 export const generateStaticParams = async () => {

--- a/apps/web-main/src/components/ui/EditorPage.tsx
+++ b/apps/web-main/src/components/ui/EditorPage.tsx
@@ -8,9 +8,39 @@ import {
   Title,
 } from '@design-system';
 import { TranslationBodyEditor } from './TranslationBodyEditor';
-import { Translation } from '@data-access';
+import {
+  Translation,
+  createBrowserClient,
+  getTranslationByUuid,
+} from '@data-access';
+import { useEffect, useState } from 'react';
+import { notFound } from 'next/navigation';
+import { TranslationSkeleton } from './TranslationSkeleton';
 
-export const EditorPage = ({ publication }: { publication: Translation }) => {
+export const EditorPage = ({ uuid }: { uuid: string }) => {
+  const [translation, setTranslation] = useState<Translation>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const getTranslation = async () => {
+      const client = createBrowserClient();
+      const translation = await getTranslationByUuid({ client, uuid });
+
+      setLoading(false);
+
+      if (!translation) {
+        return;
+      }
+
+      setTranslation(translation);
+    };
+    getTranslation();
+  }, [uuid]);
+
+  if (!translation && !loading) {
+    return notFound();
+  }
+
   return (
     <ThreeColumns>
       <LeftPanel>
@@ -20,11 +50,17 @@ export const EditorPage = ({ publication }: { publication: Translation }) => {
       </LeftPanel>
       <MainPanel>
         <div className="flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4">
-          <Title language={'en'}>
-            {publication.frontMatter.titles.find((t) => t.language === 'en')
-              ?.title || 'Untitled'}
-          </Title>
-          <TranslationBodyEditor translation={publication} />
+          {translation ? (
+            <>
+              <Title language={'en'}>
+                {translation.frontMatter.titles.find((t) => t.language === 'en')
+                  ?.title || 'Untitled'}
+              </Title>
+              <TranslationBodyEditor translation={translation} />
+            </>
+          ) : (
+            <TranslationSkeleton />
+          )}
         </div>
       </MainPanel>
       <RightPanel>

--- a/apps/web-main/src/components/ui/TranslationSkeleton.tsx
+++ b/apps/web-main/src/components/ui/TranslationSkeleton.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from '@design-system';
+
+export const TranslationSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-6">
+      <Skeleton className="h-12 mb-4" />
+      <Skeleton className="h-20 w-1/2" />
+      <Skeleton className="h-48" />
+      <Skeleton className="h-24 w-5/6" />
+      <Skeleton className="h-64" />
+    </div>
+  );
+};


### PR DESCRIPTION
### Summary

Editor content has been generated statically up until now. This changes moves it into the client component to be sure we always have the latest data.