### PR TITLE
Conditional indentation for paragraphs

### DIFF
--- a/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/ParagraphButtons.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/menu/selectors/ParagraphButtons.tsx
@@ -4,8 +4,8 @@ import { useEditorState } from '@tiptap/react';
 import { Button } from '../../../../Button/Button';
 import {
   ArrowDownToLineIcon,
+  ArrowUpToLineIcon,
   IndentIcon,
-  PilcrowRightIcon,
 } from 'lucide-react';
 
 interface SelectorResult {
@@ -16,7 +16,7 @@ interface SelectorResult {
 
 const items = [
   {
-    icon: PilcrowRightIcon,
+    icon: ArrowUpToLineIcon,
     onClick: (editor: Editor) => {
       editor.chain().focus().toggleLeadingSpace().run();
     },

--- a/libs/design-system/src/lib/Editor/extensions/LeadingSpace.ts
+++ b/libs/design-system/src/lib/Editor/extensions/LeadingSpace.ts
@@ -29,7 +29,7 @@ export const LeadingSpace = Extension.create<LeadingSpaceOptions>({
   name: 'leadingSpace',
   addOptions() {
     return {
-      types: ['paragraph'],
+      types: ['paragraph', 'heading', 'lineGroup'],
       defaultHasLeadingSpace: false,
     };
   },
@@ -40,12 +40,12 @@ export const LeadingSpace = Extension.create<LeadingSpaceOptions>({
         attributes: {
           hasLeadingSpace: {
             default: this.options.defaultHasLeadingSpace,
-            parseHTML: (element) => element.className.includes('indent-8'),
+            parseHTML: (element) => element.className.includes('mt-6'),
             renderHTML: (attributes) => {
-              if (!attributes.hasLeadingSpace) {
-                return {};
+              if (attributes.hasLeadingSpace) {
+                return mergeAttributes(attributes, { class: 'mt-6 no-indent' });
               }
-              return mergeAttributes(attributes, { class: 'indent-8' });
+              return {};
             },
           },
         },

--- a/libs/design-system/src/lib/Editor/extensions/Paragraph/Paragraph.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Paragraph/Paragraph.ts
@@ -2,7 +2,7 @@ import TiptapParagraph from '@tiptap/extension-paragraph';
 
 export const Paragraph = TiptapParagraph.configure({
   HTMLAttributes: {
-    class: 'leading-7 mb-1',
+    class: 'leading-7 mb-1 conditional-indent',
   },
 });
 

--- a/libs/design-system/src/lib/Editor/extensions/Trailer.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Trailer.ts
@@ -42,10 +42,11 @@ export const Trailer = Extension.create<TrailerOptions>({
             default: this.options.defaultHasTrailer,
             parseHTML: (element) => element.className.includes('pb-6'),
             renderHTML: (attributes) => {
-              if (!attributes.hasTrailer) {
-                return {};
+              if (attributes.hasTrailer) {
+                return mergeAttributes(attributes, { class: 'pb-6 no-indent' });
               }
-              return mergeAttributes(attributes, { class: 'pb-6' });
+
+              return {};
             },
           },
         },

--- a/libs/design-system/src/lib/theme/editor.css
+++ b/libs/design-system/src/lib/theme/editor.css
@@ -18,6 +18,14 @@
   max-width: none !important;
 }
 
+.conditional-indent {
+  text-indent: calc(var(--spacing) * 8);
+}
+
+.conditional-indent.no-indent {
+  text-indent: 0;
+}
+
 .drag-handle {
   position: fixed;
   opacity: 1;


### PR DESCRIPTION
### Summary

If a paragraph has a `leading-space` or `trailer` annotation, do not indent. Otherwise, indentation is the default style.