### PR TITLE
Translation Editor

### DIFF
--- a/libs/design-system/src/lib/Editor/BlockEditor/BlockEditor.stories.tsx
+++ b/libs/design-system/src/lib/Editor/BlockEditor/BlockEditor.stories.tsx
@@ -85,6 +85,11 @@ export const Primary: Story = {
     isEditable: { control: 'boolean' },
     content: { control: 'object' },
   },
+  render: ({ isEditable, content }) => (
+    <div className="p-8">
+      <BlockEditor isEditable={isEditable} content={content} />
+    </div>
+  ),
 };
 
 export default meta;

--- a/libs/design-system/src/lib/Editor/BlockEditor/hooks/useDefaultExtensions.ts
+++ b/libs/design-system/src/lib/Editor/BlockEditor/hooks/useDefaultExtensions.ts
@@ -1,49 +1,33 @@
 'use client';
 
-import { Document } from '../../extensions/Document';
+import Document from '../../extensions/Document';
 import Heading from '../../extensions/Heading/Heading';
 import Paragraph from '../../extensions/Paragraph/Paragraph';
-import Placeholder from '@tiptap/extension-placeholder';
 import { SlashCommand } from '../../extensions/SlashCommand/SlashCommand';
 import { getSuggestion } from '../../extensions/SlashCommand/Suggestions';
-import { cn } from '@lib-utils';
-import Link from '@tiptap/extension-link';
+import Link from '../../extensions/Link';
+import Placeholder from '../../extensions/Placeholder';
+import TextAlign from '../../extensions/TextAlign';
 import Underline from '@tiptap/extension-underline';
-import TextAlign from '@tiptap/extension-text-align';
-import { StarterKit } from '../../extensions/StarterKit';
+import StarterKit from '../../extensions/StarterKit';
+import TranslationMetadata from '../../extensions/TranslationMetadata';
 import { DragHandle } from '../../extensions/DragHandle/DragHandle';
-import { TranslationMetadata } from '../../extensions/TranslationMetadata';
 
 export const useDefaultExtensions = () => {
   return {
     extensions: [
       Document,
-      DragHandle.configure({
-        draghandleWidth: 25,
-      }),
+      DragHandle,
       Heading,
-      Link.configure({
-        HTMLAttributes: {
-          class: cn(
-            '!text-foreground underline underline-offset-[3px] transition-colors cursor-pointer',
-          ),
-        },
-        openOnClick: false,
-      }),
+      Link,
       Paragraph,
-      Placeholder.configure({
-        placeholder: 'Type / for commands...',
-        emptyEditorClass: cn('is-editor-empty text-gray-400'),
-        emptyNodeClass: cn('is-empty text-gray-400'),
-      }),
+      Placeholder,
       SlashCommand.configure({
         suggestion: getSuggestion(),
       }),
       StarterKit,
       TranslationMetadata,
-      TextAlign.configure({
-        types: ['heading', 'paragraph'],
-      }),
+      TextAlign,
       Underline,
     ],
   };

--- a/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.stories.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.stories.tsx
@@ -1,0 +1,109 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { TranslationEditor } from './TranslationEditor';
+
+const content = {
+  type: 'translation',
+  content: [
+    {
+      attrs: {
+        uuid: '54a251d8-e074-4516-973b-b353bfe385ed',
+        class: 'passage',
+        type: 'translationHeader',
+        sort: 136,
+        label: '1.',
+      },
+      type: 'passage',
+      content: [
+        {
+          attrs: {
+            level: 1,
+          },
+          type: 'heading',
+          content: [
+            {
+              type: 'text',
+              text: 'The Translation',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      attrs: {
+        uuid: '31a821e6-9a69-4950-a32d-52645ef0fbe5',
+        class: 'passage',
+        type: 'translation',
+        sort: 141,
+        label: '1.1',
+      },
+      type: 'passage',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Homage to all the buddhas and bodhisattvas!',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      attrs: {
+        uuid: '09d19c19-a9da-450b-be90-c517f106469b',
+        class: 'passage',
+        type: 'translation',
+        sort: 146,
+        label: '1.2',
+      },
+      type: 'passage',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Thus did I hear at one time. The Buddha was residing in Śrāvastī, in Jeta’s Grove, Anāthapiṇḍada’s park, together with a great community of monks, consisting of 1,250 monks, and a great assembly of bodhisattvas. At that time, the Blessed One addressed the monks:',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: '“Monks, for as long as they live, bodhisattvas, great beings, should not abandon four factors even at the cost of their lives. What are these four?',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const meta: Meta<typeof TranslationEditor> = {
+  component: TranslationEditor,
+  title: 'Editor/TranslationEditor',
+  tags: ['autodocs'],
+};
+
+type Story = StoryObj<typeof TranslationEditor>;
+
+export const Primary: Story = {
+  args: {
+    isEditable: true,
+    content,
+  },
+  argTypes: {
+    isEditable: { control: 'boolean' },
+    content: { control: 'object' },
+  },
+  render: ({ isEditable, content }) => (
+    <div className="p-8">
+      <TranslationEditor isEditable={isEditable} content={content} />
+    </div>
+  ),
+};
+
+export default meta;

--- a/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { EditorContent, JSONContent } from '@tiptap/react';
+import { useBlockEditor } from '../BlockEditor';
+import { MainBubbleMenu } from '../menus/MainBubbleMenu';
+import { useTranslationExtensions } from './hooks/useTranslationExtensions';
+
+export type TranslationEditorContentItem = JSONContent & {
+  attrs?: {
+    uuid?: string | null;
+    class?: string | null;
+    type?: string | null;
+    sort?: number | null;
+  };
+};
+
+export type TranslationEditorContent =
+  | TranslationEditorContentItem[]
+  | TranslationEditorContentItem;
+
+export const TranslationEditor = ({
+  content,
+  isEditable = true,
+}: {
+  content: TranslationEditorContent;
+  isEditable?: boolean;
+}) => {
+  const { extensions } = useTranslationExtensions();
+  const { editor } = useBlockEditor({
+    extensions,
+    content,
+    isEditable,
+  });
+  return (
+    <div className="flex h-full">
+      <div className="relative flex flex-col flex-1 h-full">
+        <EditorContent className="flex-1" editor={editor} />
+        <MainBubbleMenu editor={editor} />
+      </div>
+    </div>
+  );
+};
+
+export default TranslationEditor;

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/Passage.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/Passage.tsx
@@ -1,0 +1,24 @@
+import type { NodeViewProps } from '@tiptap/react';
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
+
+export const Passage = ({ node, updateAttributes }: NodeViewProps) => {
+  if (!node.attrs.label) {
+    updateAttributes({
+      label: '0.',
+    });
+  }
+
+  return (
+    <NodeViewWrapper className="passage relative leading-7 mt-6 ml-6">
+      <label
+        className="absolute -left-16 w-16 text-end text-slate hover:cursor-pointer"
+        contentEditable={false}
+      >
+        {node.attrs.label}
+      </label>
+      <NodeViewContent className="content is-editable pl-6" />
+    </NodeViewWrapper>
+  );
+};
+
+export default Passage;

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/PassageNode.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/PassageNode.ts
@@ -1,0 +1,168 @@
+import { Node } from '@tiptap/core';
+import { ReactNodeViewRenderer, mergeAttributes } from '@tiptap/react';
+import { Passage } from './Passage';
+import { Selection, TextSelection } from '@tiptap/pm/state';
+import { ResolvedPos } from '@tiptap/pm/model';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    passage: {
+      refereshLabelsAfter: () => ReturnType;
+      splitPassage: () => ReturnType;
+    };
+  }
+}
+
+const currentPassageDepth = ($from: ResolvedPos) => {
+  let passageDepth = null;
+  for (let i = $from.depth; i >= 0; i--) {
+    if ($from.node(i).type.name === 'passage') {
+      passageDepth = i;
+      break;
+    }
+  }
+
+  return passageDepth;
+};
+
+const incrementLabel = (label: string, depth = -1) => {
+  const labelParts: (string | number)[] = ((label as string) || '').split('.');
+  const index = depth === -1 ? labelParts.length - 1 : depth;
+  const toIncrement = `${labelParts[index]}` || '0';
+  const newVal = Number.parseInt(toIncrement) + 1;
+  labelParts[index] = newVal;
+
+  return labelParts.join('.');
+};
+
+export const PassageNode = Node.create({
+  name: 'passage',
+  group: 'block',
+  content: 'block+',
+  parseHTML() {
+    return [
+      {
+        tag: 'passage',
+      },
+    ];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['passage', mergeAttributes(HTMLAttributes), 0];
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(Passage);
+  },
+  addCommands() {
+    return {
+      refereshLabelsAfter:
+        () =>
+        ({ state, dispatch }) => {
+          if (!dispatch) {
+            return true;
+          }
+
+          const { selection } = state;
+          const { $from } = selection;
+          const txn = state.tr;
+
+          const passageDepth = currentPassageDepth($from);
+          if (passageDepth === null) {
+            return false;
+          }
+
+          const passagePos = $from.start(passageDepth) - 1;
+          const currentPassage = $from.node(passageDepth);
+          const currentLabel = currentPassage.attrs.label as string;
+
+          if (!currentLabel) {
+            return false;
+          }
+
+          const currentPrefix = currentLabel.split('.').slice(0, -1).join('.');
+          const currentDepth = currentPrefix.length;
+
+          state.doc.descendants((node, pos) => {
+            const targetLabel = node.attrs.label as string;
+            const isChildPassage =
+              node.type.name === 'passage' && pos > passagePos && !!targetLabel;
+
+            if (!isChildPassage) {
+              return;
+            }
+
+            const matchesPrefix = targetLabel.startsWith(currentPrefix);
+            if (!matchesPrefix) {
+              return false;
+            }
+
+            const oldAttrs = node.attrs;
+            txn.setNodeMarkup(pos, null, {
+              ...oldAttrs,
+              label: incrementLabel(oldAttrs.label, currentDepth),
+            });
+          });
+
+          return true;
+        },
+      splitPassage:
+        () =>
+        ({ state, dispatch }) => {
+          const { selection } = state;
+          const { $from } = selection;
+
+          // Find the passage node that contains the current selection
+          const passageDepth = currentPassageDepth($from);
+          if (passageDepth === null) {
+            return false;
+          }
+
+          const passageNode = $from.node(passageDepth);
+          const passageStart = $from.start(passageDepth) - 1; // -1 to include the passage node itself
+          const passageEnd = $from.end(passageDepth) + 1; // +1 to include the passage node itself
+
+          // Get the position within the passage content
+          const posInPassage = $from.pos - $from.start(passageDepth);
+
+          // Split the passage content
+          const beforeContent = passageNode.content.cut(0, posInPassage);
+          const afterContent = passageNode.content.cut(posInPassage);
+
+          if (!dispatch) return true;
+
+          const tr = state.tr;
+
+          // Replace current passage with first part
+          tr.replaceWith(
+            passageStart,
+            passageEnd,
+            state.schema.nodes.passage.create(passageNode.attrs, beforeContent),
+          );
+
+          // Calculate where to insert the new passage
+          const newPassagePos = passageStart + beforeContent.size + 2; // +2 for passage wrapper
+          const oldAttrs = passageNode.attrs;
+          const attrs = {
+            ...oldAttrs,
+            uuid: null,
+            label: incrementLabel(oldAttrs.label),
+          };
+          // Insert new passage with remaining content
+          tr.insert(
+            newPassagePos,
+            state.schema.nodes.passage.create(attrs, afterContent),
+          );
+
+          // move the cursor to the new paragraph
+          const $pos = tr.doc.resolve(newPassagePos + 1);
+          const newSelection =
+            TextSelection.findFrom($pos, 1, true) || Selection.near($pos, 1);
+          if (newSelection) {
+            tr.setSelection(newSelection);
+          }
+
+          dispatch(tr);
+          return true;
+        },
+    };
+  },
+});

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/index.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/index.ts
@@ -1,0 +1,1 @@
+export * from './PassageNode';

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/TranslationDocument.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/TranslationDocument.ts
@@ -1,0 +1,7 @@
+import { Node } from '@tiptap/core';
+
+export default Node.create({
+  name: 'translation',
+  topNode: true,
+  content: 'passage+',
+});

--- a/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import Heading from '../../extensions/Heading/Heading';
+import Paragraph from '../../extensions/Paragraph/Paragraph';
+import { SlashCommand } from '../../extensions/SlashCommand/SlashCommand';
+import {
+  BulletListSuggestion,
+  Heading1Suggestion,
+  Heading2Suggestion,
+  Heading3Suggestion,
+  NumberListSuggestion,
+  QuoteSuggestion,
+  TextSuggestion,
+  getSuggestion,
+} from '../../extensions/SlashCommand/Suggestions';
+import Underline from '@tiptap/extension-underline';
+import Link from '../../extensions/Link';
+import Placeholder from '../../extensions/Placeholder';
+import TextAlign from '../../extensions/TextAlign';
+import StarterKit from '../../extensions/StarterKit';
+import TranslationMetadata from '../../extensions/TranslationMetadata';
+import TranslationDocument from '../extensions/TranslationDocument';
+import { PassageNode } from '../extensions/Passage';
+import { CommandSuggestionItem } from '../../extensions/SlashCommand/SuggestionList';
+import { TableOfContentsIcon } from 'lucide-react';
+
+const PassageSuggestion: CommandSuggestionItem = {
+  title: 'Passage',
+  description: 'Start a new passage.',
+  keywords: ['passage'],
+  icon: TableOfContentsIcon,
+  command: ({ editor, range }) => {
+    editor
+      .chain()
+      .deleteRange(range)
+      .selectParentNode()
+      .deleteCurrentNode()
+      .splitPassage()
+      .refereshLabelsAfter()
+      .run();
+  },
+};
+
+export const useTranslationExtensions = () => {
+  const suggestions = [
+    TextSuggestion,
+    PassageSuggestion,
+    Heading1Suggestion,
+    Heading2Suggestion,
+    Heading3Suggestion,
+    BulletListSuggestion,
+    NumberListSuggestion,
+    QuoteSuggestion,
+  ];
+  return {
+    extensions: [
+      TranslationDocument,
+      Heading,
+      Link,
+      Paragraph,
+      PassageNode,
+      Placeholder,
+      SlashCommand.configure({
+        suggestion: getSuggestion(suggestions),
+      }),
+      StarterKit,
+      TranslationMetadata,
+      TextAlign,
+      Underline,
+    ],
+  };
+};

--- a/libs/design-system/src/lib/Editor/extensions/DragHandle/DragHandle.ts
+++ b/libs/design-system/src/lib/Editor/extensions/DragHandle/DragHandle.ts
@@ -389,7 +389,7 @@ export const DragHandle = Extension.create({
 
   addOptions() {
     return {
-      dragHandleWidth: 20,
+      dragHandleWidth: 25,
       scrollTreshold: 100,
       excludedTags: [],
       customNodes: [],

--- a/libs/design-system/src/lib/Editor/extensions/Link.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Link.ts
@@ -1,0 +1,11 @@
+import { cn } from '@lib-utils';
+import Link from '@tiptap/extension-link';
+
+export default Link.configure({
+  HTMLAttributes: {
+    class: cn(
+      '!text-foreground underline underline-offset-[3px] transition-colors cursor-pointer',
+    ),
+  },
+  openOnClick: false,
+});

--- a/libs/design-system/src/lib/Editor/extensions/Placeholder.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Placeholder.ts
@@ -1,0 +1,9 @@
+import { cn } from '@lib-utils';
+import Placeholder from '@tiptap/extension-placeholder';
+
+export default Placeholder.configure({
+  placeholder: 'Type / for commands...',
+  emptyEditorClass: cn('is-editor-empty text-gray-400'),
+  emptyNodeClass: cn('is-empty text-gray-400'),
+  includeChildren: true,
+});

--- a/libs/design-system/src/lib/Editor/extensions/SlashCommand/Suggestions.ts
+++ b/libs/design-system/src/lib/Editor/extensions/SlashCommand/Suggestions.ts
@@ -22,101 +22,112 @@ type SuggestionType = Omit<
   'editor'
 >;
 
-const baseList: CommandSuggestionItem[] = [
-  {
-    title: 'Text',
-    description: 'Just start typing',
-    keywords: ['text', 'paragraph', 'p'],
-    icon: LetterTextIcon,
-    command: ({ editor, range }) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .toggleNode('paragraph', 'paragraph')
-        .run();
-    },
+export const TextSuggestion: CommandSuggestionItem = {
+  title: 'Text',
+  description: 'Just start typing',
+  keywords: ['text', 'paragraph', 'p'],
+  icon: LetterTextIcon,
+  command: ({ editor, range }) => {
+    editor.chain().focus().toggleNode('paragraph', 'paragraph').run();
   },
-  {
-    title: 'Heading 1',
-    description: 'Big section heading.',
-    keywords: ['title', 'big', 'large', 'heading'],
-    icon: Heading1Icon,
-    command: ({ editor, range }) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .setNode('heading', { level: 1 })
-        .run();
-    },
+};
+
+export const Heading1Suggestion: CommandSuggestionItem = {
+  title: 'Heading 1',
+  description: 'Big section heading.',
+  keywords: ['title', 'big', 'large', 'heading'],
+  icon: Heading1Icon,
+  command: ({ editor, range }) => {
+    editor
+      .chain()
+      .focus()
+      .deleteRange(range)
+      .setNode('heading', { level: 1 })
+      .run();
   },
-  {
-    title: 'Heading 2',
-    description: 'Medium section heading.',
-    keywords: ['subtitle', 'medium', 'heading'],
-    icon: Heading2Icon,
-    command: ({ editor, range }) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .setNode('heading', { level: 2 })
-        .run();
-    },
+};
+
+export const Heading2Suggestion: CommandSuggestionItem = {
+  title: 'Heading 2',
+  description: 'Medium section heading.',
+  keywords: ['subtitle', 'medium', 'heading'],
+  icon: Heading2Icon,
+  command: ({ editor, range }) => {
+    editor
+      .chain()
+      .focus()
+      .deleteRange(range)
+      .setNode('heading', { level: 2 })
+      .run();
   },
-  {
-    title: 'Heading 3',
-    description: 'Small section heading.',
-    keywords: ['subtitle', 'small', 'heading'],
-    icon: Heading3Icon,
-    command: ({ editor, range }) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .setNode('heading', { level: 3 })
-        .run();
-    },
+};
+
+export const Heading3Suggestion: CommandSuggestionItem = {
+  title: 'Heading 3',
+  description: 'Small section heading.',
+  keywords: ['subtitle', 'small', 'heading'],
+  icon: Heading3Icon,
+  command: ({ editor, range }) => {
+    editor
+      .chain()
+      .focus()
+      .deleteRange(range)
+      .setNode('heading', { level: 3 })
+      .run();
   },
-  {
-    title: 'Bullet List',
-    description: 'Create a simple bullet list.',
-    keywords: ['unordered', 'list', 'bullet'],
-    icon: ListIcon,
-    command: ({ editor, range }) => {
-      editor.chain().focus().deleteRange(range).toggleBulletList().run();
-    },
+};
+
+export const BulletListSuggestion: CommandSuggestionItem = {
+  title: 'Bullet List',
+  description: 'Create a simple bullet list.',
+  keywords: ['unordered', 'list', 'bullet'],
+  icon: ListIcon,
+  command: ({ editor, range }) => {
+    editor.chain().focus().deleteRange(range).toggleBulletList().run();
   },
-  {
-    title: 'Numbered List',
-    description: 'Create a list with numbering.',
-    keywords: ['ordered', 'list'],
-    icon: ListOrderedIcon,
-    command: ({ editor, range }) => {
-      editor.chain().focus().deleteRange(range).toggleOrderedList().run();
-    },
+};
+
+export const NumberListSuggestion: CommandSuggestionItem = {
+  title: 'Numbered List',
+  description: 'Create a list with numbering.',
+  keywords: ['ordered', 'list'],
+  icon: ListOrderedIcon,
+  command: ({ editor, range }) => {
+    editor.chain().focus().deleteRange(range).toggleOrderedList().run();
   },
-  {
-    title: 'Quote',
-    description: 'Capture a quote.',
-    keywords: ['blockquote'],
-    icon: TextQuoteIcon,
-    command: ({ editor, range }) =>
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .toggleNode('paragraph', 'paragraph')
-        .toggleBlockquote()
-        .run(),
-  },
+};
+
+export const QuoteSuggestion: CommandSuggestionItem = {
+  title: 'Quote',
+  description: 'Capture a quote.',
+  keywords: ['blockquote'],
+  icon: TextQuoteIcon,
+  command: ({ editor, range }) =>
+    editor
+      .chain()
+      .focus()
+      .deleteRange(range)
+      .toggleNode('paragraph', 'paragraph')
+      .toggleBlockquote()
+      .run(),
+};
+
+const defaultSuggestions: CommandSuggestionItem[] = [
+  TextSuggestion,
+  Heading1Suggestion,
+  Heading2Suggestion,
+  Heading3Suggestion,
+  BulletListSuggestion,
+  NumberListSuggestion,
+  QuoteSuggestion,
 ];
 
-export const getSuggestion = (): SuggestionType => {
+export const getSuggestion = (
+  suggestions: CommandSuggestionItem[] = defaultSuggestions,
+): SuggestionType => {
   return {
     items: ({ query }) => {
-      return baseList.filter((item: CommandSuggestionItem) => {
+      return suggestions.filter((item: CommandSuggestionItem) => {
         return item.keywords.some((kwd) => kwd.startsWith(query.toLowerCase()));
       });
     },

--- a/libs/design-system/src/lib/Editor/extensions/StarterKit.ts
+++ b/libs/design-system/src/lib/Editor/extensions/StarterKit.ts
@@ -6,7 +6,7 @@ import {
   UL_STYLE,
 } from '../../Typography/Typography';
 
-export const StarterKit = TiptapStarterKit.configure({
+export default TiptapStarterKit.configure({
   document: false,
   heading: false,
   paragraph: false,

--- a/libs/design-system/src/lib/Editor/extensions/TextAlign.ts
+++ b/libs/design-system/src/lib/Editor/extensions/TextAlign.ts
@@ -1,0 +1,5 @@
+import TextAlign from '@tiptap/extension-text-align';
+
+export default TextAlign.configure({
+  types: ['heading', 'paragraph'],
+});

--- a/libs/design-system/src/lib/Editor/extensions/TranslationMetadata.ts
+++ b/libs/design-system/src/lib/Editor/extensions/TranslationMetadata.ts
@@ -1,7 +1,7 @@
 import { Extension } from '@tiptap/core';
 import { v4 as uuidv4 } from 'uuid';
 
-export const TranslationMetadata = Extension.create({
+export default Extension.create({
   name: 'translationMetadata',
   addGlobalAttributes() {
     const prohibitedNodes = ['text', 'doc'];

--- a/libs/design-system/src/lib/theme/global.css
+++ b/libs/design-system/src/lib/theme/global.css
@@ -1,6 +1,4 @@
-@import (
-  'https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&family=Roboto+Serif:ital,opsz,wght@0,8..144,100..900;1,8..144,100..900&display=swap'
-);
+@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&family=Roboto+Serif:ital,opsz,wght@0,8..144,100..900;1,8..144,100..900&display=swap');
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import './editor.css';
@@ -73,7 +71,7 @@
     --primary-foreground: 240 6% 10%;
     --secondary: 240 4% 16%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 240 6% 10%;
+    --muted: 240 4% 10%;
     --muted-foreground: 240 5% 65%;
     --accent: 240 4% 10%;
     --accent-foreground: 240 5% 96%;


### PR DESCRIPTION
### Summary

This adds a new `TranslationEditor` that has a custom `passage` node type as its fundamental building block. All top-level nodes must be passages. Passage nodes have labels associated with them, making them one level higher than a paragraph, for example. Hitting enter in the editor creates a new paragraph by default. Using the slash command to create a new passage, generates a new uuid and label. It also increments subsequent labels (although I suspect the logic for this will need a future pass). The `TranslationEditor` component is added to the design system but is not yet incorporated into the scholar's room.

### Screenshot

![Screenshot 2025-06-06 at 12 59 58 PM](https://github.com/user-attachments/assets/ee0ca42d-3ee2-4442-9f59-c6758f0022ed)

### Linear

[DEV-161](https://linear.app/84000/issue/DEV-161/passage-document-structure)