### PR TITLE
Add italic extension to block editor

### DIFF
--- a/libs/design-system/src/lib/Editor/BlockEditor/hooks/useDefaultExtensions.ts
+++ b/libs/design-system/src/lib/Editor/BlockEditor/hooks/useDefaultExtensions.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import Underline from '@tiptap/extension-underline';
 import Document from '../../extensions/Document';
 import Heading from '../../extensions/Heading/Heading';
 import Paragraph from '../../extensions/Paragraph/Paragraph';
@@ -8,10 +9,10 @@ import { getSuggestion } from '../../extensions/SlashCommand/Suggestions';
 import Link from '../../extensions/Link';
 import Placeholder from '../../extensions/Placeholder';
 import TextAlign from '../../extensions/TextAlign';
-import Underline from '@tiptap/extension-underline';
 import StarterKit from '../../extensions/StarterKit';
 import TranslationMetadata from '../../extensions/TranslationMetadata';
 import { DragHandle } from '../../extensions/DragHandle/DragHandle';
+import { Italic } from '../../extensions/Italic';
 
 export const useDefaultExtensions = () => {
   return {
@@ -19,6 +20,7 @@ export const useDefaultExtensions = () => {
       Document,
       DragHandle,
       Heading,
+      Italic,
       Link,
       Paragraph,
       Placeholder,


### PR DESCRIPTION
The TipTap extension `StarterKit` defines the `italic` mark. At some point, it was turned off in favor of an internally defined version. Unfortunately, it was not added back to the `BlockEditor` component. This takes care of that. 