### PR TITLE
Move result count to top

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/publications/editor/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/editor/page.tsx
@@ -10,8 +10,8 @@ const page = async () => {
   const works = await getTranslationsMetadata({ client });
 
   return (
-    <div className="flex flex-row justify-center p-4 w-full">
-      <div className="sm:max-w-4/5 w-full">
+    <div className="flex flex-row justify-center pt-0 pb-8 px-4 w-full">
+      <div className="w-full">
         <H2>{'Translation Editor'}</H2>
         <TranslationsTable works={works} />
       </div>

--- a/apps/web-main/src/app/(DashboardLayout)/publications/reader/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/reader/page.tsx
@@ -10,8 +10,8 @@ const page = async () => {
   const works = await getTranslationsMetadata({ client });
 
   return (
-    <div className="flex flex-row justify-center p-4 w-full">
-      <div className="sm:max-w-4/5 w-full">
+    <div className="flex flex-row justify-center pt-0 pb-8 px-4 w-full">
+      <div className="w-full">
         <H2>{'The Reading Room'}</H2>
         <TranslationsTable works={works} />
       </div>

--- a/apps/web-main/src/components/project/ProjectsTable.tsx
+++ b/apps/web-main/src/components/project/ProjectsTable.tsx
@@ -209,6 +209,12 @@ export const ProjectsTable = ({ projects }: { projects: Project[] }) => {
         <FuzzyGlobalFilter table={table} placeholder="Search projects..." />
         <FilterStageDropdown table={table} />
       </div>
+      <div className="rounded-lg border px-4 py-3 bg-muted/50 text-sm">
+        Total results:
+        <span className="px-1 text-emerald-500 font-semibold">
+          {table.getFilteredRowModel().rows.length} projects
+        </span>
+      </div>
       <div className="overflow-hidden rounded-lg border">
         <Table>
           <TableHeader className="sticky top-0">

--- a/apps/web-main/src/components/project/ProjectsTable.tsx
+++ b/apps/web-main/src/components/project/ProjectsTable.tsx
@@ -26,7 +26,7 @@ import {
 import { Project, ProjectStage, ProjectStageLabel } from '@data-access';
 import { useEffect, useState } from 'react';
 import { SortableHeader } from '../table/SortableHeader';
-import { FuzzyGlobalFilter } from '../table/FuzzyGlobalFilter';
+import { FuzzyGlobalFilter, fuzzyFilterFn } from '../table/FuzzyGlobalFilter';
 import { TablePagination } from '../table/TablePagination';
 import { FilterStageDropdown } from './FilterStageDropdown';
 import { StageChip } from '../ui/StageChip';
@@ -186,21 +186,7 @@ export const ProjectsTable = ({ projects }: { projects: Project[] }) => {
     getSortedRowModel: getSortedRowModel(),
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
-    globalFilterFn: (
-      row: Row<TableProject>,
-      columnId: string,
-      filterValue: string,
-      addMeta,
-    ) => {
-      const rawFilter = removeDiacritics(filterValue);
-      const rowValue = row.getValue(columnId);
-      const itemRank = rankItem(rowValue, rawFilter, {
-        keepDiacritics: false,
-      });
-      addMeta({ itemRank });
-      if (itemRank.passed) console.log(itemRank);
-      return itemRank.passed && itemRank.rank > 2;
-    },
+    globalFilterFn: fuzzyFilterFn,
   });
 
   return (

--- a/apps/web-main/src/components/table/FuzzyGlobalFilter.tsx
+++ b/apps/web-main/src/components/table/FuzzyGlobalFilter.tsx
@@ -1,5 +1,7 @@
 import { Input } from '@design-system';
-import { RowData, Table } from '@tanstack/react-table';
+import { removeDiacritics } from '@lib-utils';
+import { rankItem } from '@tanstack/match-sorter-utils';
+import { FilterMeta, Row, RowData, Table } from '@tanstack/react-table';
 
 export const FuzzyGlobalFilter = <T extends RowData>({
   table,
@@ -16,4 +18,20 @@ export const FuzzyGlobalFilter = <T extends RowData>({
       className="max-w-sm"
     />
   );
+};
+
+export const fuzzyFilterFn = <T extends RowData>(
+  row: Row<T>,
+  columnId: string,
+  value: string,
+  addMeta: (meta: FilterMeta) => void,
+) => {
+  const rawFilter = removeDiacritics(value);
+  const rowValue = row.getValue(columnId);
+  const itemRank = rankItem(rowValue, rawFilter, {
+    keepDiacritics: false,
+  });
+  addMeta({ itemRank });
+  if (itemRank.passed) console.log(itemRank);
+  return itemRank.passed && itemRank.rank > 2;
 };

--- a/apps/web-main/src/components/table/TranslationsTable.tsx
+++ b/apps/web-main/src/components/table/TranslationsTable.tsx
@@ -51,7 +51,7 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
   ]);
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 10,
+    pageSize: 12,
   });
 
   const router = useRouter();
@@ -72,43 +72,55 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
       header: ({ column }) => (
         <TranslationHeader column={column} name="Work Title" />
       ),
-      cell: ({ row }) => row.original.title,
+      cell: ({ row }) => (
+        <div className="xl:w-[640px] lg:w-[300px] md:w-[200px] w-[100px] truncate">
+          {row.original.title}
+        </div>
+      ),
     },
     {
       accessorKey: 'toh',
       header: ({ column }) => <TranslationHeader column={column} name="Toh" />,
-      cell: ({ row }) => <div>{row.original.toh}</div>,
+      cell: ({ row }) => (
+        <div className="xl:w-[100px] md:w-[60px] w-[40px] truncate">
+          {row.original.toh}
+        </div>
+      ),
     },
     {
       accessorKey: 'pages',
       header: ({ column }) => (
         <TranslationHeader column={column} name="Pages" />
       ),
-      cell: ({ row }) => <div>{row.original.pages}</div>,
+      cell: ({ row }) => <div className="w-[60px]">{row.original.pages}</div>,
     },
     {
       accessorKey: 'publicationDate',
       header: ({ column }) => (
         <TranslationHeader column={column} name="Published" />
       ),
-      cell: ({ row }) => row.original.publicationDate,
+      cell: ({ row }) => (
+        <div className="w-[80px]">{row.original.publicationDate}</div>
+      ),
     },
     {
       accessorKey: 'publicationVersion',
       header: ({ column }) => (
         <TranslationHeader column={column} name="Version" />
       ),
-      cell: ({ row }) => row.original.publicationVersion,
+      cell: ({ row }) => (
+        <div className="w-[40px]">{row.original.publicationVersion}</div>
+      ),
     },
     {
       accessorKey: 'restriction',
       header: () => <></>,
       cell: ({ row }) => (
-        <>
+        <div className="w-5">
           {row.original.restriction ? (
             <TriangleAlertIcon className="text-warning" />
           ) : null}
-        </>
+        </div>
       ),
     },
   ];
@@ -142,15 +154,21 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
   return (
     <div className="w-full flex flex-col gap-4">
       <div className="flex items-center py-4">
-        <FuzzyGlobalFilter table={table} placeholder="Filter translations..." />
+        <FuzzyGlobalFilter table={table} placeholder="Search translations..." />
+      </div>
+      <div className="rounded-lg border px-4 py-3 bg-muted/50 text-sm">
+        Total results:
+        <span className="px-1 text-emerald-500 font-semibold">
+          {table.getFilteredRowModel().rows.length} texts
+        </span>
       </div>
       <div className="overflow-hidden rounded-lg border">
         <Table>
-          <TableHeader className="bg-muted sticky top-0">
+          <TableHeader className="sticky top-0">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id} className="py-4">
+                  <TableHead key={header.id}>
                     {header.isPlaceholder
                       ? null
                       : flexRender(
@@ -162,7 +180,7 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
               </TableRow>
             ))}
           </TableHeader>
-          <TableBody className="**:data-[slot=table-cell]:first:w-8">
+          <TableBody>
             {table.getRowModel().rows?.length ? (
               <>
                 {table.getRowModel().rows.map((row) => (

--- a/apps/web-main/src/components/table/TranslationsTable.tsx
+++ b/apps/web-main/src/components/table/TranslationsTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 import {
   ColumnDef,
+  Row,
   SortingState,
   Table as TableType,
   VisibilityState,
@@ -26,8 +27,10 @@ import { useEffect, useState } from 'react';
 import { TriangleAlertIcon } from 'lucide-react';
 import { SortableHeader } from './SortableHeader';
 import { usePathname, useRouter } from 'next/navigation';
-import { FuzzyGlobalFilter } from './FuzzyGlobalFilter';
+import { FuzzyGlobalFilter, fuzzyFilterFn } from './FuzzyGlobalFilter';
 import { TablePagination } from './TablePagination';
+import { removeDiacritics } from '@lib-utils';
+import { rankItem } from '@tanstack/match-sorter-utils';
 
 type TableWork = {
   uuid: string;
@@ -148,7 +151,7 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
     getSortedRowModel: getSortedRowModel(),
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
-    globalFilterFn: 'auto',
+    globalFilterFn: fuzzyFilterFn,
   });
 
   return (


### PR DESCRIPTION
### Summary

- Move filter result count in tables to be above the table to match the designs
- Update the reader/editor landing page table to look more like the projects table
- Abstract fuzzy filter function and add to reader/editor table

### Linear

[DEV-123](https://linear.app/84000/issue/DEV-123/move-results-count)