### PR TITLE
Add brand palette to design system

### DIFF
--- a/libs/design-system/src/lib/Palette/Palette.stories.tsx
+++ b/libs/design-system/src/lib/Palette/Palette.stories.tsx
@@ -1,0 +1,14 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Palette } from './Palette';
+
+const meta: Meta<typeof Palette> = {
+  title: 'Theme/Palette',
+  component: Palette,
+  tags: ['autodocs'],
+};
+
+type Story = StoryObj<typeof Palette>;
+
+export const Default: Story = {};
+
+export default meta;

--- a/libs/design-system/src/lib/Palette/Palette.tsx
+++ b/libs/design-system/src/lib/Palette/Palette.tsx
@@ -1,0 +1,31 @@
+import { H2 } from '../Typography/Typography';
+
+export const Palette = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <H2>Brand Colors</H2>
+      <div className="flex flex-wrap gap-4">
+        <div className="flex flex-col gap-1 rounded">
+          <div className="text-brick">brick</div>
+          <div className="size-16 bg-brick rounded" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <div className="text-ochre">ochre</div>
+          <div className="size-16 bg-ochre rounded" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <div className="text-emerald">emerald</div>
+          <div className="size-16 bg-emerald rounded" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <div className="text-navy">navy</div>
+          <div className="size-16 bg-navy rounded" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <div className="text-gray">gray</div>
+          <div className="size-16 bg-gray rounded" />
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
### Summary

This adds a design system story for displaying our brand colors. In addition to being a handy reference, it serves the important purpose of registering the color classes with tailwind at build time. Otherwise, the may not be available at runtime if defined dynamically.