### PR TITLE
End Notes and Glossary Instances

### DIFF
--- a/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.stories.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.stories.tsx
@@ -48,6 +48,12 @@ const content = {
               type: 'text',
               text: 'Homage to all the buddhas and bodhisattvas!',
             },
+            {
+              type: 'endNoteLink',
+              attrs: {
+                endNote: 'some-uuid-2',
+              },
+            },
           ],
         },
       ],
@@ -71,6 +77,18 @@ const content = {
             {
               type: 'text',
               text: 'Thus did I hear at one time. The Buddha was residing in Śrāvastī, in Jeta’s Grove, Anāthapiṇḍada’s park, together with a great community of monks, consisting of 1,250 monks, and a great assembly of bodhisattvas. At that time, the Blessed One addressed the monks:',
+            },
+            {
+              type: 'endNoteLink',
+              attrs: {
+                endNote: 'some-uuid',
+              },
+            },
+            {
+              type: 'endNoteLink',
+              attrs: {
+                endNote: 'some-uuid-2',
+              },
             },
           ],
         },

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteLink.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteLink.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@lib-utils';
+import { NodeViewContent, NodeViewProps, NodeViewWrapper } from '@tiptap/react';
+import { LINK_STYLE } from '../../../../Typography/Typography';
+import { useEffect, useState } from 'react';
+
+export const EndNoteLink = ({ node, getPos, editor }: NodeViewProps) => {
+  const [label, setLabel] = useState(1);
+
+  useEffect(() => {
+    const pos = getPos();
+
+    let newLabel = 1;
+    editor.state.doc.descendants((descendant, nodePos) => {
+      if (nodePos >= pos) {
+        return false;
+      }
+
+      if (descendant.type.name === node.type.name) {
+        newLabel += 1;
+      }
+    });
+    setLabel(newLabel);
+  }, [editor.state.doc, getPos, node.type.name]);
+
+  const className = editor.isEditable
+    ? 'cursor-pointer select-text'
+    : 'cursor-pointer select-none';
+
+  return (
+    <NodeViewWrapper as="sup">
+      <NodeViewContent as="span" />
+      <a
+        href={`#${node.attrs.endNote}`}
+        className={cn(LINK_STYLE, className, 'pl-0.5')}
+      >
+        {label}
+      </a>
+    </NodeViewWrapper>
+  );
+};
+
+export default EndNoteLink;

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteNode.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteNode.ts
@@ -27,6 +27,7 @@ export const EndNoteLinkNode = Node.create<EndNoteLinkOptions>({
     return {
       endNote: {
         default: undefined,
+        parseHTML: (element) => element.getAttribute('endNote'),
       },
     };
   },

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteNode.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteNode.ts
@@ -1,0 +1,75 @@
+import { Node } from '@tiptap/core';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import { EndNoteLink } from './EndNoteLink';
+
+export interface EndNoteLinkOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    endNoteLink: {
+      setEndNoteLink: (endNote: string) => ReturnType;
+      unsetEndNoteLink: () => ReturnType;
+    };
+  }
+}
+
+export const EndNoteLinkNode = Node.create<EndNoteLinkOptions>({
+  name: 'endNoteLink',
+  group: 'inline',
+  inline: true,
+  atom: false, // Changed to false to make content selectable
+  draggable: true,
+  selectable: true, // Explicitly make it selectable
+
+  addAttributes() {
+    return {
+      endNote: {
+        default: undefined,
+      },
+    };
+  },
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'span[type="endNoteLink"]',
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['span', { ...HTMLAttributes, type: 'endNoteLink' }, 0];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(EndNoteLink, {
+      contentDOMElementTag: 'span',
+    });
+  },
+
+  addCommands() {
+    return {
+      setEndNoteLink:
+        (endNote) =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: { endNote },
+          });
+        },
+      unsetEndNoteLink:
+        () =>
+        ({ commands }) => {
+          return commands.deleteSelection();
+        },
+    };
+  },
+});

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/GlossaryInstanceMark.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/GlossaryInstanceMark.ts
@@ -1,0 +1,109 @@
+import { cn } from '@lib-utils';
+import { Mark, mergeAttributes } from '@tiptap/core';
+import { LINK_STYLE } from '../../../Typography/Typography';
+
+export interface GlossaryInstanceOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    gloassaryInstance: {
+      setGlossaryInstance: (authority: string) => ReturnType;
+      unsetGlossaryInstance: () => ReturnType;
+      toggleGlossaryInstance: (authority: string) => ReturnType;
+    };
+  }
+}
+
+export const GlossaryInstanceMark = Mark.create<GlossaryInstanceOptions>({
+  name: 'glossaryInstance',
+  priority: 1000,
+  keepOnSplit: false,
+  exitable: true,
+  inclusive: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {
+        class: cn(LINK_STYLE, 'decoration-dotted'),
+      },
+    };
+  },
+
+  addAttributes() {
+    return {
+      authority: {
+        default: undefined,
+        parseHTML(element) {
+          return element.getAttribute('authority');
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'a[type="gloassaryInstance"]',
+        getAttrs: (dom) => {
+          const authority = (dom as HTMLElement).getAttribute('authority');
+
+          if (!authority) {
+            return false;
+          }
+          return null;
+        },
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { authority } = HTMLAttributes;
+    HTMLAttributes.href = `#${authority}`;
+
+    return [
+      'a',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      setGlossaryInstance:
+        (authority) =>
+        ({ chain }) => {
+          return chain()
+            .setMark(this.name, {
+              authority,
+              href: `#${authority}`,
+            })
+            .run();
+        },
+
+      toggleGlossaryInstance:
+        (authority) =>
+        ({ chain }) => {
+          return chain()
+            .toggleMark(
+              this.name,
+              {
+                authority,
+                href: `#${authority}`,
+              },
+              { extendEmptyMarkRange: true },
+            )
+            .run();
+        },
+
+      unsetGlossaryInstance:
+        () =>
+        ({ chain }) => {
+          return chain()
+            .unsetMark(this.name, { extendEmptyMarkRange: true })
+            .run();
+        },
+    };
+  },
+});

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/PassageNode.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/PassageNode.ts
@@ -7,7 +7,7 @@ import { ResolvedPos } from '@tiptap/pm/model';
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     passage: {
-      refereshLabelsAfter: () => ReturnType;
+      refreshLabelsAfter: () => ReturnType;
       splitPassage: () => ReturnType;
     };
   }
@@ -54,7 +54,7 @@ export const PassageNode = Node.create({
   },
   addCommands() {
     return {
-      refereshLabelsAfter:
+      refreshLabelsAfter:
         () =>
         ({ state, dispatch }) => {
           if (!dispatch) {

--- a/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
@@ -40,6 +40,7 @@ import { SmallCaps } from '../../extensions/SmallCaps';
 import { Italic } from '../../extensions/Italic';
 import { Indent } from '../../extensions/Indent';
 import { MantraMark } from '../extensions/Mantra/Mantra';
+import { EndNoteLinkNode } from '../extensions/EndNoteLink/EndNoteNode';
 
 const PassageSuggestion: CommandSuggestionItem = {
   title: 'Passage',
@@ -53,7 +54,7 @@ const PassageSuggestion: CommandSuggestionItem = {
       .selectParentNode()
       .deleteCurrentNode()
       .splitPassage()
-      .refereshLabelsAfter()
+      .refreshLabelsAfter()
       .run();
   },
 };
@@ -72,6 +73,7 @@ export const useTranslationExtensions = () => {
   return {
     extensions: [
       TranslationDocument,
+      EndNoteLinkNode,
       Heading,
       Image,
       Indent,

--- a/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
@@ -41,6 +41,7 @@ import { Italic } from '../../extensions/Italic';
 import { Indent } from '../../extensions/Indent';
 import { MantraMark } from '../extensions/Mantra/Mantra';
 import { EndNoteLinkNode } from '../extensions/EndNoteLink/EndNoteNode';
+import { GlossaryInstanceMark } from '../extensions/GlossaryInstanceMark';
 
 const PassageSuggestion: CommandSuggestionItem = {
   title: 'Passage',
@@ -74,6 +75,7 @@ export const useTranslationExtensions = () => {
     extensions: [
       TranslationDocument,
       EndNoteLinkNode,
+      GlossaryInstanceMark,
       Heading,
       Image,
       Indent,

--- a/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/EndNoteSelector.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/EndNoteSelector.tsx
@@ -7,14 +7,14 @@ import {
 import { cn } from '@lib-utils';
 import { Editor } from '@tiptap/core';
 import { useEditorState } from '@tiptap/react';
-import { LinkIcon } from 'lucide-react';
+import { AsteriskIcon } from 'lucide-react';
 import { SelectorInputField } from '../../../menus/SelectorInputField';
 
-export const LinkSelector = ({ editor }: { editor: Editor }) => {
+export const EndNoteSelector = ({ editor }: { editor: Editor }) => {
   const editorState = useEditorState({
     editor,
     selector: (instance) => ({
-      isActive: instance.editor.isActive('link'),
+      isActive: instance.editor.isActive('endNoteLink'),
     }),
   });
 
@@ -26,7 +26,7 @@ export const LinkSelector = ({ editor }: { editor: Editor }) => {
           size="icon"
           className="rounded-none flex-shrink-0"
         >
-          <LinkIcon
+          <AsteriskIcon
             className={cn(
               'size-4',
               editorState.isActive ? 'text-primary' : 'text-muted-foreground',
@@ -42,19 +42,14 @@ export const LinkSelector = ({ editor }: { editor: Editor }) => {
       >
         <SelectorInputField
           editor={editor}
-          type="link"
-          attr="href"
-          placeholder="Add link..."
+          type="endNoteLink"
+          attr="endNote"
+          placeholder="Add end note uuid..."
           onSubmit={(value) => {
             if (value) {
-              editor
-                .chain()
-                .focus()
-                .extendMarkRange('link')
-                .setLink({ href: value })
-                .run();
+              editor.chain().focus().setEndNoteLink(value).run();
             } else {
-              editor.chain().focus().unsetLink().run();
+              editor.chain().focus().unsetEndNoteLink().run();
             }
           }}
         />

--- a/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/GlossarySelector.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/GlossarySelector.tsx
@@ -1,0 +1,64 @@
+import { Button } from '../../../../Button/Button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '../../../../Popover/Popover';
+import { cn } from '@lib-utils';
+import { Editor } from '@tiptap/core';
+import { useEditorState } from '@tiptap/react';
+import { BookOpenTextIcon } from 'lucide-react';
+import { SelectorInputField } from '../../../menus/SelectorInputField';
+
+export const GlossarySelector = ({ editor }: { editor: Editor }) => {
+  const editorState = useEditorState({
+    editor,
+    selector: (instance) => ({
+      isActive: instance.editor.isActive('glossaryInstance'),
+    }),
+  });
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="px-2 rounded-none flex-shrink-0"
+        >
+          <BookOpenTextIcon
+            className={cn(
+              'size-4',
+              editorState.isActive ? 'text-primary' : 'text-muted-foreground',
+            )}
+            strokeWidth={2.5}
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-fit shadow-xl rounded-md border p-1"
+        align="end"
+        noPortal
+      >
+        <SelectorInputField
+          editor={editor}
+          type="glossaryInstance"
+          attr="authority"
+          placeholder="Add authority uuid..."
+          onSubmit={(value) => {
+            if (value) {
+              editor
+                .chain()
+                .focus()
+                .extendMarkRange('glossaryInstance')
+                .setGlossaryInstance(value)
+                .run();
+            } else {
+              editor.chain().focus().unsetGlossaryInstance().run();
+            }
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/TextButtons.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/TextButtons.tsx
@@ -12,6 +12,7 @@ import {
 import { LinkSelector } from './LinkSelector';
 import { Button } from '../../../../Button/Button';
 import { MantraSelector } from './MantraSelector';
+import { EndNoteSelector } from './EndNoteSelector';
 
 interface SelectorResult {
   isBold: boolean;
@@ -104,6 +105,7 @@ export const TextButtons = ({ editor }: { editor: Editor }) => {
       })}
       <MantraSelector editor={editor} />
       <LinkSelector editor={editor} />
+      <EndNoteSelector editor={editor} />
     </>
   );
 };

--- a/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/TextButtons.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/TextButtons.tsx
@@ -11,8 +11,10 @@ import {
 } from 'lucide-react';
 import { LinkSelector } from './LinkSelector';
 import { Button } from '../../../../Button/Button';
+import { Separator } from '../../../../Separator/Separator';
 import { MantraSelector } from './MantraSelector';
 import { EndNoteSelector } from './EndNoteSelector';
+import { GlossarySelector } from './GlossarySelector';
 
 interface SelectorResult {
   isBold: boolean;
@@ -104,6 +106,8 @@ export const TextButtons = ({ editor }: { editor: Editor }) => {
         );
       })}
       <MantraSelector editor={editor} />
+      <Separator orientation="vertical" className="h-10" />
+      <GlossarySelector editor={editor} />
       <LinkSelector editor={editor} />
       <EndNoteSelector editor={editor} />
     </>

--- a/libs/design-system/src/lib/Editor/extensions/Link.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Link.ts
@@ -1,11 +1,10 @@
 import { cn } from '@lib-utils';
 import Link from '@tiptap/extension-link';
+import { LINK_STYLE } from '../../Typography/Typography';
 
 export default Link.configure({
   HTMLAttributes: {
-    class: cn(
-      'text-slate underline decoration-slate underline-offset-[3px] transition-colors cursor-pointer',
-    ),
+    class: cn(LINK_STYLE),
   },
   openOnClick: true,
 });

--- a/libs/design-system/src/lib/Editor/extensions/Link.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Link.ts
@@ -1,10 +1,9 @@
-import { cn } from '@lib-utils';
 import Link from '@tiptap/extension-link';
 import { LINK_STYLE } from '../../Typography/Typography';
 
 export default Link.configure({
   HTMLAttributes: {
-    class: cn(LINK_STYLE),
+    class: LINK_STYLE,
   },
   openOnClick: true,
 });

--- a/libs/design-system/src/lib/Editor/menus/SelectorInputField.tsx
+++ b/libs/design-system/src/lib/Editor/menus/SelectorInputField.tsx
@@ -1,0 +1,64 @@
+import { Button } from '../../Button/Button';
+import { Editor } from '@tiptap/core';
+import { useEditorState } from '@tiptap/react';
+import { CheckIcon, Trash2Icon } from 'lucide-react';
+import { useRef } from 'react';
+import { Input } from '../../Input/Input';
+
+export const SelectorInputField = ({
+  editor,
+  type,
+  attr,
+  placeholder,
+  onSubmit,
+}: {
+  editor: Editor;
+  type: string;
+  attr: string;
+  placeholder: string;
+  onSubmit: (value?: string) => void;
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const editorState = useEditorState({
+    editor,
+    selector: (instance) => ({
+      isActive: instance.editor.isActive(type),
+      getValue: instance.editor.getAttributes(type)[attr],
+    }),
+  });
+
+  return (
+    <form
+      className="flex space-x-1 items-center"
+      onSubmit={(evt) => {
+        evt.preventDefault();
+        onSubmit(inputRef.current?.value);
+      }}
+    >
+      <Input
+        ref={inputRef}
+        placeholder={placeholder}
+        defaultValue={editorState.getValue}
+      />
+      {editorState.isActive ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          type="button"
+          onClick={() => {
+            if (inputRef.current) {
+              inputRef.current.value = '';
+            }
+            onSubmit();
+          }}
+        >
+          <Trash2Icon className="size-4 text-destructive" />
+        </Button>
+      ) : (
+        <Button size="icon" variant="ghost">
+          <CheckIcon className="size-4" />
+        </Button>
+      )}
+    </form>
+  );
+};

--- a/libs/design-system/src/lib/Input/Input.tsx
+++ b/libs/design-system/src/lib/Input/Input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className,
         )}
         ref={ref}

--- a/libs/design-system/src/lib/Typography/Typography.tsx
+++ b/libs/design-system/src/lib/Typography/Typography.tsx
@@ -1,5 +1,8 @@
 import { cn } from '@lib-utils';
 
+export const LINK_STYLE =
+  'text-slate underline decoration-slate underline-offset-[3px] transition-colors cursor-pointer';
+
 export const HERO_STYLE =
   'font-serif mt-8 scroll-m-20 pb-8 text-8xl lg:text-9xl';
 export function Hero({


### PR DESCRIPTION
### Summary

- Add support for end note references in the editor, which are rendered as superscript links with automatically generated reference numbers
- Add support for links to authorities in the editor
- Add both to the bubble menu

### Linear
[DEV-163](https://linear.app/84000/issue/DEV-163/render-annotations-v2) (parent issue)
[DEV-166](https://linear.app/84000/issue/DEV-166/render-end-note-link)
[DEV-167](https://linear.app/84000/issue/DEV-167/render-glossary-instance)