### PR TITLE
End note hover card

### DIFF
--- a/apps/web-editor/src/components/EditorPage.tsx
+++ b/apps/web-editor/src/components/EditorPage.tsx
@@ -47,13 +47,36 @@ export const EditorPage = ({
     })();
   }, [slug, format]);
 
+  const fetchEndNote = async (uuid: string) => {
+    return [
+      {
+        type: 'passage',
+        attrs: { label: 'n.1', uuid },
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: `This is the content of endnote ${uuid}.`,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+  };
+
   if (!content) {
     return <H3 className="text-muted-foreground px-12 py-2">Loading...</H3>;
   }
 
   switch (editorType) {
     case 'translation':
-      return <TranslationEditor content={content} />;
+      return (
+        <TranslationEditor content={content} fetchEndNote={fetchEndNote} />
+      );
+
     default:
       return <BlockEditor content={content} />;
   }

--- a/apps/web-editor/src/components/SandoxHeader.tsx
+++ b/apps/web-editor/src/components/SandoxHeader.tsx
@@ -22,6 +22,7 @@ export const SandboxHeader = () => {
     .flat();
 
   const [selectedItem, setSelectedItem] = useState<string>();
+  const [didSelect, setDidSelect] = useState(false);
 
   const { slug, format, setFormat, setSlug } = useSandbox();
   const router = useRouter();
@@ -31,8 +32,12 @@ export const SandboxHeader = () => {
     const path = slug && format ? `/${slug}/${format}` : '/';
 
     setSelectedItem(dropdownItem);
-    router.push(path);
-  }, [slug, format, router]);
+
+    if (didSelect) {
+      setDidSelect(false);
+      router.push(path);
+    }
+  }, [slug, format, router, didSelect]);
 
   const onHandleSelect = useCallback(
     (item: string, checked: boolean) => {
@@ -45,6 +50,7 @@ export const SandboxHeader = () => {
       const [newSlug, newFormat] = item.split(' - ');
       setSlug(newSlug as Slug);
       setFormat(newFormat as Format);
+      setDidSelect(true);
     },
     [setFormat, setSlug],
   );

--- a/apps/web-main/src/components/editor/CollaborativeBuilder.tsx
+++ b/apps/web-main/src/components/editor/CollaborativeBuilder.tsx
@@ -22,6 +22,7 @@ export const CollaborativeBuilder = ({
     uuid: string;
   }) => Promise<Passage[]>;
 }) => {
+  const client = createBrowserClient();
   const [body, setBody] = useState<Passage[]>();
   const [fragment, setFragment] = useState<XmlFragment>();
   const [isObserving, setIsObserving] = useState(false);
@@ -32,6 +33,7 @@ export const CollaborativeBuilder = ({
     builder: currentBuilder,
     startObserving,
     getFragment,
+    fetchEndNote,
   } = useEditorState();
 
   useEffect(() => {
@@ -44,7 +46,6 @@ export const CollaborativeBuilder = ({
         return;
       }
 
-      const client = createBrowserClient();
       const body = await fetchContent({ client, uuid });
 
       if (!body) {
@@ -57,7 +58,15 @@ export const CollaborativeBuilder = ({
 
     setFragment(getFragment());
     getContent();
-  }, [uuid, loading, currentBuilder, builder, getFragment, fetchContent]);
+  }, [
+    uuid,
+    loading,
+    currentBuilder,
+    client,
+    builder,
+    getFragment,
+    fetchContent,
+  ]);
 
   if (!body && !loading) {
     return notFound();
@@ -67,6 +76,7 @@ export const CollaborativeBuilder = ({
     <TranslationBodyEditor
       body={body}
       fragment={getFragment()}
+      fetchEndNote={fetchEndNote}
       onCreate={() => {
         if (!isObserving) {
           setIsObserving(true);

--- a/apps/web-main/src/components/ui/TranslationBodyEditor.tsx
+++ b/apps/web-main/src/components/ui/TranslationBodyEditor.tsx
@@ -11,10 +11,14 @@ export const TranslationBodyEditor = ({
   body,
   fragment,
   onCreate,
+  fetchEndNote,
 }: {
   body: Passage[];
   fragment: XmlFragment;
   onCreate?: () => void;
+  fetchEndNote?: (
+    uuid: string,
+  ) => Promise<TranslationEditorContent | undefined>;
 }) => {
   const [content, setContent] = useState<TranslationEditorContent>([]);
 
@@ -28,6 +32,7 @@ export const TranslationBodyEditor = ({
       content={content}
       fragment={fragment}
       onCreate={onCreate}
+      fetchEndNote={fetchEndNote}
     />
   );
 };

--- a/libs/data-access/src/index.ts
+++ b/libs/data-access/src/index.ts
@@ -4,6 +4,7 @@ export * from './lib/client-browser';
 export * from './lib/client-server';
 export * from './lib/glossary';
 export * from './lib/library';
+export * from './lib/passage';
 export * from './lib/projects';
 export * from './lib/publications';
 export * from './lib/storage';

--- a/libs/data-access/src/lib/passage.ts
+++ b/libs/data-access/src/lib/passage.ts
@@ -1,0 +1,28 @@
+import {
+  DataClient,
+  PassageDTO,
+  annotationsFromDTO,
+  passageFromDTO,
+} from './types';
+
+export const getPassage = async ({
+  client,
+  uuid,
+}: {
+  client: DataClient;
+  uuid: string;
+}) => {
+  const { data } = await client
+    .rpc('get_passage_with_annotations', {
+      uuid_input: uuid,
+    })
+    .single();
+
+  if (!data) {
+    console.warn(`No passage found for uuid: ${uuid}`);
+    return undefined;
+  }
+
+  const dto = data as PassageDTO;
+  return passageFromDTO(dto, annotationsFromDTO(dto?.annotations || []));
+};

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -16,6 +16,7 @@ export * from './lib/Collapsible/Collapsible';
 export * from './lib/Dropdown/Dropdown';
 export * from './lib/Editor';
 export * from './lib/Header/Header';
+export * from './lib/HoverCard/HoverCard';
 export * from './lib/Input/Input';
 export * from './lib/Label/Label';
 export * from './lib/MainLogo/MainLogo';

--- a/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/TranslationEditor.tsx
@@ -24,13 +24,17 @@ export const TranslationEditor = ({
   fragment,
   isEditable = true,
   onCreate,
+  fetchEndNote,
 }: {
   content: TranslationEditorContent;
   fragment?: XmlFragment;
   isEditable?: boolean;
   onCreate?: () => void;
+  fetchEndNote?: (
+    uuid: string,
+  ) => Promise<TranslationEditorContent | undefined>;
 }) => {
-  const { extensions } = useTranslationExtensions({ fragment });
+  const { extensions } = useTranslationExtensions({ fragment, fetchEndNote });
   const { editor } = useBlockEditor({
     extensions,
     content,

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteLink.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteLink.tsx
@@ -1,10 +1,54 @@
 import { cn } from '@lib-utils';
 import { NodeViewProps, NodeViewWrapper } from '@tiptap/react';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '../../../../HoverCard/HoverCard';
 import { LINK_STYLE } from '../../../../Typography/Typography';
 import { useEffect, useState } from 'react';
+import TranslationEditor, {
+  TranslationEditorContent,
+} from '../../TranslationEditor';
 
-export const EndNoteLink = ({ node, getPos, editor }: NodeViewProps) => {
+export const EndNoteCard = ({
+  uuid,
+  fetch,
+}: {
+  uuid: string;
+  fetch?: (uuid: string) => Promise<TranslationEditorContent | undefined>;
+}) => {
+  const [content, setContent] = useState<TranslationEditorContent>();
+
+  useEffect(() => {
+    if (!uuid || content) {
+      return;
+    }
+
+    (async () => {
+      const res = await fetch?.(uuid);
+      setContent(res);
+    })();
+  }, [uuid, content, fetch]);
+
+  if (!content) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return <TranslationEditor content={content} isEditable={false} />;
+};
+
+export const EndNoteLink = ({
+  node,
+  getPos,
+  editor,
+  extension,
+}: NodeViewProps) => {
   const [label, setLabel] = useState(1);
+
+  const fetch = extension.options.fetch as (
+    uuid: string,
+  ) => Promise<TranslationEditorContent | undefined>;
 
   useEffect(() => {
     const pos = getPos();
@@ -28,12 +72,19 @@ export const EndNoteLink = ({ node, getPos, editor }: NodeViewProps) => {
 
   return (
     <NodeViewWrapper as="sup" contentEditable={false}>
-      <a
-        href={`#${node.attrs.endNote}`}
-        className={cn(LINK_STYLE, className, 'pl-0.5')}
-      >
-        {label}
-      </a>
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <a
+            href={`#${node.attrs.endNote}`}
+            className={cn(LINK_STYLE, className, 'pl-0.5')}
+          >
+            {label}
+          </a>
+        </HoverCardTrigger>
+        <HoverCardContent>
+          <EndNoteCard uuid={node.attrs.endNote} fetch={fetch} />
+        </HoverCardContent>
+      </HoverCard>
     </NodeViewWrapper>
   );
 };

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteLink.tsx
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteLink.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 import TranslationEditor, {
   TranslationEditorContent,
 } from '../../TranslationEditor';
+import { Skeleton } from '../../../../Skeleton/Skeleton';
 
 export const EndNoteCard = ({
   uuid,
@@ -32,10 +33,14 @@ export const EndNoteCard = ({
   }, [uuid, content, fetch]);
 
   if (!content) {
-    return <div className="p-4">Loading...</div>;
+    return <Skeleton className="p-2 h-20 w-full" />;
   }
 
-  return <TranslationEditor content={content} isEditable={false} />;
+  return (
+    <div className="p-2">
+      <TranslationEditor content={content} isEditable={false} />
+    </div>
+  );
 };
 
 export const EndNoteLink = ({
@@ -81,7 +86,7 @@ export const EndNoteLink = ({
             {label}
           </a>
         </HoverCardTrigger>
-        <HoverCardContent>
+        <HoverCardContent className="w-120 max-h-96 m-2 overflow-auto">
           <EndNoteCard uuid={node.attrs.endNote} fetch={fetch} />
         </HoverCardContent>
       </HoverCard>

--- a/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteLinkNode.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/extensions/EndNoteLink/EndNoteLinkNode.ts
@@ -1,9 +1,11 @@
 import { Node } from '@tiptap/core';
 import { ReactNodeViewRenderer } from '@tiptap/react';
 import { EndNoteLink } from './EndNoteLink';
+import { TranslationEditorContent } from '../../TranslationEditor';
 
 export interface EndNoteLinkOptions {
   HTMLAttributes: Record<string, unknown>;
+  fetch: (uuid: string) => Promise<TranslationEditorContent | undefined>;
 }
 
 declare module '@tiptap/core' {
@@ -36,6 +38,7 @@ export const EndNoteLinkNode = Node.create<EndNoteLinkOptions>({
   addOptions() {
     return {
       HTMLAttributes: {},
+      fetch: async () => undefined,
     };
   },
 

--- a/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
+++ b/libs/design-system/src/lib/Editor/TranslationEditor/hooks/useTranslationExtensions.ts
@@ -53,6 +53,7 @@ import {
   HasAbbreviationCell,
 } from '../../extensions/Abbreviation/Abbreviation';
 import { ParagraphIndent } from '../../extensions/ParagraphIndent';
+import { TranslationEditorContent } from '../TranslationEditor';
 
 const PassageSuggestion: CommandSuggestionItem = {
   title: 'Passage',
@@ -73,8 +74,12 @@ const PassageSuggestion: CommandSuggestionItem = {
 
 export const useTranslationExtensions = ({
   fragment,
+  fetchEndNote,
 }: {
   fragment?: XmlFragment;
+  fetchEndNote?: (
+    uuid: string,
+  ) => Promise<TranslationEditorContent | undefined>;
 }) => {
   const suggestions = [
     TextSuggestion,
@@ -93,7 +98,9 @@ export const useTranslationExtensions = ({
     AbbreviationCell,
     HasAbbreviationCell,
     AbbreviationCommand,
-    EndNoteLinkNode,
+    EndNoteLinkNode.configure({
+      fetch: fetchEndNote,
+    }),
     EndNoteNode,
     GlossaryInstanceMark,
     Heading,


### PR DESCRIPTION
### Summary

In the editor, display the contents of an end note when hovering over its link.

### Linear

- [DEV-318](https://linear.app/84000/issue/DEV-318/end-note-hover-card)

### Screenshots

<img width="692" height="237" alt="Screenshot 2025-09-10 at 11 30 23 AM" src="https://github.com/user-attachments/assets/4f39ade3-7d29-4e02-b810-0601a841b69c" />


### Notes

- The content within the card is itself an editor instance, suggesting some interesting possibilities in the future. For now, though, it is for display only. The ability to edit the reference will come in a near-future pass.
- Adding cards for other annotations will take a little more work. The version of TipTap editor that we use does not support custom views for marks, which most links are. An end note, conversely, is a block, which is easier to work with. For annotations like glossary instances, we will either need to convert them to blocks or update to the latest major version of TipTap. A new major version was released recently with support for custom view for marks, but it did not seem ready for production last time I checked.
