### PR TITLE
Expanded works table

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/canon/[slug]/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/canon/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { CanonPage } from '@lib-canon/ssr';
 
 export const revalidate = 3600;
 
-export const getStaticParams = async () => {
+export const generateStaticParams = async () => {
   const client = createBrowserClient();
   const sections = await getCanonSections({ client });
   return sections.map((section) => ({

--- a/apps/web-main/src/app/(DashboardLayout)/canon/[slug]/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/canon/[slug]/page.tsx
@@ -1,4 +1,15 @@
+import { createBrowserClient, getCanonSections } from '@data-access';
 import { CanonPage } from '@lib-canon/ssr';
+
+export const revalidate = 3600;
+
+export const getStaticParams = async () => {
+  const client = createBrowserClient();
+  const sections = await getCanonSections({ client });
+  return sections.map((section) => ({
+    slug: section.uuid,
+  }));
+};
 
 const Page = CanonPage;
 

--- a/libs/data-access/src/lib/canon.ts
+++ b/libs/data-access/src/lib/canon.ts
@@ -1,12 +1,29 @@
 import {
   CanonDTO,
   CanonDetailDTO,
+  CanonNode,
   CanonWorksDTO,
   DataClient,
   canonDetailFromDTO,
+  canonNodeFromDTO,
   canonTreeFromDTOs,
   caononWorksFromDTO,
 } from './types';
+
+export const getCanonSections = async ({
+  client,
+}: {
+  client: DataClient;
+}): Promise<CanonNode[]> => {
+  const { data, error } = await client.rpc('scholar_canon_get_all');
+
+  if (error) {
+    console.error('Error fetching canon sections:', error);
+    return [];
+  }
+
+  return data.map((item: CanonDTO) => canonNodeFromDTO(item));
+};
 
 export const getCanonTree = async ({ client }: { client: DataClient }) => {
   const { data, error } = await client.rpc('scholar_canon_get_all');
@@ -40,14 +57,14 @@ export const getCanonSection = async ({
 
 export const getCanonWorks = async ({
   client,
-  uuid,
+  uuids,
 }: {
   client: DataClient;
-  uuid: string;
+  uuids: string[];
 }) => {
   const { data, error } = await client
     .rpc('scholar_canon_get_works', {
-      uuid_input: uuid,
+      uuids_input: uuids,
     })
     .single();
 
@@ -57,4 +74,38 @@ export const getCanonWorks = async ({
   }
 
   return caononWorksFromDTO(data as CanonWorksDTO);
+};
+
+/** Travers the canon tree to find a node by its UUID */
+export const findNodeByUuid = (
+  head: CanonNode[],
+  uuid: string,
+): CanonNode | null => {
+  for (const node of head) {
+    if (node.uuid === uuid) {
+      return node;
+    }
+    if (node.children) {
+      const found = findNodeByUuid(node.children, uuid);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+};
+
+/** Flatten the canon tree into a list of nodes */
+export const flattenCanonTree = (head: CanonNode): CanonNode[] => {
+  const flatList: CanonNode[] = [head];
+
+  const traverse = (node: CanonNode) => {
+    flatList.push(node);
+    if (node.children) {
+      node.children.forEach(traverse);
+    }
+  };
+
+  head.children?.forEach(traverse);
+  return flatList;
 };

--- a/libs/lib-canon/src/lib/page/Page.tsx
+++ b/libs/lib-canon/src/lib/page/Page.tsx
@@ -1,6 +1,9 @@
 import {
   createBrowserClient,
+  findNodeByUuid,
+  flattenCanonTree,
   getCanonSection,
+  getCanonTree,
   getCanonWorks,
 } from '@data-access';
 import { ArticlePage } from './ArticlePage';
@@ -17,8 +20,13 @@ export const CanonPage = async ({
   const { slug: uuid } = await params;
 
   const client = createBrowserClient();
+  const canon = await getCanonTree({ client });
+  const node = findNodeByUuid(canon?.children || [], uuid);
+  const nodes = node ? flattenCanonTree(node) : [node];
+  const uuids = nodes.map((n) => n?.uuid).filter(Boolean) as string[];
+
   const section = await getCanonSection({ client, uuid });
-  const works = await getCanonWorks({ client, uuid });
+  const works = await getCanonWorks({ client, uuids });
   const { tab } = await searchParams;
 
   if (!section) {


### PR DESCRIPTION
### Summary

Most sections in the canon tree do not have works expressly associated with them, especially of they are not leaf nodes. With this change, parent nodes will display all works in child nodes in their works table.

### Linear

[DEV-276](https://linear.app/84000/issue/DEV-276/canon-resource-view-parents)