### PR TITLE
Update endnote type

### DIFF
--- a/libs/data-access/src/lib/publications.ts
+++ b/libs/data-access/src/lib/publications.ts
@@ -82,7 +82,7 @@ export const getTranslationEndnotes = async ({
   client: DataClient;
   uuid: string;
 }) => {
-  return getTranslationPassages({ client, uuid, type: 'end-note' });
+  return getTranslationPassages({ client, uuid, type: 'endnote' });
 };
 
 export const getTranslationIntroduction = async ({

--- a/libs/data-access/src/lib/types/passage.ts
+++ b/libs/data-access/src/lib/types/passage.ts
@@ -3,7 +3,7 @@ import { Annotations, AnnotationsDTO } from './annotation';
 export type BodyItemType =
   | 'acknowledgment'
   | 'acknowledgmentHeader'
-  | 'end-note'
+  | 'endnote'
   | 'introduction'
   | 'summary'
   | 'summaryHeader'

--- a/libs/design-system/src/lib/Editor/BlockEditor/hooks/useDefaultExtensions.ts
+++ b/libs/design-system/src/lib/Editor/BlockEditor/hooks/useDefaultExtensions.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from '@tiptap/extension-image';
 import Underline from '@tiptap/extension-underline';
 import Document from '../../extensions/Document';
 import Heading from '../../extensions/Heading/Heading';
@@ -20,6 +21,7 @@ export const useDefaultExtensions = () => {
       Document,
       DragHandle,
       Heading,
+      Image,
       Italic,
       Link,
       Paragraph,

--- a/libs/design-system/src/lib/Translation/Passage/Passage.tsx
+++ b/libs/design-system/src/lib/Translation/Passage/Passage.tsx
@@ -14,7 +14,7 @@ export const TranslationHeader = H3;
 export const passageComponentForType: { [key in BodyItemType]: ElementType } = {
   acknowledgment: AcknowledgmentPassage,
   acknowledgmentHeader: AcknowledgmentHeader,
-  'end-note': P,
+  endnote: P,
   introduction: IntroductionPassage,
   summary: SummaryPassage,
   summaryHeader: SummaryHeader,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@tanstack/react-table": "^8.21.2",
         "@tiptap/extension-bubble-menu": "^2.14.0",
         "@tiptap/extension-document": "^2.14.0",
-        "@tiptap/extension-image": "^2.14.0",
+        "@tiptap/extension-image": "^2.22.3",
         "@tiptap/extension-italic": "^2.14.0",
         "@tiptap/extension-link": "^2.14.0",
         "@tiptap/extension-paragraph": "^2.14.0",
@@ -11299,9 +11299,9 @@
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.14.0.tgz",
-      "integrity": "sha512-pYCUzZBgsxIvVGTzuW03cPz6PIrAo26xpoxqq4W090uMVoK0SgY5W5y0IqCdw4QyLkJ2/oNSFNc2EP9jVi1CcQ==",
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.22.3.tgz",
+      "integrity": "sha512-JO8n5YOqOs+bckPZZ3qJFFLpRbYlu4N52n/7Do0XmxEMWaa3fLcR0Rsa1v3X4dGH2T5cKQ475dWSpJQRc+x07w==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tanstack/react-table": "^8.21.2",
     "@tiptap/extension-bubble-menu": "^2.14.0",
     "@tiptap/extension-document": "^2.14.0",
-    "@tiptap/extension-image": "^2.14.0",
+    "@tiptap/extension-image": "^2.22.3",
     "@tiptap/extension-italic": "^2.14.0",
     "@tiptap/extension-link": "^2.14.0",
     "@tiptap/extension-paragraph": "^2.14.0",


### PR DESCRIPTION
### Summary

This updates the `end-note` passage type to `endnote` to reflect a recent change to the database. It also adds support for image blocks in the editor, the lack of which was also causing some end note pages to break.