### PR TITLE
Annotation migration scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 .env*.local
-.ent
+.env
 
 # compiled output
 dist

--- a/apps/node-scripts/.eslintrc.json
+++ b/apps/node-scripts/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/apps/node-scripts/project.json
+++ b/apps/node-scripts/project.json
@@ -1,0 +1,58 @@
+{
+  "name": "node-scripts",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/node-scripts/src",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "dist/apps/node-scripts",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/node-scripts/src/main.ts",
+        "tsConfig": "apps/node-scripts/tsconfig.app.json",
+        "assets": ["apps/node-scripts/src/assets"],
+        "generatePackageJson": true,
+        "esbuildOptions": {
+          "sourcemap": true,
+          "outExtension": {
+            ".js": ".js"
+          }
+        }
+      },
+      "configurations": {
+        "development": {},
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "development",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "node-scripts:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "node-scripts:build:development"
+        },
+        "production": {
+          "buildTarget": "node-scripts:build:production"
+        }
+      }
+    }
+  }
+}

--- a/apps/node-scripts/src/config.ts
+++ b/apps/node-scripts/src/config.ts
@@ -1,0 +1,15 @@
+import { config } from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+export const loadConfig = () => {
+  config();
+
+  const SUPABASE_URL = process.env['SUPABASE_URL'];
+  const SUPABASE_SERVICE_KEY = process.env['SUPABASE_SERVICE_KEY'];
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+  return {
+    supabase,
+    pageSize: 100,
+  };
+};

--- a/apps/node-scripts/src/fetch.ts
+++ b/apps/node-scripts/src/fetch.ts
@@ -1,0 +1,34 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+
+export const fetchPage = async ({
+  supabase,
+  type,
+  contentType,
+  contentIndex = 0,
+  limit,
+}: {
+  supabase: SupabaseClient;
+  type: string;
+  contentType: string;
+  contentIndex?: 0 | 1;
+  limit: number;
+}) => {
+  return await supabase
+    .from('passage_annotations')
+    .select(
+      `
+        annotationUuid:uuid::text,
+        createdAt:created_at,
+        passageUuid:passage_uuid::text,
+        type:type::text,
+        start,
+        end,
+        toh,
+        passageXmlId:"passage_xmlId"::text,
+        xmlId:content->${contentIndex}->>"${contentType}"::text
+      `,
+    )
+    .eq('type', type)
+    .is('content->0->>"uuid"', null)
+    .limit(limit);
+};

--- a/apps/node-scripts/src/migrate-endnotes.ts
+++ b/apps/node-scripts/src/migrate-endnotes.ts
@@ -1,0 +1,127 @@
+import { loadConfig } from './config';
+import { fetchPage } from './fetch';
+import { AnnotationTransformer, PassageAnnotationModel } from './types';
+
+const main = async () => {
+  const { supabase, pageSize: limit } = loadConfig();
+  let lastBatch = Infinity;
+  let page = 0;
+
+  while (lastBatch >= limit) {
+    console.log(`fetching page ${page}`);
+
+    const { data: paData, error } = await fetchPage({
+      supabase,
+      limit,
+      type: 'end-note-link',
+      contentIndex: 1,
+      contentType: 'endnote_xmlId',
+    });
+
+    if (error) {
+      console.error(error);
+      return;
+    }
+
+    lastBatch = paData.length;
+    page += 1;
+
+    console.log(`fetched ${lastBatch} records`);
+
+    const annotationData: {
+      [key: string]: AnnotationTransformer;
+    } = {};
+    const xmlIdToAnnotations: { [key: string]: string[] } = {};
+
+    paData.forEach((pa) => {
+      const xmlId = pa.xmlId;
+      if (!xmlId) {
+        return;
+      }
+
+      annotationData[pa.annotationUuid] = {
+        ...pa,
+        targetUuid: '',
+      };
+
+      xmlIdToAnnotations[xmlId] = [
+        ...(xmlIdToAnnotations[xmlId] || []),
+        pa.annotationUuid,
+      ];
+    });
+
+    const { data: glData, error: glError } = await supabase
+      .from('passages')
+      .select(
+        `
+      xmlId:"xmlId"::text,
+      endNoteUuid:uuid::text
+    `,
+      )
+      .in('xmlId', Object.keys(xmlIdToAnnotations));
+
+    if (glError) {
+      console.error(glError);
+      return;
+    }
+
+    glData.forEach(({ xmlId, endNoteUuid }) => {
+      const annotations = xmlIdToAnnotations[xmlId];
+      if (!annotations) {
+        return;
+      }
+      annotations.forEach((annotationUuid) => {
+        annotationData[annotationUuid].targetUuid = endNoteUuid;
+      });
+    });
+
+    const keys = Object.keys(annotationData);
+    const upsertData: PassageAnnotationModel[] = [];
+    for (const uuid of keys) {
+      const {
+        xmlId,
+        targetUuid: endNoteUuid,
+        passageUuid: passage_uuid,
+        createdAt: created_at,
+        start,
+        end,
+        toh,
+        passageXmlId: passage_xmlId,
+        type,
+      } = annotationData[uuid];
+      if (!xmlId || !endNoteUuid) {
+        continue;
+      }
+
+      upsertData.push({
+        uuid,
+        created_at,
+        passage_uuid,
+        type,
+        start,
+        end,
+        toh,
+        passage_xmlId,
+        content: [
+          {
+            endnote_xmlId: xmlId,
+            uuid: endNoteUuid,
+          },
+        ],
+      });
+    }
+
+    console.log(`upserting ${upsertData.length} records`);
+    console.log(JSON.stringify(upsertData, null, 2));
+    const { error: upsertError } = await supabase
+      .from('passage_annotations')
+      .upsert(upsertData);
+
+    if (upsertError) {
+      console.error(upsertError);
+      return;
+    }
+  }
+};
+
+main();

--- a/apps/node-scripts/src/migrate-glossary-instances.ts
+++ b/apps/node-scripts/src/migrate-glossary-instances.ts
@@ -1,0 +1,126 @@
+import { loadConfig } from './config';
+import { fetchPage } from './fetch';
+import { AnnotationTransformer, PassageAnnotationModel } from './types';
+
+const main = async () => {
+  const { supabase, pageSize: limit } = loadConfig();
+  let lastBatch = Infinity;
+  let page = 0;
+
+  while (lastBatch >= limit) {
+    console.log(`fetching page ${page}`);
+
+    const { data: paData, error } = await fetchPage({
+      supabase,
+      limit,
+      type: 'glossary-instance',
+      contentType: 'glossary_xmlId',
+    });
+
+    if (error) {
+      console.error(error);
+      return;
+    }
+
+    lastBatch = paData.length;
+    page += 1;
+
+    console.log(`fetched ${lastBatch} records`);
+
+    const annotationData: {
+      [key: string]: AnnotationTransformer;
+    } = {};
+    const xmlIdToAnnotations: { [key: string]: string[] } = {};
+
+    paData.forEach((pa) => {
+      const xmlId = pa.xmlId;
+      if (!xmlId) {
+        return;
+      }
+
+      annotationData[pa.annotationUuid] = {
+        ...pa,
+        targetUuid: '',
+      };
+
+      xmlIdToAnnotations[xmlId] = [
+        ...(xmlIdToAnnotations[xmlId] || []),
+        pa.annotationUuid,
+      ];
+    });
+
+    const { data: glData, error: glError } = await supabase
+      .from('glossaries')
+      .select(
+        `
+      xmlId:glossary_xmlId::text,
+      authorityUuid:authority_uuid::text
+    `,
+      )
+      .in('glossary_xmlId', Object.keys(xmlIdToAnnotations));
+
+    if (glError) {
+      console.error(glError);
+      return;
+    }
+
+    glData.forEach(({ xmlId, authorityUuid }) => {
+      const annotations = xmlIdToAnnotations[xmlId];
+      if (!annotations) {
+        return;
+      }
+      annotations.forEach((annotationUuid) => {
+        annotationData[annotationUuid].targetUuid = authorityUuid;
+      });
+    });
+
+    const keys = Object.keys(annotationData);
+    const upsertData: PassageAnnotationModel[] = [];
+    for (const uuid of keys) {
+      const {
+        xmlId,
+        targetUuid: authorityUuid,
+        passageUuid: passage_uuid,
+        createdAt: created_at,
+        start,
+        end,
+        toh,
+        passageXmlId: passage_xmlId,
+        type,
+      } = annotationData[uuid];
+      if (!xmlId || !authorityUuid) {
+        continue;
+      }
+
+      upsertData.push({
+        uuid,
+        created_at,
+        passage_uuid,
+        type,
+        start,
+        end,
+        toh,
+        passage_xmlId,
+        content: [
+          {
+            glossary_xmlId: xmlId,
+            uuid: authorityUuid,
+          },
+        ],
+      });
+    }
+
+    console.log(`upserting ${upsertData.length} records`);
+    console.log(JSON.stringify(upsertData, null, 2));
+    const { error: upsertError } = await supabase
+      .from('passage_annotations')
+      .upsert(upsertData);
+
+    if (upsertError) {
+      console.error(upsertError);
+      return;
+    }
+  }
+};
+
+main();

--- a/apps/node-scripts/src/migrate-passage-refs.ts
+++ b/apps/node-scripts/src/migrate-passage-refs.ts
@@ -1,0 +1,81 @@
+import { loadConfig } from './config';
+import { fetchPage } from './fetch';
+import { PassageAnnotationModel } from './types';
+
+const ANNOTATION_TYPE = 'abbreviation';
+const CONTENT_TYPE = 'abbreviation_xmlId';
+
+const main = async () => {
+  const { supabase, pageSize: limit } = loadConfig();
+  let lastBatch = Infinity;
+  let page = 0;
+
+  while (lastBatch >= limit) {
+    console.log(`fetching page ${page}`);
+
+    const { data: paData, error } = await fetchPage({
+      supabase,
+      limit,
+      type: ANNOTATION_TYPE,
+      contentType: CONTENT_TYPE,
+    });
+
+    if (error) {
+      console.error(error);
+      return;
+    }
+
+    lastBatch = paData.length;
+    page += 1;
+
+    console.log(`fetched ${lastBatch} records`);
+    const upsertData: PassageAnnotationModel[] = [];
+    paData.forEach((pa) => {
+      const {
+        annotationUuid: uuid,
+        xmlId,
+        passageUuid: passage_uuid,
+        createdAt: created_at,
+        start,
+        end,
+        toh,
+        passageXmlId: passage_xmlId,
+        type,
+      } = pa;
+
+      if (!xmlId || !passage_uuid) {
+        return;
+      }
+
+      upsertData.push({
+        uuid,
+        created_at,
+        passage_uuid,
+        type,
+        start,
+        end,
+        toh,
+        passage_xmlId,
+        content: [
+          {
+            abbreviation_xmlId: xmlId,
+            uuid: passage_uuid,
+          },
+        ],
+      });
+    });
+
+    console.log(`upserting ${upsertData.length} records`);
+    console.log(JSON.stringify(upsertData, null, 2));
+    const { error: upsertError } = await supabase
+      .from('passage_annotations')
+      .upsert(upsertData);
+
+    if (upsertError) {
+      console.error(upsertError);
+      return;
+    }
+  }
+};
+
+main();

--- a/apps/node-scripts/src/types.ts
+++ b/apps/node-scripts/src/types.ts
@@ -1,0 +1,26 @@
+export type PassageAnnotationModel = {
+  uuid: string;
+  created_at: unknown | null;
+  passage_uuid: string;
+  content: {
+    [key: string]: string;
+  }[];
+  type: string;
+  start: unknown;
+  end: unknown;
+  passage_xmlId: string | null;
+  toh: unknown | null;
+};
+
+export type AnnotationTransformer = {
+  annotationUuid: string;
+  createdAt: unknown;
+  passageUuid: string;
+  type: string;
+  start: unknown;
+  end: unknown;
+  targetUuid: string;
+  passageXmlId?: string;
+  xmlId?: string;
+  toh?: unknown | null;
+};

--- a/apps/node-scripts/tsconfig.app.json
+++ b/apps/node-scripts/tsconfig.app.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/node-scripts/tsconfig.json
+++ b/apps/node-scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@tiptap/suggestion": "^2.11.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dotenv": "^16.5.0",
         "i18next": "24.2.2",
         "install": "^0.13.0",
         "jwt-decode": "^4.0.0",
@@ -17744,10 +17745,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "dev": true,
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -29144,6 +29144,19 @@
         "@swc/core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nx/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@tiptap/suggestion": "^2.11.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dotenv": "^16.5.0",
     "i18next": "24.2.2",
     "install": "^0.13.0",
     "jwt-decode": "^4.0.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,8 +18,8 @@
       "@data-access": ["libs/data-access/src/index.ts"],
       "@design-system": ["libs/design-system/src/index.ts"],
       "@design-system-css": ["libs/design-system/src/lib/theme/global.css"],
-      "@lib-utils": ["libs/lib-utils/src/index.ts"],
-      "@lib-editing": ["libs/lib-editing/src/index.ts"]
+      "@lib-editing": ["libs/lib-editing/src/index.ts"],
+      "@lib-utils": ["libs/lib-utils/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
### Summary

A handful of scripts that can be run after translations have been migrated from eXist-db to Supabase. The initial focus is updating annotations to reference entity uuids instead of xml Ids.

### Linear

[DEV-138](https://linear.app/84000/issue/DEV-138/resolve-content-uuids)
[DEV-156](https://linear.app/84000/issue/DEV-156)
[DEV-157](https://linear.app/84000/issue/DEV-157)
[DEV-158](https://linear.app/84000/issue/DEV-158)