### PR TITLE
Update brand colors

### DIFF
--- a/libs/design-system/src/lib/Palette/Palette.tsx
+++ b/libs/design-system/src/lib/Palette/Palette.tsx
@@ -50,6 +50,17 @@ export const Palette = () => {
         <H2>Brand Colors</H2>
         <div className="flex flex-wrap gap-4">
           <PaletteColor
+            label="navy"
+            labelColor="text-navy"
+            colors={[
+              'bg-navy',
+              'bg-navy/80',
+              'bg-navy/60',
+              'bg-navy/40',
+              'bg-navy/20',
+            ]}
+          />
+          <PaletteColor
             label="brick"
             labelColor="text-brick"
             colors={[
@@ -83,14 +94,14 @@ export const Palette = () => {
             ]}
           />
           <PaletteColor
-            label="navy"
-            labelColor="text-navy"
+            label="slate"
+            labelColor="text-slate"
             colors={[
-              'bg-navy',
-              'bg-navy/80',
-              'bg-navy/60',
-              'bg-navy/40',
-              'bg-navy/20',
+              'bg-slate',
+              'bg-slate/80',
+              'bg-slate/60',
+              'bg-slate/40',
+              'bg-slate/20',
             ]}
           />
           <PaletteColor

--- a/libs/design-system/src/lib/theme/global.css
+++ b/libs/design-system/src/lib/theme/global.css
@@ -47,10 +47,11 @@
     --error: 255, 102, 46;
     --error-foreground: 255, 229, 237;
 
-    --emerald: 173, 83%, 32%;
-    --ochre: 13, 80%, 40%;
-    --navy: 203, 100%, 23%;
-    --brick: 339, 82%, 35%;
+    --emerald: 179, 79%, 32%;
+    --ochre: 36, 86%, 52%;
+    --navy: 204, 100%, 22%;
+    --brick: 346, 71%, 39%;
+    --slate: 205, 36%, 53%;
     --gray: 216, 12%, 84%;
   }
 
@@ -107,10 +108,11 @@
     --error: 255, 102, 46;
     --error-foreground: 255, 229, 237;
 
-    --emerald: 173, 83%, 32%;
-    --ochre: 13, 80%, 40%;
-    --navy: 203, 100%, 23%;
-    --brick: 339, 82%, 35%;
+    --emerald: 179, 79%, 32%;
+    --ochre: 36, 86%, 52%;
+    --navy: 204, 100%, 22%;
+    --brick: 346, 71%, 39%;
+    --slate: 205, 36%, 53%;
     --gray: 216, 12%, 84%;
   }
 }
@@ -170,4 +172,5 @@
   --color-ochre: hsl(var(--ochre));
   --color-navy: hsl(var(--navy));
   --color-brick: hsl(var(--brick));
+  --color-slate: hsl(var(--slate));
 }


### PR DESCRIPTION
Based values defined [here](https://84000-translate.slack.com/files/U06DW9BLB34/F08TEGHMTPT/image_19-5-25_at_19.17.jpeg). Note that the hsla values are actually hsb. The process for converting them to the CSS hsla colors was 1) copy colors into Figma as hsb 2) switch to hsl mode 3) copy those to the global.css. We will need to define weight variants later. Tailwind can automatically handle variants based on alpha but not weight.