### PR TITLE
Faster Editor Loading

### DIFF
--- a/apps/web-main/src/components/editor/CollaborativeBuilder.tsx
+++ b/apps/web-main/src/components/editor/CollaborativeBuilder.tsx
@@ -40,16 +40,19 @@ export const CollaborativeBuilder = ({
     }
 
     const getContent = async () => {
+      if (!loading) {
+        return;
+      }
+
       const client = createBrowserClient();
       const body = await fetchContent({ client, uuid });
-
-      setLoading(false);
 
       if (!body) {
         return;
       }
 
       setBody(body);
+      setLoading(false);
     };
 
     setFragment(getFragment());

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/Passage.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/Passage/Passage.tsx
@@ -17,13 +17,11 @@ export const Passage = ({ node, editor, updateAttributes }: NodeViewProps) => {
       {editor.isEditable ? (
         <input
           className={cn(className, 'px-1 placeholder:text-slate-100')}
-          contentEditable={false}
           value={node.attrs.label || ''}
           onChange={updateLabel}
           onBlur={updateLabel}
           placeholder="x.x"
           type="text"
-          autoFocus
           spellCheck={false}
         />
       ) : (


### PR DESCRIPTION
### Summary

An inconsequential exception has been causing editor load times to suffer. While there's still room for improvement, this speeds things up by preventing the exception.
