### PR TITLE
Render abbreviations

### DIFF
--- a/apps/web-main/src/components/editor/EditorSidebar.tsx
+++ b/apps/web-main/src/components/editor/EditorSidebar.tsx
@@ -55,14 +55,6 @@ const englishEditorItems: EditorSidebarItem[] = [
     key: 'end-notes',
     title: 'End Notes',
   },
-  {
-    key: 'bibliography',
-    title: 'Bibliography',
-  },
-  {
-    key: 'glossary',
-    title: 'Glossary',
-  },
 ];
 
 const isActive = (key: EditorBuilderType, active: EditorBuilderType) =>

--- a/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.stories.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.stories.tsx
@@ -129,6 +129,69 @@ const content = {
         },
       ],
     },
+    {
+      attrs: {
+        uuid: 'b1c8f0d2-3c4e-4a5b-9d6f-7e8f9a0b1c2d',
+        class: 'passage',
+        type: 'abbreviationHeader',
+        sort: 150,
+        label: 'ab.',
+      },
+      type: 'passage',
+      content: [
+        {
+          type: 'heading',
+          attrs: {
+            level: 3,
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Abbreviations',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      attrs: {
+        uuid: 'b1c8f0d2-3c4e-4a5b-9d6f-7e8f9a0b1c2d',
+        class: 'passage',
+        type: 'abbreviation',
+        sort: 151,
+      },
+      type: 'passage',
+      content: [
+        {
+          type: 'table',
+          content: [
+            {
+              type: 'tableRow',
+              content: [
+                {
+                  type: 'abbreviation',
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'C',
+                    },
+                  ],
+                },
+                {
+                  type: 'hasAbbreviation',
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Choné Kangyur',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 };
 

--- a/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
@@ -43,6 +43,12 @@ import { MantraMark } from '../extensions/Mantra/Mantra';
 import { EndNoteLinkNode } from '../extensions/EndNoteLink/EndNoteLinkNode';
 import { GlossaryInstanceMark } from '../extensions/GlossaryInstanceMark';
 import { EndNoteNode } from '../extensions/EndNote/EndNoteNode';
+import {
+  AbbreviationCell,
+  AbbreviationCommand,
+  AbbreviationSuggestion,
+  HasAbbreviationCell,
+} from '../../extensions/Abbreviation/Abbreviation';
 
 const PassageSuggestion: CommandSuggestionItem = {
   title: 'Passage',
@@ -68,6 +74,7 @@ export const useTranslationExtensions = () => {
     Heading1Suggestion,
     Heading2Suggestion,
     Heading3Suggestion,
+    AbbreviationSuggestion,
     BulletListSuggestion,
     NumberListSuggestion,
     QuoteSuggestion,
@@ -75,6 +82,9 @@ export const useTranslationExtensions = () => {
   return {
     extensions: [
       TranslationDocument,
+      AbbreviationCell,
+      HasAbbreviationCell,
+      AbbreviationCommand,
       EndNoteLinkNode,
       EndNoteNode,
       GlossaryInstanceMark,

--- a/libs/design-system/src/lib/Editor/extensions/Abbreviation/Abbreviation.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Abbreviation/Abbreviation.ts
@@ -1,0 +1,93 @@
+import { Extension } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/react';
+import { TableCell } from '../Table';
+import { CommandSuggestionItem } from '../SlashCommand/SuggestionList';
+import { TableIcon } from 'lucide-react';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    abbreviationCommand: {
+      insertAbbreviation: () => ReturnType;
+    };
+  }
+}
+
+export const AbbreviationCommand = Extension.create({
+  name: 'abbreviationCommand',
+
+  addCommands() {
+    return {
+      insertAbbreviation:
+        () =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: 'table',
+            content: [
+              {
+                type: 'tableRow',
+                content: [
+                  {
+                    type: 'abbreviation',
+                    content: [{ type: 'text', text: 'A' }],
+                  },
+                  {
+                    type: 'hasAbbreviation',
+                    content: [{ type: 'text', text: 'Abbreviation' }],
+                  },
+                ],
+              },
+            ],
+          });
+        },
+    };
+  },
+});
+
+export const AbbreviationSuggestion: CommandSuggestionItem = {
+  title: 'Abbreviation',
+  description: 'Insert an abbreviation',
+  keywords: ['abbreviation'],
+  icon: TableIcon,
+  command: ({ editor, range }) => {
+    editor.chain().focus().deleteRange(range).insertAbbreviation().run();
+  },
+};
+
+export const AbbreviationCell = TableCell.extend({
+  name: 'abbreviation',
+  group: 'tableCell',
+  content: 'inline*',
+  parseHTML() {
+    return [{ tag: 'td[type=abbreviation]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'td',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        type: 'abbreviation',
+        class: 'italic',
+      }),
+      0,
+    ];
+  },
+});
+
+export const HasAbbreviationCell = TableCell.extend({
+  name: 'hasAbbreviation',
+  group: 'tableCell',
+  content: 'inline*',
+  parseHTML() {
+    return [{ tag: 'td[type=hasAbbreviation]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'td',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        type: 'hasAbbreviation',
+      }),
+      0,
+    ];
+  },
+});

--- a/libs/design-system/src/lib/Editor/extensions/Table.ts
+++ b/libs/design-system/src/lib/Editor/extensions/Table.ts
@@ -9,4 +9,6 @@ export const Table = TipTapTable.configure({
 
 export const TableCell = TipTapTableCell;
 export const TableHeader = TipTapTableHeader;
-export const TableRow = TipTapTableRow;
+export const TableRow = TipTapTableRow.extend({
+  content: '(tableCell | tableHeader | abbreviation | hasAbbreviation)*',
+});

--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -76,12 +76,47 @@ const endNoteTemplate = (passage: Passage): BlockEditorContentItem => {
   return block;
 };
 
+const abbreviationTemplate = (passage: Passage): BlockEditorContentItem => {
+  const content = [textTemplate(passage.content)];
+  const block: BlockEditorContentItem = {
+    type: 'table',
+    attrs: {
+      start: 0,
+      end: passage.content.length,
+      uuid: passage.uuid,
+    },
+    content: [
+      {
+        type: 'tableRow',
+        attrs: {
+          start: 0,
+          end: passage.content.length,
+          uuid: passage.uuid,
+        },
+        content: [
+          {
+            type: 'abbreviation',
+            attrs: {
+              start: 0,
+              end: passage.content.length,
+              uuid: passage.uuid,
+            },
+            content,
+          },
+        ],
+      },
+    ],
+  };
+
+  return block;
+};
+
 const TEMPLATES_FOR_BLOCK_TYPE: {
   [key in BodyItemType]: (passage: Passage) => BlockEditorContentItem;
 } = {
   acknowledgment: paragraphTemplate,
   acknowledgmentHeader: headingTemplate,
-  abbreviations: paragraphTemplate,
+  abbreviations: abbreviationTemplate,
   abbreviationHeader: headingTemplate,
   appendix: paragraphTemplate,
   appendixHeader: headingTemplate,

--- a/libs/lib-editing/src/lib/transformers/abbreviation.ts
+++ b/libs/lib-editing/src/lib/transformers/abbreviation.ts
@@ -1,3 +1,24 @@
-import { pass } from './transformer';
+import { recurse } from './recurse';
+import { splitBlock } from './split-block';
+import { Transformer } from './transformer';
 
-export const abbreviation = pass;
+export const abbreviation: Transformer = (ctx) => {
+  recurse({
+    until: ['abbreviation'],
+    ...ctx,
+    transform: (ctx) => {
+      splitBlock({
+        ...ctx,
+        transform: ({ block }) => {
+          block.type = 'abbreviation';
+          block.attrs = {
+            ...block.attrs,
+            start: ctx.annotation?.start,
+            end: ctx.annotation?.end,
+            uuid: ctx.annotation?.uuid,
+          };
+        },
+      });
+    },
+  });
+};

--- a/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
+++ b/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
@@ -1,3 +1,24 @@
-import { pass } from './transformer';
+import { recurse } from './recurse';
+import { splitBlock } from './split-block';
+import { Transformer } from './transformer';
 
-export const hasAbbreviation = pass;
+export const hasAbbreviation: Transformer = (ctx) => {
+  recurse({
+    until: ['abbreviation'],
+    ...ctx,
+    transform: (ctx) => {
+      splitBlock({
+        ...ctx,
+        transform: ({ block }) => {
+          block.type = 'hasAbbreviation';
+          block.attrs = {
+            ...block.attrs,
+            start: ctx.annotation?.start,
+            end: ctx.annotation?.end,
+            uuid: ctx.annotation?.uuid,
+          };
+        },
+      });
+    },
+  });
+};


### PR DESCRIPTION
### Summary

Abbreviations are rendered as two-column tables. This adds basic support for parsing, editing, and rendering them.

### Linear

[DEV-164](https://linear.app/84000/issue/DEV-164/render-abbreviations)