### PR TITLE
Ignore some annotations

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/publications/reader/[slug]/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/reader/[slug]/page.tsx
@@ -23,14 +23,14 @@ const page = async ({ params }: { params: Promise<{ slug: string }> }) => {
       <div className="xl:max-w-1/2 lg:max-w-2/3 sm:max-w-4/5 w-full">
         <Titles titles={publication.frontMatter.titles} />
         {publication?.frontMatter.introductions.map(
-          ({ type, content }, index) => {
+          ({ type, content, uuid }) => {
             const Component = passageComponentForType[type];
-            return <Component key={index}>{content}</Component>;
+            return <Component key={uuid}>{content}</Component>;
           },
         )}
-        {publication?.body.map(({ type, content }, index) => {
+        {publication?.body.map(({ type, content, uuid }) => {
           const Component = passageComponentForType[type];
-          return <Component key={index}>{content}</Component>;
+          return <Component key={uuid}>{content}</Component>;
         })}
       </div>
     </div>

--- a/libs/data-access/src/lib/publications.ts
+++ b/libs/data-access/src/lib/publications.ts
@@ -13,11 +13,9 @@ export const getTranslationUuids = async ({
   client,
 }: {
   client: DataClient;
-}) => {
-  const { data } = await client
-    .from('translation_json')
-    .select('uuid:work_uuid');
-  return data?.map(({ uuid }) => uuid) || [];
+}): Promise<string[]> => {
+  const { data } = await client.rpc('get_static_translation_uuids');
+  return data?.map(({ uuid }: { uuid: string }) => uuid) || [];
 };
 
 export const getTranslationByUuid = async ({

--- a/libs/data-access/src/lib/types/annotation-type.ts
+++ b/libs/data-access/src/lib/types/annotation-type.ts
@@ -98,6 +98,15 @@ const ANNOATION_TYPE_DTO_TO_TYPE: Record<AnnotationDTOType, AnnotationType> = {
   unknown: 'unknown',
 } as const;
 
+export const ANNOTATIONS_TO_IGNORE: AnnotationDTOType[] = [
+  'end-note-link',
+  'leading-space',
+  'paragraph',
+  'reference',
+  'span',
+  'unknown',
+];
+
 export const annotationTypeFromDTO = (
   type: AnnotationDTOType,
 ): AnnotationType => {

--- a/libs/data-access/src/lib/types/annotation.ts
+++ b/libs/data-access/src/lib/types/annotation.ts
@@ -1,4 +1,5 @@
 import {
+  ANNOTATIONS_TO_IGNORE,
   AnnotationDTOType,
   AnnotationType,
   annotationTypeFromDTO,
@@ -470,5 +471,7 @@ export const annotationFromDTO = (dto: AnnotationDTO): Annotation => {
 };
 
 export const annotationsFromDTO = (dto?: AnnotationsDTO): Annotations => {
-  return dto?.map(annotationFromDTO) || [];
+  const filtered =
+    dto?.filter((a) => !ANNOTATIONS_TO_IGNORE.includes(a.type)) || [];
+  return filtered.map(annotationFromDTO);
 };

--- a/libs/design-system/src/lib/Translation/Title/Titles.tsx
+++ b/libs/design-system/src/lib/Translation/Title/Titles.tsx
@@ -11,7 +11,11 @@ export const Titles = ({ titles }: { titles: TitlesData }) => {
   return (
     <div className="flex flex-col gap-0">
       {titles.map((title) => (
-        <Title key={title.uuid} uuid={title.uuid} language={title.language}>
+        <Title
+          key={`${title.uuid}-${title.language}`}
+          uuid={title.uuid}
+          language={title.language}
+        >
           {title.title}
         </Title>
       ))}


### PR DESCRIPTION
### Summary

- Fix an issue where key was reused when iterating over titles
- Fetch uuids for static pages from a rpc endpoint, allowing for fine control on the backend over what gets generated at build time
- Ignore a handlful of annotations that don't need to parsed by the client