### PR TITLE
Fetch passages and annotations dynamically

### DIFF
--- a/apps/web-main/src/components/table/ProjectsTable.tsx
+++ b/apps/web-main/src/components/table/ProjectsTable.tsx
@@ -57,38 +57,50 @@ export const ProjectsTable = ({ projects }: { projects: Project[] }) => {
   ]);
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 10,
+    pageSize: 20,
   });
 
   const columns: ColumnDef<Project>[] = [
     {
       accessorKey: 'toh',
       header: ({ column }) => <ProjectHeader column={column} name="Toh" />,
-      cell: ({ row }) => <div className="text-right">{row.original.toh}</div>,
+      cell: ({ row }) => (
+        <div className="xl:w-[80px] md:w-[60px] w-[40px] truncate">
+          {row.original.toh}
+        </div>
+      ),
     },
     {
       accessorKey: 'title',
       header: ({ column }) => (
         <ProjectHeader column={column} name="Work Title" />
       ),
-      cell: ({ row }) => row.original.title,
+      cell: ({ row }) => (
+        <div className="xl:w-[600px] lg:w-[300px] md:w-[200px] w-[100px] truncate">
+          {row.original.title}
+        </div>
+      ),
     },
     {
       accessorKey: 'translator',
       header: ({ column }) => (
-        <ProjectHeader column={column} name="Translator or Group" />
+        <ProjectHeader column={column} name="Translator" />
       ),
-      cell: ({ row }) => row.original.translator,
+      cell: ({ row }) => (
+        <div className="xl:w-[160px] lg:w-[120px] md:w-[100px] w-[60px] truncate">
+          {row.original.translator}
+        </div>
+      ),
     },
     {
       accessorKey: 'stage',
       header: ({ column }) => <ProjectHeader column={column} name="Stage" />,
-      cell: ({ row }) => <div className="text-right">{row.original.stage}</div>,
+      cell: ({ row }) => <div className="w-[60px]">{row.original.stage}</div>,
     },
     {
       accessorKey: 'pages',
       header: ({ column }) => <ProjectHeader column={column} name="Pages" />,
-      cell: ({ row }) => <div className="text-right">{row.original.pages}</div>,
+      cell: ({ row }) => <div className="w-[60px]">{row.original.pages}</div>,
     },
     {
       accessorKey: 'stageDate',
@@ -96,7 +108,7 @@ export const ProjectsTable = ({ projects }: { projects: Project[] }) => {
         <ProjectHeader column={column} name="Last Updated" />
       ),
       cell: ({ row }) => (
-        <div className="text-right">
+        <div className="w-[100px]">
           {row.original.stageDate.toLocaleDateString()}
         </div>
       ),
@@ -235,7 +247,7 @@ export const ProjectsTable = ({ projects }: { projects: Project[] }) => {
                   />
                 </SelectTrigger>
                 <SelectContent side="top">
-                  {[10, 20, 30, 40, 50].map((pageSize) => (
+                  {[10, 20, 50, 100].map((pageSize) => (
                     <SelectItem key={pageSize} value={`${pageSize}`}>
                       {pageSize}
                     </SelectItem>

--- a/apps/web-main/src/components/ui/EditorPage.tsx
+++ b/apps/web-main/src/components/ui/EditorPage.tsx
@@ -9,35 +9,39 @@ import {
 } from '@design-system';
 import { TranslationBodyEditor } from './TranslationBodyEditor';
 import {
-  Translation,
+  Body,
   createBrowserClient,
-  getTranslationByUuid,
+  getTranslationBody,
+  getTranslationMetadataByUuid,
 } from '@data-access';
 import { useEffect, useState } from 'react';
 import { notFound } from 'next/navigation';
 import { TranslationSkeleton } from './TranslationSkeleton';
 
 export const EditorPage = ({ uuid }: { uuid: string }) => {
-  const [translation, setTranslation] = useState<Translation>();
+  const [body, setBody] = useState<Body>();
+  const [title, setTitle] = useState('Untitled');
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const getTranslation = async () => {
       const client = createBrowserClient();
-      const translation = await getTranslationByUuid({ client, uuid });
+      const body = await getTranslationBody({ client, uuid });
+      const { title } = await getTranslationMetadataByUuid({ client, uuid });
 
       setLoading(false);
 
-      if (!translation) {
+      if (!body) {
         return;
       }
 
-      setTranslation(translation);
+      setTitle(title);
+      setBody(body);
     };
     getTranslation();
   }, [uuid]);
 
-  if (!translation && !loading) {
+  if (!body && !loading) {
     return notFound();
   }
 
@@ -50,13 +54,10 @@ export const EditorPage = ({ uuid }: { uuid: string }) => {
       </LeftPanel>
       <MainPanel>
         <div className="flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4">
-          {translation ? (
+          {body ? (
             <>
-              <Title language={'en'}>
-                {translation.frontMatter.titles.find((t) => t.language === 'en')
-                  ?.title || 'Untitled'}
-              </Title>
-              <TranslationBodyEditor translation={translation} />
+              <Title language={'en'}>{title}</Title>
+              <TranslationBodyEditor body={body} />
             </>
           ) : (
             <TranslationSkeleton />

--- a/apps/web-main/src/components/ui/TranslationBodyEditor.tsx
+++ b/apps/web-main/src/components/ui/TranslationBodyEditor.tsx
@@ -1,22 +1,18 @@
 'use client';
 
-import { Translation } from '@data-access';
+import { Body } from '@data-access';
 import { BlockEditor } from '@design-system';
 import type { BlockEditorContent } from '@design-system';
-import { bodyBlocksFromTranslation } from '@lib-editing';
+import { blocksFromTranslationBody } from '@lib-editing';
 import { useEffect, useState } from 'react';
 
-export const TranslationBodyEditor = ({
-  translation,
-}: {
-  translation: Translation;
-}) => {
+export const TranslationBodyEditor = ({ body }: { body: Body }) => {
   const [content, setContent] = useState<BlockEditorContent>([]);
 
   useEffect(() => {
-    const blocks = bodyBlocksFromTranslation(translation);
+    const blocks = blocksFromTranslationBody(body);
     setContent(blocks);
-  }, [translation]);
+  }, [body]);
 
   return <BlockEditor content={content} />;
 };

--- a/libs/data-access/src/lib/types/passage.ts
+++ b/libs/data-access/src/lib/types/passage.ts
@@ -1,4 +1,4 @@
-import { Annotations } from './annotation';
+import { Annotations, AnnotationsDTO } from './annotation';
 
 export type BodyItemType =
   | 'acknowledgment'
@@ -29,6 +29,7 @@ export type PassageDTO = {
   uuid: string;
   work_uuid: string;
   xmlId?: string;
+  annotations?: AnnotationsDTO;
 };
 
 export const passageFromDTO = (

--- a/libs/data-access/src/lib/types/translation.ts
+++ b/libs/data-access/src/lib/types/translation.ts
@@ -36,3 +36,9 @@ export const translationFromDTO = (dto: TranslationDTO): Translation => {
     frontMatter: frontMatterFromDTO(dto.frontMatter, annotations),
   };
 };
+
+export const translationBodyFromDTO = (dto: BodyDTO): Body => {
+  return dto.map((p) =>
+    passageFromDTO(p, annotationsFromDTO(p.annotations || [])),
+  );
+};

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -25,6 +25,7 @@ export * from './lib/Sheet/Sheet';
 export * from './lib/Sidebar/Sidebar';
 export * from './lib/Skeleton/Skeleton';
 export * from './lib/Table/Table';
+export * from './lib/Tabs/Tabs';
 export * from './lib/ThreeColumns/ThreeColumns';
 export * from './lib/Tooltip/Tooltip';
 export * from './lib/Translation';

--- a/libs/design-system/src/lib/Tabs/Tabs.stories.tsx
+++ b/libs/design-system/src/lib/Tabs/Tabs.stories.tsx
@@ -1,0 +1,34 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './Tabs';
+
+const meta: Meta<typeof Tabs> = {
+  component: Tabs,
+  title: 'Controls/Tabs',
+  tags: ['autodocs'],
+};
+
+type Story = StoryObj<typeof Tabs>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultValue="imprint">
+      <TabsList>
+        <TabsTrigger value="acknowledments">Acknowledments</TabsTrigger>
+        <TabsTrigger value="introduction">Introduction</TabsTrigger>
+        <TabsTrigger value="imprint">Imprint</TabsTrigger>
+      </TabsList>
+      <TabsContent value="acknowledments">
+        Acknowledgement content goes here.
+      </TabsContent>
+      <TabsContent value="introduction">
+        Introduction content goes here.
+      </TabsContent>
+      <TabsContent value="imprint">
+        Imprint content goes here.
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+export default meta; 

--- a/libs/design-system/src/lib/Tabs/Tabs.tsx
+++ b/libs/design-system/src/lib/Tabs/Tabs.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@lib-utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-10 w-fit items-center justify-center rounded-md p-1",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -1,5 +1,5 @@
 import { BlockEditorContent, BlockEditorContentItem } from '@design-system';
-import { Passage, Translation } from '@data-access';
+import { Body, Passage, Translation } from '@data-access';
 import { annotateBlock } from './annotation';
 
 const TEMPLATES_FOR_BLOCK_TYPE: {
@@ -38,9 +38,9 @@ const TEMPLATES_FOR_BLOCK_TYPE: {
   }),
 };
 
-export const bodyBlocksFromTranslation = (translation: Translation) => {
+export const blocksFromTranslationBody = (body: Body) => {
   const blocks: BlockEditorContent = [];
-  translation.body.forEach((passage) => {
+  body.forEach((passage) => {
     if (!passage.content) {
       console.warn('passage has no content');
       console.warn(passage);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-tabs": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.1.8",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.48.1",
@@ -7328,6 +7329,275 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.1"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.4.tgz",
+      "integrity": "sha512-fuHMHWSf5SRhXke+DbHXj2wVMo+ghVH30vhX3XVacdXqDl+J4XWafMIGOOER861QpBx1jxgwKXL2dQnfrsd8MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.3",
+        "@radix-ui/react-primitive": "2.0.3",
+        "@radix-ui/react-roving-focus": "1.1.3",
+        "@radix-ui/react-use-controllable-state": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.3.tgz",
+      "integrity": "sha512-mM2pxoQw5HJ49rkzwOs7Y6J4oYH22wS8BfK2/bBxROlI4xuR0c4jEenQP63LlTlDkO6Buj2Vt+QYAYcOgqtrXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.3",
+        "@radix-ui/react-slot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.3.tgz",
+      "integrity": "sha512-IrVLIhskYhH3nLvtcBLQFZr61tBG7wx7O3kEmdzcYwRGAEBmBicGGL7ATzNgruYJ3xBTbuzEEq9OXJM3PAX3tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.3.tgz",
+      "integrity": "sha512-Pf/t/GkndH7CQ8wE2hbkXA+WyZ83fhQQn5DDmwDiDo6AwN/fhaH8oqZ0jRjMrO2iaMhDi6P1HRx6AZwyMinY1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.3.tgz",
+      "integrity": "sha512-ufbpLUjZiOg4iYgb2hQrWXEPYX6jOLBbR27bDyAff5GYMRrCzcze8lukjuXVUQvJ6HZe8+oL+hhswDcjmcgVyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
+      "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.1.tgz",
+      "integrity": "sha512-YnEXIy8/ga01Y1PN0VfaNH//MhA91JlEGVBDxDzROqwrAtG5Yr2QGEPz8A/rJA3C7ZAHryOYGaUv8fLSW2H/mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.4",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.48.1",


### PR DESCRIPTION
### Summary

- Editor pages are not static, so their data should be fetched client-side. Now it is.
- Some designs have a tab ui for selecting content. While not yet integrated, this adds the components for future use.

### Linear

[DEV-92](https://linear.app/84000/issue/DEV-92/fetch-translation-entities-dynamically)