### PR TITLE
Toh251 test harness

### DIFF
--- a/apps/web-editor/src/components/EditorPage.tsx
+++ b/apps/web-editor/src/components/EditorPage.tsx
@@ -7,8 +7,10 @@ import {
   TranslationEditorContent,
 } from '@design-system';
 import { useEffect, useState } from 'react';
+import { blocksFromTranslationBody } from '@lib-editing';
 import { EditorType, Format, Slug } from '@lib-editing/fixtures/types';
 import { EMPTY_DOCUMENT, SLUG_PATHS } from './constants';
+import { PassageDTO, translationBodyFromDTO } from '@data-access';
 
 export const EditorPage = ({
   slug,
@@ -32,7 +34,16 @@ export const EditorPage = ({
         content: EMPTY_DOCUMENT,
         type: 'block',
       };
-      setContent(content);
+
+      let parsedContent = content;
+      if (format === 'passages') {
+        const dtos = content as PassageDTO[];
+        const passages = translationBodyFromDTO(dtos);
+        console.log(JSON.stringify(passages, null, 2));
+        parsedContent = blocksFromTranslationBody(passages);
+      }
+
+      setContent(parsedContent);
       setEditorType(type);
     })();
   }, [slug, format]);

--- a/apps/web-editor/src/components/EditorPage.tsx
+++ b/apps/web-editor/src/components/EditorPage.tsx
@@ -39,7 +39,6 @@ export const EditorPage = ({
       if (format === 'passages') {
         const dtos = content as PassageDTO[];
         const passages = translationBodyFromDTO(dtos);
-        console.log(JSON.stringify(passages, null, 2));
         parsedContent = blocksFromTranslationBody(passages);
       }
 

--- a/apps/web-editor/src/components/constants.ts
+++ b/apps/web-editor/src/components/constants.ts
@@ -2,6 +2,15 @@ import {
   content as basicJsonContent,
   type as basicJsonType,
 } from '@lib-editing/fixtures/basic/json';
+import {
+  content as toh251JsonContent,
+  type as toh251JsonType,
+} from '@lib-editing/fixtures/toh251/json';
+import {
+  content as toh251PassagesContent,
+  type as toh251PassagesType,
+} from '@lib-editing/fixtures/toh251/passages';
+
 import { EditorType, Format, Slug } from '@lib-editing/fixtures/types';
 import { JSONContent } from '@tiptap/react';
 
@@ -19,6 +28,16 @@ export const SLUG_PATHS: {
     json: {
       content: basicJsonContent,
       type: basicJsonType,
+    },
+  },
+  toh251: {
+    json: {
+      content: toh251JsonContent,
+      type: toh251JsonType,
+    },
+    passages: {
+      content: toh251PassagesContent,
+      type: toh251PassagesType,
     },
   },
 };

--- a/libs/data-access/src/lib/types/annotation.ts
+++ b/libs/data-access/src/lib/types/annotation.ts
@@ -52,9 +52,16 @@ export type HasAbbreviationAnnotation = AnnotationBase & {
   type: 'hasAbbreviation';
 };
 
+export type HeadingClass =
+  | 'section-label'
+  | 'section-title'
+  | 'supplementary'
+  | 'table-label';
+
 export type HeadingAnnotation = AnnotationBase & {
   type: 'heading';
   level: number;
+  class?: HeadingClass;
 };
 
 export type ImageAnnotation = AnnotationBase & {
@@ -156,21 +163,28 @@ export type UnknownAnnotation = AnnotationBase & {
 };
 
 export type AnnotationDTOContentKey =
+  | 'endnote_xmlId'
+  | 'glossary_xmlId'
   | 'heading-level'
+  | 'heading-type'
   | 'href'
   | 'label'
   | 'lang'
   | 'link-text'
+  | 'link-text-lookup'
   | 'link-type'
   | 'media-type'
   | 'paragraph'
+  | 'quote_xmlId'
   | 'src'
   | 'text-style'
   | 'type'
   | 'title'
   | 'uuid';
 
-export type AnnotationDTOContent = Record<AnnotationDTOContentKey, unknown>;
+export type AnnotationDTOContent = Partial<
+  Record<AnnotationDTOContentKey, unknown>
+>;
 
 export type AnnotationDTO = {
   content: AnnotationDTOContent[];
@@ -294,7 +308,6 @@ const dtoToAnnotationMap: Record<
   'has-abbreviation': (dto: AnnotationDTO): HasAbbreviationAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as HasAbbreviationAnnotation;
   },
   heading: (dto: AnnotationDTO): HeadingAnnotation => {
@@ -305,6 +318,10 @@ const dtoToAnnotationMap: Record<
         const levelStr = headerStr.replace('h', '');
         const level = parseInt(levelStr, 10);
         heading.level = level;
+      }
+
+      if (content['heading-type']) {
+        heading.class = content['heading-type'] as HeadingClass;
       }
     });
 
@@ -361,19 +378,16 @@ const dtoToAnnotationMap: Record<
   'leading-space': (dto: AnnotationDTO) => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as LeadingSpaceAnnotation;
   },
   line: (dto: AnnotationDTO): LineAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as LineAnnotation;
   },
   'line-group': (dto: AnnotationDTO): LineGroupAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as LineGroupAnnotation;
   },
   link: (dto: AnnotationDTO): LinkAnnotation => {
@@ -393,13 +407,11 @@ const dtoToAnnotationMap: Record<
   list: (dto: AnnotationDTO): ListAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as ListAnnotation;
   },
   'list-item': (dto: AnnotationDTO): ListItemAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as ListItemAnnotation;
   },
   mantra: (dto: AnnotationDTO): MantraAnnotation => {
@@ -414,7 +426,6 @@ const dtoToAnnotationMap: Record<
   paragraph: (dto: AnnotationDTO): ParagraphAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as ParagraphAnnotation;
   },
   quote: (dto: AnnotationDTO): QuoteAnnotation => {
@@ -440,7 +451,6 @@ const dtoToAnnotationMap: Record<
   reference: (dto: AnnotationDTO): ReferenceAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as ReferenceAnnotation;
   },
   span: (dto: AnnotationDTO): SpanAnnotation => {
@@ -459,31 +469,26 @@ const dtoToAnnotationMap: Record<
   'table-body-data': (dto: AnnotationDTO): TableBodyDataAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as TableBodyDataAnnotation;
   },
   'table-body-header': (dto: AnnotationDTO): TableBodyHeaderAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as TableBodyHeaderAnnotation;
   },
   'table-body-row': (dto: AnnotationDTO): TableBodyRowAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as TableBodyRowAnnotation;
   },
   trailer: (dto: AnnotationDTO): TrailerAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as TrailerAnnotation;
   },
   unknown: (dto: AnnotationDTO): UnknownAnnotation => {
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
     } as UnknownAnnotation;
   },
 };
@@ -495,7 +500,6 @@ export const annotationFromDTO = (dto: AnnotationDTO): Annotation => {
     console.warn(dto);
     return {
       ...baseAnnotationFromDTO(dto),
-      content: [],
       type: 'unknown',
     } as UnknownAnnotation;
   }

--- a/libs/data-access/src/lib/types/passage.ts
+++ b/libs/data-access/src/lib/types/passage.ts
@@ -43,9 +43,10 @@ export type PassageDTO = {
   sort: number;
   type: BodyItemType;
   uuid: string;
-  work_uuid: string;
+  workUuid: string;
   xmlId?: string;
-  annotations?: AnnotationsDTO;
+  parent?: string;
+  annotations?: AnnotationsDTO | null;
 };
 
 export const passageFromDTO = (
@@ -58,7 +59,7 @@ export const passageFromDTO = (
     sort: dto.sort,
     type: dto.type,
     uuid: dto.uuid,
-    workUuid: dto.work_uuid,
+    workUuid: dto.workUuid,
     xmlId: dto.xmlId,
     annotations: annotations.filter((a) => a.passageUuid === dto.uuid) || [],
   };

--- a/libs/lib-editing/src/fixtures/toh251/json-real.ts
+++ b/libs/lib-editing/src/fixtures/toh251/json-real.ts
@@ -1,0 +1,1052 @@
+/*
+ * NOTE: this is the actual output of parsing. A separate document represents
+ * the ideal output. Some obervations:
+ * - There are some off-by-one errors in the end positions of some blocks. These
+ *   exclusive end positions. The input is inclusive. Explore making this
+ *   consistent.
+ * - Some endNoteLinks appear to be in the wrong place. It may also make sense
+ *   handle them differently, since they don't have text.
+ * - The uuids for leading spaces and trailers are not tracked.
+ * - Lines in verse have trailing spaces that are represented as text blocks.
+ *   These may need to be trimmed.
+ */
+
+import { TranslationEditorContent } from '@design-system';
+import { EditorType } from '../types';
+
+export const type: EditorType = 'translation';
+
+export const content: TranslationEditorContent = [
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '0a812d07-8fcc-41b9-9af5-96ec9bce25d5',
+      sort: 165,
+      type: 'translationHeader',
+      label: '1.',
+    },
+    content: [
+      {
+        type: 'heading',
+        attrs: {
+          level: 2,
+          class: 'section-title',
+          start: 0,
+          end: 15,
+          uuid: 'c4229046-ec92-4d1e-8bd2-ac9e860d0b64',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'The Translation',
+            attrs: {
+              start: 0,
+              end: 15,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'b7a07809-d6e0-427b-bfc6-50ea2acd8155',
+      sort: 168,
+      type: 'translation',
+      label: '1.1',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 43,
+          uuid: 'b7a07809-d6e0-427b-bfc6-50ea2acd8155',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'Homage to all the buddhas and bodhisattvas!',
+            attrs: {
+              start: 0,
+              end: 43,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
+      sort: 170,
+      type: 'translation',
+      label: '1.2',
+    },
+    // TODO: keep track of leading space annotation uuid
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 262,
+          uuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
+          hasLeadingSpace: true,
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'Thus did I hear at one time. The Buddha was residing in ',
+            attrs: {
+              start: 0,
+              end: 56,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Śrāvastī',
+            attrs: {
+              start: 56,
+              end: 64,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '55532312-84c3-4ab9-9220-58b7598c8440',
+                  uuid: '48b09ede-46cf-419a-9ec8-64c4a610b456',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', in ',
+            attrs: {
+              start: 64,
+              end: 69,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Jeta’s Grove, Anāthapiṇḍada’s park',
+            attrs: {
+              start: 69,
+              end: 103,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '86c17e77-82a6-4b77-bd21-3f012d36f1f5',
+                  uuid: '4ebf55f0-fddd-45e6-a9af-09997c6f96f5',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', together with a great community of monks, consisting of 1,250 monks, and a great assembly of bodhisattvas. At that time, the Blessed One addressed the monks:',
+            attrs: {
+              start: 103,
+              end: 262,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
+      sort: 176,
+      type: 'translation',
+      label: '1.3',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 147,
+          uuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '73776d26-6858-413b-9d62-5ffe18a59e4c',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon four factors even at the cost of their lives. What are these four?',
+            attrs: {
+              start: 60,
+              end: 147,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '1350a8f8-cb5f-48d6-8d24-7152124b2ed9',
+      sort: 181,
+      type: 'translation',
+      label: '1.4',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 138,
+          uuid: '1350a8f8-cb5f-48d6-8d24-7152124b2ed9',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '93fb08c3-dabb-45e3-b9d6-05d40fb8df92',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon the ',
+            attrs: {
+              start: 60,
+              end: 85,
+            },
+          },
+          {
+            type: 'text',
+            text: 'thought of awakening',
+            attrs: {
+              start: 85,
+              end: 105,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '71c3e498-a282-46c2-a1b2-09bff483deac',
+                  uuid: '7cb61bc2-cf3c-4b28-a026-56062c3febce',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' even at the cost of their lives.',
+            attrs: {
+              start: 105,
+              end: 138,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'f1ed1290-9632-4bcf-8e9d-e6bf561e32a8',
+      sort: 187,
+      type: 'translation',
+      label: '1.5',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 134,
+          uuid: 'f1ed1290-9632-4bcf-8e9d-e6bf561e32a8',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '1e14fa7b-adde-4991-8b26-3f4ff17ac243',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon the ',
+            attrs: {
+              start: 60,
+              end: 85,
+            },
+          },
+          {
+            type: 'text',
+            text: 'spiritual friend',
+            attrs: {
+              start: 85,
+              end: 101,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+                  uuid: 'b720b5d4-3213-4638-b192-eb8e8dca8299',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' even at the cost of their lives.',
+            attrs: {
+              start: 101,
+              end: 134,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+      sort: 193,
+      type: 'translation',
+      label: '1.6',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 136,
+          uuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '9be0ece5-da55-4d6d-934f-26149e9241ac',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon ',
+            attrs: {
+              start: 60,
+              end: 81,
+            },
+          },
+          {
+            type: 'text',
+            text: 'tolerance',
+            attrs: {
+              start: 81,
+              end: 90,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+                  uuid: '247d0cd6-8f48-4e3d-8c70-ab5ddf7f1382',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' and ',
+            attrs: {
+              start: 90,
+              end: 95,
+            },
+          },
+          {
+            type: 'text',
+            text: 'lenience',
+            attrs: {
+              start: 95,
+              end: 103,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+                  uuid: 'bc10971b-913a-4a6b-b0cb-888310563c90',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' even at the cost of their lives.',
+            attrs: {
+              start: 103,
+              end: 136,
+            },
+          },
+          // TODO: consider handling end notes differently since they don't have text
+          {
+            type: 'endNoteLink',
+            attrs: {
+              start: 136,
+              end: 136,
+              endNote: '5433d5e2-c2f2-4a05-bc48-60dcb1109fbf',
+              uuid: 'de90ce7e-9b47-4324-ae1c-b803ee1cd28e',
+            },
+            marks: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
+      sort: 202,
+      type: 'translation',
+      label: '1.7',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 140,
+          uuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '85247b59-0ae2-4dc2-8f1d-fc7d43d18e04',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon ',
+            attrs: {
+              start: 60,
+              end: 81,
+            },
+          },
+          {
+            type: 'text',
+            text: 'dwelling in the wilderness',
+            attrs: {
+              start: 81,
+              end: 107,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '54ba640b-1d20-454d-bff4-14becefbc904',
+                  uuid: '9f5020c2-2a3f-4faa-8d83-e953dfb0b255',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' even at the cost of their lives.',
+            attrs: {
+              start: 107,
+              end: 140,
+            },
+          },
+          // BUG: this should be one earlier
+          {
+            type: 'endNoteLink',
+            attrs: {
+              start: 107,
+              end: 107,
+              endNote: 'fb6c0152-67eb-4ef9-91bc-8fb6ea64e6f1',
+              uuid: 'd5f88fe6-79d7-45ed-bf99-2cbfca3bc9f3',
+            },
+            marks: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '7dea2dba-3580-4d45-8bb3-f9cea52a1991',
+      sort: 209,
+      type: 'translation',
+      label: '1.8',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 133,
+          uuid: '7dea2dba-3580-4d45-8bb3-f9cea52a1991',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: 'f78b3d56-2441-426f-ae87-8285bb46c82a',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon these four factors even at the cost of their lives.”',
+            attrs: {
+              start: 60,
+              end: 133,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'd9096952-6a7d-4f87-93cf-a8c99a4c1ef3',
+      sort: 213,
+      type: 'translation',
+      label: '1.9',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 120,
+          uuid: 'd9096952-6a7d-4f87-93cf-a8c99a4c1ef3',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'The Blessed One spoke these words, and once the Sugata had spoken in this way, he, the Teacher, also said the following:',
+            attrs: {
+              start: 0,
+              end: 120,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      sort: 215,
+      type: 'translation',
+      label: '1.10',
+    },
+    content: [
+      {
+        type: 'lineGroup',
+        attrs: {
+          start: 0,
+          end: 201,
+          uuid: '7d2b05e7-c63f-40ea-8e6b-3ccefb83c603',
+        },
+        content: [
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: '“Let the wise conceive the thought of perfect awakening, ',
+                attrs: {
+                  start: 0,
+                  end: 57,
+                },
+              },
+            ],
+            // BUG: end should be 57
+            attrs: {
+              start: 0,
+              end: 56,
+              uuid: '181a3584-20b8-4d6e-a0e5-c0ea733dbae6',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'And not cast aside the thought of omniscience',
+                attrs: {
+                  start: 57,
+                  end: 102,
+                },
+              },
+              {
+                type: 'text',
+                text: ';',
+                attrs: {
+                  start: 102,
+                  end: 103,
+                },
+              },
+              // BUG: should be one earlier
+              {
+                type: 'endNoteLink',
+                attrs: {
+                  start: 102,
+                  end: 102,
+                  endNote: 'fb352874-9ae4-4658-97ea-ec944f2c6dfc',
+                  uuid: 'bc5071aa-2099-4323-a353-6318e01de343',
+                },
+                marks: [],
+              },
+              // BUG: text blocks should not be empty. This appears to be a quirk
+              // of verse, where the passages have spaces between lines. They must
+              // trimmed.
+              {
+                type: 'text',
+                text: ' ',
+                attrs: {
+                  start: 103,
+                  end: 104,
+                },
+              },
+            ],
+            attrs: {
+              start: 57,
+              // BUG: should be 104
+              end: 103,
+              uuid: 'ca6b3880-1040-4920-b1ce-e80aa7e7bcd7',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'Let them maintain the strength of ',
+                attrs: {
+                  start: 104,
+                  end: 138,
+                },
+              },
+              {
+                type: 'text',
+                text: 'tolerance',
+                attrs: {
+                  start: 138,
+                  end: 147,
+                },
+                marks: [
+                  {
+                    type: 'glossaryInstance',
+                    attrs: {
+                      authority: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+                      uuid: '79f4938e-df3c-40c8-a618-fa188a124517',
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                text: ' and ',
+                attrs: {
+                  start: 147,
+                  end: 152,
+                },
+              },
+              {
+                type: 'text',
+                text: 'lenience',
+                attrs: {
+                  start: 152,
+                  end: 160,
+                },
+                marks: [
+                  {
+                    type: 'glossaryInstance',
+                    attrs: {
+                      authority: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+                      uuid: 'dd65abe5-d658-40d9-820d-d9c427e40f5e',
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                text: ', ',
+                attrs: {
+                  start: 160,
+                  end: 162,
+                },
+              },
+            ],
+            attrs: {
+              start: 104,
+              end: 161, // BUG: should be 162
+              uuid: '196aa179-8cea-4525-8a41-19eb0781312f',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'And never forsake the ',
+                attrs: {
+                  start: 162,
+                  end: 184,
+                },
+              },
+              {
+                type: 'text',
+                text: 'spiritual friend',
+                attrs: {
+                  start: 184,
+                  end: 200,
+                },
+                marks: [
+                  {
+                    type: 'glossaryInstance',
+                    attrs: {
+                      authority: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+                      uuid: '83d1bcb5-15ed-492b-a401-d59e7a0c0ad3',
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                text: '.',
+                attrs: {
+                  start: 200,
+                  end: 201,
+                },
+              },
+            ],
+            attrs: {
+              start: 162,
+              end: 201, // NOTE: this is correct since the last line doesn't have trailing space
+              uuid: 'cf054120-9398-4855-8c62-3677041041d4',
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+      sort: 230,
+      type: 'translation',
+      label: '1.11',
+    },
+    content: [
+      {
+        type: 'lineGroup',
+        attrs: {
+          start: 0,
+          end: 184,
+          uuid: 'e9eec4aa-3a9f-435b-9111-4aa27a3deb11',
+        },
+        content: [
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: '“If the wise, like the king of beasts, abandon fear, ',
+                attrs: {
+                  start: 0,
+                  end: 53,
+                },
+              },
+            ],
+            attrs: {
+              start: 0,
+              end: 52,
+              uuid: '9b820bc7-def0-484e-bdd8-088d19e37b48',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'Always remain ',
+                attrs: {
+                  start: 53,
+                  end: 67,
+                },
+              },
+              {
+                type: 'text',
+                text: 'dwelling in the wilderness',
+                attrs: {
+                  start: 67,
+                  end: 93,
+                },
+                marks: [
+                  {
+                    type: 'glossaryInstance',
+                    attrs: {
+                      authority: '54ba640b-1d20-454d-bff4-14becefbc904',
+                      uuid: 'cc951a6e-3334-4f23-8727-8d1b9807e186',
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                text: ', ',
+                attrs: {
+                  start: 93,
+                  end: 95,
+                },
+              },
+            ],
+            attrs: {
+              start: 53,
+              end: 94,
+              uuid: 'd65f874d-9d51-42f3-aa8d-60a200f566fd',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'And constantly maintain these factors, ',
+                attrs: {
+                  start: 95,
+                  end: 134,
+                },
+              },
+            ],
+            attrs: {
+              start: 95,
+              end: 133,
+              uuid: '7defb520-391b-488f-8821-ab35d7fac408',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'They will conquer the māras and attain awakening.”',
+                attrs: {
+                  start: 134,
+                  end: 184,
+                },
+              },
+            ],
+            attrs: {
+              start: 134,
+              end: 184,
+              uuid: 'e003cc18-27e1-4be5-b52d-ed4230eaf692',
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '3c0a9671-d031-40fa-ae5b-def8887c4ded',
+      sort: 241,
+      type: 'translation',
+      label: '1.12',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 149,
+          uuid: '3c0a9671-d031-40fa-ae5b-def8887c4ded',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'When the Blessed One had said this, the monks and bodhisattvas, together with the entire assembly, rejoiced and praised the words of the Blessed One.',
+            attrs: {
+              start: 0,
+              end: 149,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
+      sort: 243,
+      type: 'translation',
+      label: '1.13',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 62,
+          uuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
+          // NOTE: harTrailer loses the trailer annotation uuid
+          hasTrailer: true,
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'This concludes ',
+            attrs: {
+              start: 0,
+              end: 15,
+            },
+          },
+          {
+            type: 'text',
+            text: '“The Noble Mahāyāna Sūtra on the Four Factors.”',
+            attrs: {
+              start: 15,
+              end: 62,
+            },
+            marks: [
+              {
+                type: 'italic',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/libs/lib-editing/src/fixtures/toh251/json-real.ts
+++ b/libs/lib-editing/src/fixtures/toh251/json-real.ts
@@ -1,14 +1,13 @@
 /*
  * NOTE: this is the actual output of parsing. A separate document represents
  * the ideal output. Some obervations:
- * - There are some off-by-one errors in the end positions of some blocks. These
- *   exclusive end positions. The input is inclusive. Explore making this
- *   consistent.
+ * - There are some off-by-one errors in the end positions of some blocks. The
+ *   input is inclusive with the exception that an annotation can go one past the
+ *   end of passage content. The output is exclusive but should be inclusive. It
+ *   can correct the exceptions noted above.
  * - Some endNoteLinks appear to be in the wrong place. It may also make sense
  *   handle them differently, since they don't have text.
  * - The uuids for leading spaces and trailers are not tracked.
- * - Lines in verse have trailing spaces that are represented as text blocks.
- *   These may need to be trimmed.
  */
 
 import { TranslationEditorContent } from '@design-system';
@@ -30,7 +29,6 @@ export const content: TranslationEditorContent = [
         type: 'heading',
         attrs: {
           level: 2,
-          class: 'section-title',
           start: 0,
           end: 15,
           uuid: 'c4229046-ec92-4d1e-8bd2-ac9e860d0b64',
@@ -85,7 +83,6 @@ export const content: TranslationEditorContent = [
       type: 'translation',
       label: '1.2',
     },
-    // TODO: keep track of leading space annotation uuid
     content: [
       {
         type: 'paragraph',
@@ -115,7 +112,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: '55532312-84c3-4ab9-9220-58b7598c8440',
+                  authority: 'f2a07704-3c71-4f05-8e6a-5d326406fae2',
                   uuid: '48b09ede-46cf-419a-9ec8-64c4a610b456',
                 },
               },
@@ -140,7 +137,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: '86c17e77-82a6-4b77-bd21-3f012d36f1f5',
+                  authority: '7fc58f66-5fbb-4973-8744-f6589f8aae97',
                   uuid: '4ebf55f0-fddd-45e6-a9af-09997c6f96f5',
                 },
               },
@@ -194,7 +191,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  authority: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
                   uuid: '73776d26-6858-413b-9d62-5ffe18a59e4c',
                 },
               },
@@ -248,7 +245,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  authority: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
                   uuid: '93fb08c3-dabb-45e3-b9d6-05d40fb8df92',
                 },
               },
@@ -273,7 +270,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: '71c3e498-a282-46c2-a1b2-09bff483deac',
+                  authority: '445f17ca-164b-4c68-82a3-f9f3ee3595b6',
                   uuid: '7cb61bc2-cf3c-4b28-a026-56062c3febce',
                 },
               },
@@ -327,7 +324,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  authority: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
                   uuid: '1e14fa7b-adde-4991-8b26-3f4ff17ac243',
                 },
               },
@@ -352,7 +349,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+                  authority: '4049f21f-fa6c-4180-80f5-0750c14162da',
                   uuid: 'b720b5d4-3213-4638-b192-eb8e8dca8299',
                 },
               },
@@ -406,7 +403,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  authority: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
                   uuid: '9be0ece5-da55-4d6d-934f-26149e9241ac',
                 },
               },
@@ -431,7 +428,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+                  authority: '3268038f-cca4-471a-94b3-13c62c85b7ca',
                   uuid: '247d0cd6-8f48-4e3d-8c70-ab5ddf7f1382',
                 },
               },
@@ -456,7 +453,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+                  authority: '4f7a6a56-6c00-43a0-b457-f3e741364a05',
                   uuid: 'bc10971b-913a-4a6b-b0cb-888310563c90',
                 },
               },
@@ -470,7 +467,6 @@ export const content: TranslationEditorContent = [
               end: 136,
             },
           },
-          // TODO: consider handling end notes differently since they don't have text
           {
             type: 'endNoteLink',
             attrs: {
@@ -521,7 +517,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  authority: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
                   uuid: '85247b59-0ae2-4dc2-8f1d-fc7d43d18e04',
                 },
               },
@@ -546,7 +542,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: '54ba640b-1d20-454d-bff4-14becefbc904',
+                  authority: 'c2d14c50-fccd-4438-bebc-6dfa4f77194e',
                   uuid: '9f5020c2-2a3f-4faa-8d83-e953dfb0b255',
                 },
               },
@@ -560,7 +556,6 @@ export const content: TranslationEditorContent = [
               end: 140,
             },
           },
-          // BUG: this should be one earlier
           {
             type: 'endNoteLink',
             attrs: {
@@ -611,7 +606,7 @@ export const content: TranslationEditorContent = [
               {
                 type: 'glossaryInstance',
                 attrs: {
-                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  authority: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
                   uuid: 'f78b3d56-2441-426f-ae87-8285bb46c82a',
                 },
               },
@@ -687,10 +682,9 @@ export const content: TranslationEditorContent = [
                 },
               },
             ],
-            // BUG: end should be 57
             attrs: {
               start: 0,
-              end: 56,
+              end: 57,
               uuid: '181a3584-20b8-4d6e-a0e5-c0ea733dbae6',
             },
           },
@@ -706,15 +700,6 @@ export const content: TranslationEditorContent = [
                 },
               },
               {
-                type: 'text',
-                text: ';',
-                attrs: {
-                  start: 102,
-                  end: 103,
-                },
-              },
-              // BUG: should be one earlier
-              {
                 type: 'endNoteLink',
                 attrs: {
                   start: 102,
@@ -724,22 +709,18 @@ export const content: TranslationEditorContent = [
                 },
                 marks: [],
               },
-              // BUG: text blocks should not be empty. This appears to be a quirk
-              // of verse, where the passages have spaces between lines. They must
-              // trimmed.
               {
                 type: 'text',
-                text: ' ',
+                text: '; ',
                 attrs: {
-                  start: 103,
+                  start: 102,
                   end: 104,
                 },
               },
             ],
             attrs: {
               start: 57,
-              // BUG: should be 104
-              end: 103,
+              end: 104,
               uuid: 'ca6b3880-1040-4920-b1ce-e80aa7e7bcd7',
             },
           },
@@ -765,7 +746,7 @@ export const content: TranslationEditorContent = [
                   {
                     type: 'glossaryInstance',
                     attrs: {
-                      authority: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+                      authority: '3268038f-cca4-471a-94b3-13c62c85b7ca',
                       uuid: '79f4938e-df3c-40c8-a618-fa188a124517',
                     },
                   },
@@ -790,7 +771,7 @@ export const content: TranslationEditorContent = [
                   {
                     type: 'glossaryInstance',
                     attrs: {
-                      authority: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+                      authority: '4f7a6a56-6c00-43a0-b457-f3e741364a05',
                       uuid: 'dd65abe5-d658-40d9-820d-d9c427e40f5e',
                     },
                   },
@@ -807,7 +788,7 @@ export const content: TranslationEditorContent = [
             ],
             attrs: {
               start: 104,
-              end: 161, // BUG: should be 162
+              end: 162,
               uuid: '196aa179-8cea-4525-8a41-19eb0781312f',
             },
           },
@@ -833,7 +814,7 @@ export const content: TranslationEditorContent = [
                   {
                     type: 'glossaryInstance',
                     attrs: {
-                      authority: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+                      authority: '4049f21f-fa6c-4180-80f5-0750c14162da',
                       uuid: '83d1bcb5-15ed-492b-a401-d59e7a0c0ad3',
                     },
                   },
@@ -850,7 +831,7 @@ export const content: TranslationEditorContent = [
             ],
             attrs: {
               start: 162,
-              end: 201, // NOTE: this is correct since the last line doesn't have trailing space
+              end: 201,
               uuid: 'cf054120-9398-4855-8c62-3677041041d4',
             },
           },
@@ -889,7 +870,7 @@ export const content: TranslationEditorContent = [
             ],
             attrs: {
               start: 0,
-              end: 52,
+              end: 53,
               uuid: '9b820bc7-def0-484e-bdd8-088d19e37b48',
             },
           },
@@ -915,7 +896,7 @@ export const content: TranslationEditorContent = [
                   {
                     type: 'glossaryInstance',
                     attrs: {
-                      authority: '54ba640b-1d20-454d-bff4-14becefbc904',
+                      authority: 'c2d14c50-fccd-4438-bebc-6dfa4f77194e',
                       uuid: 'cc951a6e-3334-4f23-8727-8d1b9807e186',
                     },
                   },
@@ -932,7 +913,7 @@ export const content: TranslationEditorContent = [
             ],
             attrs: {
               start: 53,
-              end: 94,
+              end: 95,
               uuid: 'd65f874d-9d51-42f3-aa8d-60a200f566fd',
             },
           },
@@ -950,7 +931,7 @@ export const content: TranslationEditorContent = [
             ],
             attrs: {
               start: 95,
-              end: 133,
+              end: 134,
               uuid: '7defb520-391b-488f-8821-ab35d7fac408',
             },
           },
@@ -1020,7 +1001,6 @@ export const content: TranslationEditorContent = [
           start: 0,
           end: 62,
           uuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
-          // NOTE: harTrailer loses the trailer annotation uuid
           hasTrailer: true,
         },
         content: [

--- a/libs/lib-editing/src/fixtures/toh251/json.ts
+++ b/libs/lib-editing/src/fixtures/toh251/json.ts
@@ -1,0 +1,1021 @@
+import { TranslationEditorContent } from '@design-system';
+import { EditorType } from '../types';
+
+export const type: EditorType = 'translation';
+
+export const content: TranslationEditorContent = [
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '0a812d07-8fcc-41b9-9af5-96ec9bce25d5',
+      sort: 165,
+      type: 'translationHeader',
+      label: '1.',
+    },
+    content: [
+      {
+        type: 'heading',
+        attrs: {
+          level: 2,
+          class: 'section-title',
+          start: 0,
+          end: 15,
+          uuid: 'c4229046-ec92-4d1e-8bd2-ac9e860d0b64',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'The Translation',
+            attrs: {
+              start: 0,
+              end: 15,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'b7a07809-d6e0-427b-bfc6-50ea2acd8155',
+      sort: 168,
+      type: 'translation',
+      label: '1.1',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 43,
+          uuid: 'b7a07809-d6e0-427b-bfc6-50ea2acd8155',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'Homage to all the buddhas and bodhisattvas!',
+            attrs: {
+              start: 0,
+              end: 43,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
+      sort: 170,
+      type: 'translation',
+      label: '1.2',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 262,
+          uuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
+          hasLeadingSpace: true,
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'Thus did I hear at one time. The Buddha was residing in ',
+            attrs: {
+              start: 0,
+              end: 56,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Śrāvastī',
+            attrs: {
+              start: 56,
+              end: 64,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '55532312-84c3-4ab9-9220-58b7598c8440',
+                  uuid: '48b09ede-46cf-419a-9ec8-64c4a610b456',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', in ',
+            attrs: {
+              start: 64,
+              end: 69,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Jeta’s Grove, Anāthapiṇḍada’s park',
+            attrs: {
+              start: 69,
+              end: 103,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '86c17e77-82a6-4b77-bd21-3f012d36f1f5',
+                  uuid: '4ebf55f0-fddd-45e6-a9af-09997c6f96f5',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', together with a great community of monks, consisting of 1,250 monks, and a great assembly of bodhisattvas. At that time, the Blessed One addressed the monks:',
+            attrs: {
+              start: 103,
+              end: 262,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
+      sort: 176,
+      type: 'translation',
+      label: '1.3',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 147,
+          uuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '73776d26-6858-413b-9d62-5ffe18a59e4c',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon four factors even at the cost of their lives. What are these four?',
+            attrs: {
+              start: 60,
+              end: 147,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '1350a8f8-cb5f-48d6-8d24-7152124b2ed9',
+      sort: 181,
+      type: 'translation',
+      label: '1.4',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 138,
+          uuid: '1350a8f8-cb5f-48d6-8d24-7152124b2ed9',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '93fb08c3-dabb-45e3-b9d6-05d40fb8df92',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon the ',
+            attrs: {
+              start: 60,
+              end: 85,
+            },
+          },
+          {
+            type: 'text',
+            text: 'thought of awakening',
+            attrs: {
+              start: 85,
+              end: 105,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '71c3e498-a282-46c2-a1b2-09bff483deac',
+                  uuid: '7cb61bc2-cf3c-4b28-a026-56062c3febce',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' even at the cost of their lives.',
+            attrs: {
+              start: 105,
+              end: 138,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'f1ed1290-9632-4bcf-8e9d-e6bf561e32a8',
+      sort: 187,
+      type: 'translation',
+      label: '1.5',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 134,
+          uuid: 'f1ed1290-9632-4bcf-8e9d-e6bf561e32a8',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '1e14fa7b-adde-4991-8b26-3f4ff17ac243',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon the ',
+            attrs: {
+              start: 60,
+              end: 85,
+            },
+          },
+          {
+            type: 'text',
+            text: 'spiritual friend',
+            attrs: {
+              start: 85,
+              end: 101,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+                  uuid: 'b720b5d4-3213-4638-b192-eb8e8dca8299',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' even at the cost of their lives.',
+            attrs: {
+              start: 101,
+              end: 134,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+      sort: 193,
+      type: 'translation',
+      label: '1.6',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 136,
+          uuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '9be0ece5-da55-4d6d-934f-26149e9241ac',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon ',
+            attrs: {
+              start: 60,
+              end: 81,
+            },
+          },
+          {
+            type: 'text',
+            text: 'tolerance',
+            attrs: {
+              start: 81,
+              end: 90,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+                  uuid: '247d0cd6-8f48-4e3d-8c70-ab5ddf7f1382',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' and ',
+            attrs: {
+              start: 90,
+              end: 95,
+            },
+          },
+          {
+            type: 'text',
+            text: 'lenience',
+            attrs: {
+              start: 95,
+              end: 103,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+                  uuid: 'bc10971b-913a-4a6b-b0cb-888310563c90',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' even at the cost of their lives.',
+            attrs: {
+              start: 103,
+              end: 136,
+            },
+          },
+          {
+            type: 'endNoteLink',
+            attrs: {
+              start: 136,
+              end: 136,
+              endNote: '5433d5e2-c2f2-4a05-bc48-60dcb1109fbf',
+              uuid: 'de90ce7e-9b47-4324-ae1c-b803ee1cd28e',
+            },
+            marks: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
+      sort: 202,
+      type: 'translation',
+      label: '1.7',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 140,
+          uuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: '85247b59-0ae2-4dc2-8f1d-fc7d43d18e04',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon ',
+            attrs: {
+              start: 60,
+              end: 81,
+            },
+          },
+          {
+            type: 'text',
+            text: 'dwelling in the wilderness',
+            attrs: {
+              start: 81,
+              end: 107,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: '54ba640b-1d20-454d-bff4-14becefbc904',
+                  uuid: '9f5020c2-2a3f-4faa-8d83-e953dfb0b255',
+                },
+              },
+            ],
+          },
+          {
+            type: 'endNoteLink',
+            attrs: {
+              start: 107,
+              end: 107,
+              endNote: 'fb6c0152-67eb-4ef9-91bc-8fb6ea64e6f1',
+              uuid: 'd5f88fe6-79d7-45ed-bf99-2cbfca3bc9f3',
+            },
+            marks: [],
+          },
+          {
+            type: 'text',
+            text: ' even at the cost of their lives.',
+            attrs: {
+              start: 107,
+              end: 140,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '7dea2dba-3580-4d45-8bb3-f9cea52a1991',
+      sort: 209,
+      type: 'translation',
+      label: '1.8',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 133,
+          uuid: '7dea2dba-3580-4d45-8bb3-f9cea52a1991',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '“Monks, for as long as they live, bodhisattvas, ',
+            attrs: {
+              start: 0,
+              end: 48,
+            },
+          },
+          {
+            type: 'text',
+            text: 'great beings',
+            attrs: {
+              start: 48,
+              end: 60,
+            },
+            marks: [
+              {
+                type: 'glossaryInstance',
+                attrs: {
+                  authority: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+                  uuid: 'f78b3d56-2441-426f-ae87-8285bb46c82a',
+                },
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ', should not abandon these four factors even at the cost of their lives.”',
+            attrs: {
+              start: 60,
+              end: 133,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'd9096952-6a7d-4f87-93cf-a8c99a4c1ef3',
+      sort: 213,
+      type: 'translation',
+      label: '1.9',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 120,
+          uuid: 'd9096952-6a7d-4f87-93cf-a8c99a4c1ef3',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'The Blessed One spoke these words, and once the Sugata had spoken in this way, he, the Teacher, also said the following:',
+            attrs: {
+              start: 0,
+              end: 120,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      sort: 215,
+      type: 'translation',
+      label: '1.10',
+    },
+    content: [
+      {
+        type: 'lineGroup',
+        attrs: {
+          start: 0,
+          end: 201,
+          uuid: '7d2b05e7-c63f-40ea-8e6b-3ccefb83c603',
+        },
+        content: [
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: '“Let the wise conceive the thought of perfect awakening, ',
+                attrs: {
+                  start: 0,
+                  end: 57,
+                },
+              },
+            ],
+            attrs: {
+              start: 0,
+              end: 57,
+              uuid: '181a3584-20b8-4d6e-a0e5-c0ea733dbae6',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'And not cast aside the thought of omniscience;',
+                attrs: {
+                  start: 57,
+                  end: 102,
+                },
+              },
+              {
+                type: 'endNoteLink',
+                attrs: {
+                  start: 102,
+                  end: 102,
+                  endNote: 'fb352874-9ae4-4658-97ea-ec944f2c6dfc',
+                  uuid: 'bc5071aa-2099-4323-a353-6318e01de343',
+                },
+                marks: [],
+              },
+              {
+                type: 'text',
+                text: ' ',
+                attrs: {
+                  start: 102,
+                  end: 104,
+                },
+              },
+            ],
+            attrs: {
+              start: 57,
+              end: 104,
+              uuid: 'ca6b3880-1040-4920-b1ce-e80aa7e7bcd7',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'Let them maintain the strength of ',
+                attrs: {
+                  start: 104,
+                  end: 138,
+                },
+              },
+              {
+                type: 'text',
+                text: 'tolerance',
+                attrs: {
+                  start: 138,
+                  end: 147,
+                },
+                marks: [
+                  {
+                    type: 'glossaryInstance',
+                    attrs: {
+                      authority: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+                      uuid: '79f4938e-df3c-40c8-a618-fa188a124517',
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                text: ' and ',
+                attrs: {
+                  start: 147,
+                  end: 152,
+                },
+              },
+              {
+                type: 'text',
+                text: 'lenience',
+                attrs: {
+                  start: 152,
+                  end: 160,
+                },
+                marks: [
+                  {
+                    type: 'glossaryInstance',
+                    attrs: {
+                      authority: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+                      uuid: 'dd65abe5-d658-40d9-820d-d9c427e40f5e',
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                text: ', ',
+                attrs: {
+                  start: 160,
+                  end: 162,
+                },
+              },
+            ],
+            attrs: {
+              start: 104,
+              end: 162,
+              uuid: '196aa179-8cea-4525-8a41-19eb0781312f',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'And never forsake the ',
+                attrs: {
+                  start: 162,
+                  end: 184,
+                },
+              },
+              {
+                type: 'text',
+                text: 'spiritual friend',
+                attrs: {
+                  start: 184,
+                  end: 200,
+                },
+                marks: [
+                  {
+                    type: 'glossaryInstance',
+                    attrs: {
+                      authority: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+                      uuid: '83d1bcb5-15ed-492b-a401-d59e7a0c0ad3',
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                text: '.',
+                attrs: {
+                  start: 200,
+                  end: 201,
+                },
+              },
+            ],
+            attrs: {
+              start: 162,
+              end: 201,
+              uuid: 'cf054120-9398-4855-8c62-3677041041d4',
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+      sort: 230,
+      type: 'translation',
+      label: '1.11',
+    },
+    content: [
+      {
+        type: 'lineGroup',
+        attrs: {
+          start: 0,
+          end: 184,
+          uuid: 'e9eec4aa-3a9f-435b-9111-4aa27a3deb11',
+        },
+        content: [
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: '“If the wise, like the king of beasts, abandon fear, ',
+                attrs: {
+                  start: 0,
+                  end: 53,
+                },
+              },
+            ],
+            attrs: {
+              start: 0,
+              end: 52,
+              uuid: '9b820bc7-def0-484e-bdd8-088d19e37b48',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'Always remain ',
+                attrs: {
+                  start: 53,
+                  end: 67,
+                },
+              },
+              {
+                type: 'text',
+                text: 'dwelling in the wilderness',
+                attrs: {
+                  start: 67,
+                  end: 93,
+                },
+                marks: [
+                  {
+                    type: 'glossaryInstance',
+                    attrs: {
+                      authority: '54ba640b-1d20-454d-bff4-14becefbc904',
+                      uuid: 'cc951a6e-3334-4f23-8727-8d1b9807e186',
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                text: ', ',
+                attrs: {
+                  start: 93,
+                  end: 95,
+                },
+              },
+            ],
+            attrs: {
+              start: 53,
+              end: 95,
+              uuid: 'd65f874d-9d51-42f3-aa8d-60a200f566fd',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'And constantly maintain these factors, ',
+                attrs: {
+                  start: 95,
+                  end: 134,
+                },
+              },
+            ],
+            attrs: {
+              start: 95,
+              end: 134,
+              uuid: '7defb520-391b-488f-8821-ab35d7fac408',
+            },
+          },
+          {
+            type: 'line',
+            content: [
+              {
+                type: 'text',
+                text: 'They will conquer the māras and attain awakening.”',
+                attrs: {
+                  start: 134,
+                  end: 184,
+                },
+              },
+            ],
+            attrs: {
+              start: 134,
+              end: 184,
+              uuid: 'e003cc18-27e1-4be5-b52d-ed4230eaf692',
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: '3c0a9671-d031-40fa-ae5b-def8887c4ded',
+      sort: 241,
+      type: 'translation',
+      label: '1.12',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 149,
+          uuid: '3c0a9671-d031-40fa-ae5b-def8887c4ded',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'When the Blessed One had said this, the monks and bodhisattvas, together with the entire assembly, rejoiced and praised the words of the Blessed One.',
+            attrs: {
+              start: 0,
+              end: 149,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'passage',
+    attrs: {
+      uuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
+      sort: 243,
+      type: 'translation',
+      label: '1.13',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        attrs: {
+          start: 0,
+          end: 62,
+          uuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
+          hasTrailer: true,
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'This concludes ',
+            attrs: {
+              start: 0,
+              end: 15,
+            },
+          },
+          {
+            type: 'text',
+            text: '“The Noble Mahāyāna Sūtra on the Four Factors.”',
+            attrs: {
+              start: 15,
+              end: 62,
+            },
+            marks: [
+              {
+                type: 'italic',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/libs/lib-editing/src/fixtures/toh251/passages.ts
+++ b/libs/lib-editing/src/fixtures/toh251/passages.ts
@@ -15,7 +15,7 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 15, // NOTE: exclusive
+        end: 15,
         type: 'heading',
         uuid: 'c4229046-ec92-4d1e-8bd2-ac9e860d0b64',
         start: 0,
@@ -40,7 +40,7 @@ export const content: PassageDTO[] = [
     parent: 'UT22084-066-009-section-1',
     content: 'Homage to all the buddhas and bodhisattvas!',
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
-    annotations: [],
+    annotations: null,
   },
   {
     sort: 170,
@@ -54,7 +54,7 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 0, // NOTE: inclusive (length 0)
+        end: 0,
         type: 'leading-space',
         uuid: 'c0e02497-7d8e-4150-9178-f13a2ad77d91',
         start: 0,
@@ -62,26 +62,26 @@ export const content: PassageDTO[] = [
         passageUuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
       },
       {
-        end: 63, // NOTE: inclusive
+        end: 64,
         type: 'glossary-instance',
         uuid: '48b09ede-46cf-419a-9ec8-64c4a610b456',
         start: 56,
         content: [
           {
-            uuid: '55532312-84c3-4ab9-9220-58b7598c8440',
+            uuid: 'f2a07704-3c71-4f05-8e6a-5d326406fae2',
             glossary_xmlId: 'UT22084-066-009-72',
           },
         ],
         passageUuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
       },
       {
-        end: 102, // NOTE: inclusive
+        end: 103,
         type: 'glossary-instance',
         uuid: '4ebf55f0-fddd-45e6-a9af-09997c6f96f5',
         start: 69,
         content: [
           {
-            uuid: '86c17e77-82a6-4b77-bd21-3f012d36f1f5',
+            uuid: '7fc58f66-5fbb-4973-8744-f6589f8aae97',
             glossary_xmlId: 'UT22084-066-009-284',
           },
         ],
@@ -101,7 +101,7 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 147, // NOTE: inclusive
+        end: 147,
         type: 'quoted',
         uuid: '217f133b-e296-4782-bd37-9bb2de9798cd',
         start: 0,
@@ -116,7 +116,7 @@ export const content: PassageDTO[] = [
         passageUuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
       },
       {
-        end: 125, // NOTE: inclusive
+        end: 126,
         type: 'quoted',
         uuid: '096b6b31-d7e7-45aa-89a5-eeddaa75944e',
         start: 8,
@@ -131,13 +131,13 @@ export const content: PassageDTO[] = [
         passageUuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
       },
       {
-        end: 59, // NOTE: inclusive
+        end: 60,
         type: 'glossary-instance',
         uuid: '73776d26-6858-413b-9d62-5ffe18a59e4c',
         start: 48,
         content: [
           {
-            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            uuid: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
             glossary_xmlId: 'UT22084-066-009-69',
           },
         ],
@@ -157,26 +157,26 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 59, // NOTE: inclusive
+        end: 60,
         type: 'glossary-instance',
         uuid: '93fb08c3-dabb-45e3-b9d6-05d40fb8df92',
         start: 48,
         content: [
           {
-            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            uuid: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
             glossary_xmlId: 'UT22084-066-009-69',
           },
         ],
         passageUuid: '1350a8f8-cb5f-48d6-8d24-7152124b2ed9',
       },
       {
-        end: 104, // NOTE: inclusive
+        end: 105,
         type: 'glossary-instance',
         uuid: '7cb61bc2-cf3c-4b28-a026-56062c3febce',
         start: 85,
         content: [
           {
-            uuid: '71c3e498-a282-46c2-a1b2-09bff483deac',
+            uuid: '445f17ca-164b-4c68-82a3-f9f3ee3595b6',
             glossary_xmlId: 'UT22084-066-009-64',
           },
         ],
@@ -196,26 +196,26 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 59, // NOTE: inclusive
+        end: 60,
         type: 'glossary-instance',
         uuid: '1e14fa7b-adde-4991-8b26-3f4ff17ac243',
         start: 48,
         content: [
           {
-            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            uuid: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
             glossary_xmlId: 'UT22084-066-009-69',
           },
         ],
         passageUuid: 'f1ed1290-9632-4bcf-8e9d-e6bf561e32a8',
       },
       {
-        end: 100, // NOTE: inclusive
+        end: 101,
         type: 'glossary-instance',
         uuid: 'b720b5d4-3213-4638-b192-eb8e8dca8299',
         start: 85,
         content: [
           {
-            uuid: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+            uuid: '4049f21f-fa6c-4180-80f5-0750c14162da',
             glossary_xmlId: 'UT22084-066-009-68',
           },
         ],
@@ -235,46 +235,46 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 59, // NOTE: inclusive
+        end: 60,
         type: 'glossary-instance',
         uuid: '9be0ece5-da55-4d6d-934f-26149e9241ac',
         start: 48,
         content: [
           {
-            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            uuid: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
             glossary_xmlId: 'UT22084-066-009-69',
           },
         ],
         passageUuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
       },
       {
-        end: 89, // NOTE: inclusive
+        end: 90,
         type: 'glossary-instance',
         uuid: '247d0cd6-8f48-4e3d-8c70-ab5ddf7f1382',
         start: 81,
         content: [
           {
-            uuid: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+            uuid: '3268038f-cca4-471a-94b3-13c62c85b7ca',
             glossary_xmlId: 'UT22084-066-009-66',
           },
         ],
         passageUuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
       },
       {
-        end: 102, // NOTE: inclusive
+        end: 103,
         type: 'glossary-instance',
         uuid: 'bc10971b-913a-4a6b-b0cb-888310563c90',
         start: 95,
         content: [
           {
-            uuid: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+            uuid: '4f7a6a56-6c00-43a0-b457-f3e741364a05',
             glossary_xmlId: 'UT22084-066-009-65',
           },
         ],
         passageUuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
       },
       {
-        end: 136, // NOTE: inclusive (length 0)
+        end: 136,
         type: 'end-note-link',
         uuid: 'de90ce7e-9b47-4324-ae1c-b803ee1cd28e',
         start: 136,
@@ -300,26 +300,26 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 59,
+        end: 60,
         type: 'glossary-instance',
         uuid: '85247b59-0ae2-4dc2-8f1d-fc7d43d18e04',
         start: 48,
         content: [
           {
-            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            uuid: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
             glossary_xmlId: 'UT22084-066-009-69',
           },
         ],
         passageUuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
       },
       {
-        end: 106,
+        end: 107,
         type: 'glossary-instance',
         uuid: '9f5020c2-2a3f-4faa-8d83-e953dfb0b255',
         start: 81,
         content: [
           {
-            uuid: '54ba640b-1d20-454d-bff4-14becefbc904',
+            uuid: 'c2d14c50-fccd-4438-bebc-6dfa4f77194e',
             glossary_xmlId: 'UT22084-066-009-67',
           },
         ],
@@ -352,13 +352,13 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 59,
+        end: 60,
         type: 'glossary-instance',
         uuid: 'f78b3d56-2441-426f-ae87-8285bb46c82a',
         start: 48,
         content: [
           {
-            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            uuid: '1e6586e7-e5dd-49ef-8d6c-b97b66c6aa34',
             glossary_xmlId: 'UT22084-066-009-69',
           },
         ],
@@ -390,7 +390,7 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 201, // NOTE: exclusive (length is 201)
+        end: 201,
         type: 'line-group',
         uuid: '7d2b05e7-c63f-40ea-8e6b-3ccefb83c603',
         start: 0,
@@ -398,7 +398,7 @@ export const content: PassageDTO[] = [
         passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
       },
       {
-        end: 56, // NOTE: inclusive (excludes trailing space)
+        end: 57,
         type: 'line',
         uuid: '181a3584-20b8-4d6e-a0e5-c0ea733dbae6',
         start: 0,
@@ -406,7 +406,7 @@ export const content: PassageDTO[] = [
         passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
       },
       {
-        end: 103, // NOTE: inclusive (excludes trailing space)
+        end: 104,
         type: 'line',
         uuid: 'ca6b3880-1040-4920-b1ce-e80aa7e7bcd7',
         start: 57,
@@ -427,7 +427,7 @@ export const content: PassageDTO[] = [
         passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
       },
       {
-        end: 161, // NOTE: inclusive (excludes trailing space)
+        end: 162,
         type: 'line',
         uuid: '196aa179-8cea-4525-8a41-19eb0781312f',
         start: 104,
@@ -435,33 +435,33 @@ export const content: PassageDTO[] = [
         passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
       },
       {
-        end: 146,
+        end: 147,
         type: 'glossary-instance',
         uuid: '79f4938e-df3c-40c8-a618-fa188a124517',
         start: 138,
         content: [
           {
-            uuid: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+            uuid: '3268038f-cca4-471a-94b3-13c62c85b7ca',
             glossary_xmlId: 'UT22084-066-009-66',
           },
         ],
         passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
       },
       {
-        end: 159,
+        end: 160,
         type: 'glossary-instance',
         uuid: 'dd65abe5-d658-40d9-820d-d9c427e40f5e',
         start: 152,
         content: [
           {
-            uuid: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+            uuid: '4f7a6a56-6c00-43a0-b457-f3e741364a05',
             glossary_xmlId: 'UT22084-066-009-65',
           },
         ],
         passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
       },
       {
-        end: 201, // NOTE: exclusive (no trailing space)
+        end: 201,
         type: 'line',
         uuid: 'cf054120-9398-4855-8c62-3677041041d4',
         start: 162,
@@ -469,13 +469,13 @@ export const content: PassageDTO[] = [
         passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
       },
       {
-        end: 199,
+        end: 200,
         type: 'glossary-instance',
         uuid: '83d1bcb5-15ed-492b-a401-d59e7a0c0ad3',
         start: 184,
         content: [
           {
-            uuid: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+            uuid: '4049f21f-fa6c-4180-80f5-0750c14162da',
             glossary_xmlId: 'UT22084-066-009-68',
           },
         ],
@@ -495,7 +495,7 @@ export const content: PassageDTO[] = [
     workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
     annotations: [
       {
-        end: 184, // NOTE: exclusive (length is 184)
+        end: 184,
         type: 'line-group',
         uuid: 'e9eec4aa-3a9f-435b-9111-4aa27a3deb11',
         start: 0,
@@ -503,7 +503,7 @@ export const content: PassageDTO[] = [
         passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
       },
       {
-        end: 52, // NOTE: inclusive (excludes trailing space)
+        end: 53,
         type: 'line',
         uuid: '9b820bc7-def0-484e-bdd8-088d19e37b48',
         start: 0,
@@ -511,7 +511,7 @@ export const content: PassageDTO[] = [
         passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
       },
       {
-        end: 94, // NOTE: inclusive (excludes trailing space)
+        end: 95,
         type: 'line',
         uuid: 'd65f874d-9d51-42f3-aa8d-60a200f566fd',
         start: 53,
@@ -519,20 +519,20 @@ export const content: PassageDTO[] = [
         passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
       },
       {
-        end: 92,
+        end: 93,
         type: 'glossary-instance',
         uuid: 'cc951a6e-3334-4f23-8727-8d1b9807e186',
         start: 67,
         content: [
           {
-            uuid: '54ba640b-1d20-454d-bff4-14becefbc904',
+            uuid: 'c2d14c50-fccd-4438-bebc-6dfa4f77194e',
             glossary_xmlId: 'UT22084-066-009-67',
           },
         ],
         passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
       },
       {
-        end: 133, // NOTE: inclusive (excludes trailing space)
+        end: 134,
         type: 'line',
         uuid: '7defb520-391b-488f-8821-ab35d7fac408',
         start: 95,
@@ -540,7 +540,7 @@ export const content: PassageDTO[] = [
         passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
       },
       {
-        end: 184, // NOTE: exclusive (no trailing space)
+        end: 184,
         type: 'line',
         uuid: 'e003cc18-27e1-4be5-b52d-ed4230eaf692',
         start: 134,
@@ -580,7 +580,7 @@ export const content: PassageDTO[] = [
         passageUuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
       },
       {
-        end: 62, // NOTE: exclusive
+        end: 62,
         type: 'inline-title',
         uuid: '895f43ec-7189-4273-b067-d557523723aa',
         start: 15,

--- a/libs/lib-editing/src/fixtures/toh251/passages.ts
+++ b/libs/lib-editing/src/fixtures/toh251/passages.ts
@@ -1,0 +1,596 @@
+import { PassageDTO } from '@data-access';
+import { EditorType } from '../types';
+
+export const type: EditorType = 'translation';
+
+export const content: PassageDTO[] = [
+  {
+    sort: 165,
+    type: 'translationHeader',
+    uuid: '0a812d07-8fcc-41b9-9af5-96ec9bce25d5',
+    label: '1.',
+    xmlId: 'UT22084-066-009-section-1',
+    parent: 'UT22084-066-009-section-1',
+    content: 'The Translation',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 15, // NOTE: exclusive
+        type: 'heading',
+        uuid: 'c4229046-ec92-4d1e-8bd2-ac9e860d0b64',
+        start: 0,
+        content: [
+          {
+            'heading-level': 'h2',
+          },
+          {
+            'heading-type': 'section-title',
+          },
+        ],
+        passageUuid: '0a812d07-8fcc-41b9-9af5-96ec9bce25d5',
+      },
+    ],
+  },
+  {
+    sort: 168,
+    type: 'translation',
+    uuid: 'b7a07809-d6e0-427b-bfc6-50ea2acd8155',
+    label: '1.1',
+    xmlId: 'UT22084-066-009-26',
+    parent: 'UT22084-066-009-section-1',
+    content: 'Homage to all the buddhas and bodhisattvas!',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [],
+  },
+  {
+    sort: 170,
+    type: 'translation',
+    uuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
+    label: '1.2',
+    xmlId: 'UT22084-066-009-226',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      'Thus did I hear at one time. The Buddha was residing in Śrāvastī, in Jeta’s Grove, Anāthapiṇḍada’s park, together with a great community of monks, consisting of 1,250 monks, and a great assembly of bodhisattvas. At that time, the Blessed One addressed the monks:',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 0, // NOTE: inclusive (length 0)
+        type: 'leading-space',
+        uuid: 'c0e02497-7d8e-4150-9178-f13a2ad77d91',
+        start: 0,
+        content: [],
+        passageUuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
+      },
+      {
+        end: 63, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: '48b09ede-46cf-419a-9ec8-64c4a610b456',
+        start: 56,
+        content: [
+          {
+            uuid: '55532312-84c3-4ab9-9220-58b7598c8440',
+            glossary_xmlId: 'UT22084-066-009-72',
+          },
+        ],
+        passageUuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
+      },
+      {
+        end: 102, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: '4ebf55f0-fddd-45e6-a9af-09997c6f96f5',
+        start: 69,
+        content: [
+          {
+            uuid: '86c17e77-82a6-4b77-bd21-3f012d36f1f5',
+            glossary_xmlId: 'UT22084-066-009-284',
+          },
+        ],
+        passageUuid: '2dda83c5-f367-4b13-96b0-14835d5bb2dd',
+      },
+    ],
+  },
+  {
+    sort: 176,
+    type: 'translation',
+    uuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
+    label: '1.3',
+    xmlId: 'UT22084-066-009-30',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      '“Monks, for as long as they live, bodhisattvas, great beings, should not abandon four factors even at the cost of their lives. What are these four?',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 147, // NOTE: inclusive
+        type: 'quoted',
+        uuid: '217f133b-e296-4782-bd37-9bb2de9798cd',
+        start: 0,
+        content: [
+          {
+            quote_xmlId: 'UT23703-113-010-249',
+          },
+          {
+            'link-text-lookup': 'quotingTextShortcode',
+          },
+        ],
+        passageUuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
+      },
+      {
+        end: 125, // NOTE: inclusive
+        type: 'quoted',
+        uuid: '096b6b31-d7e7-45aa-89a5-eeddaa75944e',
+        start: 8,
+        content: [
+          {
+            quote_xmlId: 'UT23703-113-010-249',
+          },
+          {
+            'link-text-lookup': 'quotingTextShortcode',
+          },
+        ],
+        passageUuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
+      },
+      {
+        end: 59, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: '73776d26-6858-413b-9d62-5ffe18a59e4c',
+        start: 48,
+        content: [
+          {
+            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            glossary_xmlId: 'UT22084-066-009-69',
+          },
+        ],
+        passageUuid: 'df6f18e0-7db5-4b06-8a8a-fb3a31144f85',
+      },
+    ],
+  },
+  {
+    sort: 181,
+    type: 'translation',
+    uuid: '1350a8f8-cb5f-48d6-8d24-7152124b2ed9',
+    label: '1.4',
+    xmlId: 'UT22084-066-009-31',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      '“Monks, for as long as they live, bodhisattvas, great beings, should not abandon the thought of awakening even at the cost of their lives.',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 59, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: '93fb08c3-dabb-45e3-b9d6-05d40fb8df92',
+        start: 48,
+        content: [
+          {
+            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            glossary_xmlId: 'UT22084-066-009-69',
+          },
+        ],
+        passageUuid: '1350a8f8-cb5f-48d6-8d24-7152124b2ed9',
+      },
+      {
+        end: 104, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: '7cb61bc2-cf3c-4b28-a026-56062c3febce',
+        start: 85,
+        content: [
+          {
+            uuid: '71c3e498-a282-46c2-a1b2-09bff483deac',
+            glossary_xmlId: 'UT22084-066-009-64',
+          },
+        ],
+        passageUuid: '1350a8f8-cb5f-48d6-8d24-7152124b2ed9',
+      },
+    ],
+  },
+  {
+    sort: 187,
+    type: 'translation',
+    uuid: 'f1ed1290-9632-4bcf-8e9d-e6bf561e32a8',
+    label: '1.5',
+    xmlId: 'UT22084-066-009-32',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      '“Monks, for as long as they live, bodhisattvas, great beings, should not abandon the spiritual friend even at the cost of their lives.',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 59, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: '1e14fa7b-adde-4991-8b26-3f4ff17ac243',
+        start: 48,
+        content: [
+          {
+            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            glossary_xmlId: 'UT22084-066-009-69',
+          },
+        ],
+        passageUuid: 'f1ed1290-9632-4bcf-8e9d-e6bf561e32a8',
+      },
+      {
+        end: 100, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: 'b720b5d4-3213-4638-b192-eb8e8dca8299',
+        start: 85,
+        content: [
+          {
+            uuid: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+            glossary_xmlId: 'UT22084-066-009-68',
+          },
+        ],
+        passageUuid: 'f1ed1290-9632-4bcf-8e9d-e6bf561e32a8',
+      },
+    ],
+  },
+  {
+    sort: 193,
+    type: 'translation',
+    uuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+    label: '1.6',
+    xmlId: 'UT22084-066-009-33',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      '“Monks, for as long as they live, bodhisattvas, great beings, should not abandon tolerance and lenience even at the cost of their lives.',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 59, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: '9be0ece5-da55-4d6d-934f-26149e9241ac',
+        start: 48,
+        content: [
+          {
+            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            glossary_xmlId: 'UT22084-066-009-69',
+          },
+        ],
+        passageUuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+      },
+      {
+        end: 89, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: '247d0cd6-8f48-4e3d-8c70-ab5ddf7f1382',
+        start: 81,
+        content: [
+          {
+            uuid: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+            glossary_xmlId: 'UT22084-066-009-66',
+          },
+        ],
+        passageUuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+      },
+      {
+        end: 102, // NOTE: inclusive
+        type: 'glossary-instance',
+        uuid: 'bc10971b-913a-4a6b-b0cb-888310563c90',
+        start: 95,
+        content: [
+          {
+            uuid: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+            glossary_xmlId: 'UT22084-066-009-65',
+          },
+        ],
+        passageUuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+      },
+      {
+        end: 136, // NOTE: inclusive (length 0)
+        type: 'end-note-link',
+        uuid: 'de90ce7e-9b47-4324-ae1c-b803ee1cd28e',
+        start: 136,
+        content: [
+          {
+            uuid: '5433d5e2-c2f2-4a05-bc48-60dcb1109fbf',
+            endnote_xmlId: 'UT22084-066-009-34',
+          },
+        ],
+        passageUuid: '965340e9-4b95-4ab7-966d-059e25b094aa',
+      },
+    ],
+  },
+  {
+    sort: 202,
+    type: 'translation',
+    uuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
+    label: '1.7',
+    xmlId: 'UT22084-066-009-35',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      '“Monks, for as long as they live, bodhisattvas, great beings, should not abandon dwelling in the wilderness even at the cost of their lives.',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 59,
+        type: 'glossary-instance',
+        uuid: '85247b59-0ae2-4dc2-8f1d-fc7d43d18e04',
+        start: 48,
+        content: [
+          {
+            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            glossary_xmlId: 'UT22084-066-009-69',
+          },
+        ],
+        passageUuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
+      },
+      {
+        end: 106,
+        type: 'glossary-instance',
+        uuid: '9f5020c2-2a3f-4faa-8d83-e953dfb0b255',
+        start: 81,
+        content: [
+          {
+            uuid: '54ba640b-1d20-454d-bff4-14becefbc904',
+            glossary_xmlId: 'UT22084-066-009-67',
+          },
+        ],
+        passageUuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
+      },
+      {
+        end: 107,
+        type: 'end-note-link',
+        uuid: 'd5f88fe6-79d7-45ed-bf99-2cbfca3bc9f3',
+        start: 107,
+        content: [
+          {
+            uuid: 'fb6c0152-67eb-4ef9-91bc-8fb6ea64e6f1',
+            endnote_xmlId: 'UT22084-066-009-135',
+          },
+        ],
+        passageUuid: '06d427ec-46d0-4df1-9d48-08716f8710ec',
+      },
+    ],
+  },
+  {
+    sort: 209,
+    type: 'translation',
+    uuid: '7dea2dba-3580-4d45-8bb3-f9cea52a1991',
+    label: '1.8',
+    xmlId: 'UT22084-066-009-36',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      '“Monks, for as long as they live, bodhisattvas, great beings, should not abandon these four factors even at the cost of their lives.”',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 59,
+        type: 'glossary-instance',
+        uuid: 'f78b3d56-2441-426f-ae87-8285bb46c82a',
+        start: 48,
+        content: [
+          {
+            uuid: 'a6c40c30-43ed-4634-9b0a-1d707dbc463f',
+            glossary_xmlId: 'UT22084-066-009-69',
+          },
+        ],
+        passageUuid: '7dea2dba-3580-4d45-8bb3-f9cea52a1991',
+      },
+    ],
+  },
+  {
+    sort: 213,
+    type: 'translation',
+    uuid: 'd9096952-6a7d-4f87-93cf-a8c99a4c1ef3',
+    label: '1.9',
+    xmlId: 'UT22084-066-009-37',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      'The Blessed One spoke these words, and once the Sugata had spoken in this way, he, the Teacher, also said the following:',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: null,
+  },
+  {
+    sort: 215,
+    type: 'translation',
+    uuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+    label: '1.10',
+    xmlId: 'UT22084-066-009-38',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      '“Let the wise conceive the thought of perfect awakening, And not cast aside the thought of omniscience; Let them maintain the strength of tolerance and lenience, And never forsake the spiritual friend.',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 201, // NOTE: exclusive (length is 201)
+        type: 'line-group',
+        uuid: '7d2b05e7-c63f-40ea-8e6b-3ccefb83c603',
+        start: 0,
+        content: [],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+      {
+        end: 56, // NOTE: inclusive (excludes trailing space)
+        type: 'line',
+        uuid: '181a3584-20b8-4d6e-a0e5-c0ea733dbae6',
+        start: 0,
+        content: [],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+      {
+        end: 103, // NOTE: inclusive (excludes trailing space)
+        type: 'line',
+        uuid: 'ca6b3880-1040-4920-b1ce-e80aa7e7bcd7',
+        start: 57,
+        content: [],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+      {
+        end: 102,
+        type: 'end-note-link',
+        uuid: 'bc5071aa-2099-4323-a353-6318e01de343',
+        start: 102,
+        content: [
+          {
+            uuid: 'fb352874-9ae4-4658-97ea-ec944f2c6dfc',
+            endnote_xmlId: 'UT22084-066-009-39',
+          },
+        ],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+      {
+        end: 161, // NOTE: inclusive (excludes trailing space)
+        type: 'line',
+        uuid: '196aa179-8cea-4525-8a41-19eb0781312f',
+        start: 104,
+        content: [],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+      {
+        end: 146,
+        type: 'glossary-instance',
+        uuid: '79f4938e-df3c-40c8-a618-fa188a124517',
+        start: 138,
+        content: [
+          {
+            uuid: '64a50fd8-0fd0-4a50-a5f8-c081ba5ef861',
+            glossary_xmlId: 'UT22084-066-009-66',
+          },
+        ],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+      {
+        end: 159,
+        type: 'glossary-instance',
+        uuid: 'dd65abe5-d658-40d9-820d-d9c427e40f5e',
+        start: 152,
+        content: [
+          {
+            uuid: 'c0488d9a-13cf-4890-bb99-957a44404c94',
+            glossary_xmlId: 'UT22084-066-009-65',
+          },
+        ],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+      {
+        end: 201, // NOTE: exclusive (no trailing space)
+        type: 'line',
+        uuid: 'cf054120-9398-4855-8c62-3677041041d4',
+        start: 162,
+        content: [],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+      {
+        end: 199,
+        type: 'glossary-instance',
+        uuid: '83d1bcb5-15ed-492b-a401-d59e7a0c0ad3',
+        start: 184,
+        content: [
+          {
+            uuid: '9861c4ef-4f1e-4332-bb65-01b36e4285a7',
+            glossary_xmlId: 'UT22084-066-009-68',
+          },
+        ],
+        passageUuid: '7ece3672-4152-4d60-a0d5-cc623a8cfa6f',
+      },
+    ],
+  },
+  {
+    sort: 230,
+    type: 'translation',
+    uuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+    label: '1.11',
+    xmlId: 'UT22084-066-009-40',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      '“If the wise, like the king of beasts, abandon fear, Always remain dwelling in the wilderness, And constantly maintain these factors, They will conquer the māras and attain awakening.”',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 184, // NOTE: exclusive (length is 184)
+        type: 'line-group',
+        uuid: 'e9eec4aa-3a9f-435b-9111-4aa27a3deb11',
+        start: 0,
+        content: [],
+        passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+      },
+      {
+        end: 52, // NOTE: inclusive (excludes trailing space)
+        type: 'line',
+        uuid: '9b820bc7-def0-484e-bdd8-088d19e37b48',
+        start: 0,
+        content: [],
+        passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+      },
+      {
+        end: 94, // NOTE: inclusive (excludes trailing space)
+        type: 'line',
+        uuid: 'd65f874d-9d51-42f3-aa8d-60a200f566fd',
+        start: 53,
+        content: [],
+        passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+      },
+      {
+        end: 92,
+        type: 'glossary-instance',
+        uuid: 'cc951a6e-3334-4f23-8727-8d1b9807e186',
+        start: 67,
+        content: [
+          {
+            uuid: '54ba640b-1d20-454d-bff4-14becefbc904',
+            glossary_xmlId: 'UT22084-066-009-67',
+          },
+        ],
+        passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+      },
+      {
+        end: 133, // NOTE: inclusive (excludes trailing space)
+        type: 'line',
+        uuid: '7defb520-391b-488f-8821-ab35d7fac408',
+        start: 95,
+        content: [],
+        passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+      },
+      {
+        end: 184, // NOTE: exclusive (no trailing space)
+        type: 'line',
+        uuid: 'e003cc18-27e1-4be5-b52d-ed4230eaf692',
+        start: 134,
+        content: [],
+        passageUuid: 'ee947d31-48e1-4b37-a901-b999b24962f3',
+      },
+    ],
+  },
+  {
+    sort: 241,
+    type: 'translation',
+    uuid: '3c0a9671-d031-40fa-ae5b-def8887c4ded',
+    label: '1.12',
+    xmlId: 'UT22084-066-009-41',
+    parent: 'UT22084-066-009-section-1',
+    content:
+      'When the Blessed One had said this, the monks and bodhisattvas, together with the entire assembly, rejoiced and praised the words of the Blessed One.',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: null,
+  },
+  {
+    sort: 243,
+    type: 'translation',
+    uuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
+    label: '1.13',
+    xmlId: 'UT22084-066-009-42',
+    parent: 'UT22084-066-009-section-1',
+    content: 'This concludes “The Noble Mahāyāna Sūtra on the Four Factors.”',
+    workUuid: 'ef63eb47-f3e4-4d27-8d60-59e8411627a2',
+    annotations: [
+      {
+        end: 62,
+        type: 'trailer',
+        uuid: '76612414-df30-4c73-89fa-139e794a4a4d',
+        start: 0,
+        content: [],
+        passageUuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
+      },
+      {
+        end: 62, // NOTE: exclusive
+        type: 'inline-title',
+        uuid: '895f43ec-7189-4273-b067-d557523723aa',
+        start: 15,
+        content: [
+          {
+            lang: 'en',
+          },
+        ],
+        passageUuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
+      },
+    ],
+  },
+];

--- a/libs/lib-editing/src/fixtures/types.ts
+++ b/libs/lib-editing/src/fixtures/types.ts
@@ -1,4 +1,4 @@
-export const SLUGS = ['basic'];
+export const SLUGS = ['basic', 'toh251'];
 export type Slug = (typeof SLUGS)[number];
 
 export const FORMATS = ['json', 'passages', 'html', 'text'] as const;

--- a/libs/lib-editing/src/lib/transformers/split-block.ts
+++ b/libs/lib-editing/src/lib/transformers/split-block.ts
@@ -36,7 +36,6 @@ export const splitBlock: Transformer = ({
     return;
   }
 
-  // Inclusive annotation bounds
   const annStart = annotation?.start ?? 0;
   const annEnd = annotation?.end ?? 0;
 

--- a/libs/lib-editing/src/lib/transformers/split-content.ts
+++ b/libs/lib-editing/src/lib/transformers/split-content.ts
@@ -25,7 +25,6 @@ export const splitContent: Transformer = ({
     return;
   }
 
-  // Inclusive annotation bounds
   const annStartAbs = annotation.start;
   const annEndAbs = annotation.end;
   const currentContent = parent.content || [];
@@ -61,7 +60,6 @@ export const splitContent: Transformer = ({
     newContent.push(newBlock);
   }
 
-  // Sort by inclusive start offset
   newContent.sort((a, b) => (a.attrs?.start ?? 0) - (b.attrs?.start ?? 0));
   parent.content = newContent;
 };

--- a/libs/lib-editing/src/lib/transformers/split-node.ts
+++ b/libs/lib-editing/src/lib/transformers/split-node.ts
@@ -19,10 +19,9 @@ export function splitNode(
 ): SplitBlock {
   const itemStart = item.attrs?.start ?? 0;
   const text = item.text ?? '';
-  // Inclusive end: the last character is at itemEnd - 1, so itemEnd should be itemStart + text.length - 1
   const itemEnd =
     typeof item.text === 'string'
-      ? itemStart + text.length - 1
+      ? itemStart + text.length
       : (item.attrs?.end ?? itemStart);
 
   // Non-text blocks: treat atomically
@@ -45,13 +44,9 @@ export function splitNode(
     return { prefix: [], middle: [], suffix: [item] };
   }
 
-  // Compute indices for slicing (inclusive)
-  // preLen: up to (rangeStart - itemStart)
-  // midLen: from (rangeStart - itemStart) to (rangeEnd - itemStart + 1)
-  // postLen: after (rangeEnd - itemStart + 1)
   const preLen = Math.max(rangeStart - itemStart, 0);
   const midLen = Math.max(
-    Math.min(itemEnd, rangeEnd) - Math.max(itemStart, rangeStart) + 1,
+    Math.min(itemEnd, rangeEnd) - Math.max(itemStart, rangeStart),
     0,
   );
   const postStartIdx = preLen + midLen;


### PR DESCRIPTION
### Summary

Adds test fixtures for Tohoku 251 and use them as a basis for evaluating discrepancies in parsing. For this first pass, annotations have been converted to use an exclusive `end` value. Among other things, this helps differentiate between annotations that legitimately have length 0.

### Notes

Many thousands of `passage_annotation` rows still need to be updated. These are ones where `start` equals `end` but shouldn't. Great care will be taken in updating those records.
