### PR TITLE
AI summary integration

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/publications/editor/[slug]/summarizer/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/editor/[slug]/summarizer/page.tsx
@@ -1,0 +1,5 @@
+import { AiSummarizerPage } from '@lib-editing';
+
+const Page = AiSummarizerPage;
+
+export default Page;

--- a/apps/web-main/src/app/(DashboardLayout)/publications/reader/[slug]/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/reader/[slug]/page.tsx
@@ -32,6 +32,7 @@ const page = async ({ params }: { params: Promise<{ slug: string }> }) => {
           const Component = passageComponentForType[type];
           return <Component key={uuid}>{content}</Component>;
         })}
+        <div className="h-[var(--header-height)]" />
       </div>
     </div>
   );

--- a/apps/web-main/src/app/(DashboardLayout)/publications/reader/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/reader/page.tsx
@@ -14,6 +14,7 @@ const page = async () => {
       <div className="w-full max-w-[1466px]">
         <H2 className="text-navy-500">{'The Reading Room'}</H2>
         <TranslationsTable works={works} />
+        <div className="h-[var(--header-height)]" />
       </div>
     </div>
   );

--- a/apps/web-main/src/app/(DashboardLayout)/research-library/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/research-library/page.tsx
@@ -7,7 +7,11 @@ const Page = () => {
   }
 
   return (
-    <iframe src={url} className="size-full" title="84000 Research Library" />
+    <iframe
+      src={url}
+      className="size-full pb-[var(--header-height)]"
+      title="84000 Research Library"
+    />
   );
 };
 

--- a/apps/web-main/src/app/(DashboardLayout)/research-library/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/research-library/page.tsx
@@ -1,9 +1,13 @@
+import { notFound } from 'next/navigation';
+
 const Page = () => {
+  const url = process.env.NEXT_PUBLIC_RESEARCH_LIBRARY_URL;
+  if (!url) {
+    return notFound();
+  }
+
   return (
-    <iframe
-      src="https://84000-research-library.vercel.app/"
-      className="size-full"
-    />
+    <iframe src={url} className="size-full" title="84000 Research Library" />
   );
 };
 

--- a/apps/web-main/src/components/ui/AppContent.tsx
+++ b/apps/web-main/src/components/ui/AppContent.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 export const AppContent = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="fixed h-screen pb-(--header-height) w-full overflow-auto">
+    <div className="fixed top-[--header-height] size-full overflow-auto">
       {children}
     </div>
   );

--- a/libs/lib-canon/src/lib/page/WorksPage.tsx
+++ b/libs/lib-canon/src/lib/page/WorksPage.tsx
@@ -134,6 +134,7 @@ export const WorksPage = ({
           </div>
         )}
       />
+      <div className="h-[var(--header-height)]" />
     </>
   );
 };

--- a/libs/lib-editing/src/lib/components/editor/EndNotesEditor/EndNotesEditor.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EndNotesEditor/EndNotesEditor.tsx
@@ -28,7 +28,7 @@ export const EndNotesEditor = ({
   });
 
   return (
-    <div className="flex h-full">
+    <div className="flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4 py-(--header-height)">
       <div className="relative flex flex-col flex-1 h-full">
         <EditorContent className="flex-1" editor={editor} />
         <EndNotesBubbleMenu editor={editor} />

--- a/libs/lib-editing/src/lib/components/editor/TitlesEditor/TitlesEditor.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TitlesEditor/TitlesEditor.tsx
@@ -32,7 +32,7 @@ export const TitlesEditor = ({
     isEditable,
   });
   return (
-    <div className="flex h-full">
+    <div className="flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4 py-(--header-height)">
       <div className="relative flex flex-col flex-1 h-full">
         <EditorContent className="flex-1" editor={editor} />
         <EmptyBubbleMenu editor={editor} />

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/TranslationEditor.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/TranslationEditor.tsx
@@ -51,7 +51,7 @@ export const TranslationEditor = ({
     onCreate,
   });
   return (
-    <div className="flex h-full">
+    <div className="flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4 py-(--header-height)">
       <div className="relative flex flex-col flex-1 h-full">
         <EditorContent className="flex-1" editor={editor} />
         <TranslationBubbleMenu editor={editor} />

--- a/libs/lib-editing/src/lib/components/page/AiSummarizerPage.tsx
+++ b/libs/lib-editing/src/lib/components/page/AiSummarizerPage.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { notFound } from 'next/navigation';
+import { useEditorState } from './EditorProvider';
+
+export const AiSummarizerPage = () => {
+  const { uuid } = useEditorState();
+
+  const url = process.env.NEXT_PUBLIC_AI_SUMMARIZER_URL;
+  if (!url) {
+    return notFound();
+  }
+
+  const src = `${url}?uuid=${uuid}`;
+  return (
+    <iframe
+      src={src}
+      className="w-full h-[calc(100vh-var(--header-height))]"
+      title="AI Summarizer"
+    />
+  );
+};

--- a/libs/lib-editing/src/lib/components/page/AiSummarizerPage.tsx
+++ b/libs/lib-editing/src/lib/components/page/AiSummarizerPage.tsx
@@ -12,11 +12,5 @@ export const AiSummarizerPage = () => {
   }
 
   const src = `${url}?uuid=${uuid}`;
-  return (
-    <iframe
-      src={src}
-      className="w-full h-[calc(100vh-var(--header-height))]"
-      title="AI Summarizer"
-    />
-  );
+  return <iframe src={src} className="flex-grow" title="AI Summarizer" />;
 };

--- a/libs/lib-editing/src/lib/components/page/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/page/EditorProvider.tsx
@@ -10,7 +10,7 @@ import React, {
 } from 'react';
 import { Doc, Transaction, XmlElement, XmlFragment } from 'yjs';
 import { usePathname, useRouter } from 'next/navigation';
-import type { EditorBuilderType } from './types';
+import type { EditorMenuItemType } from './types';
 import type { TranslationEditorContent } from '../editor/TranslationEditor';
 import { EditorSidebar } from './EditorSidebar';
 import {
@@ -24,14 +24,14 @@ import { blockFromPassage } from '../../block';
 interface EditorContextState {
   doc?: Doc;
   uuid: string;
-  builder: EditorBuilderType;
+  builder: EditorMenuItemType;
   dirtyUuids: string[];
   getFragment: () => XmlFragment;
   fetchEndNote: (uuid: string) => Promise<TranslationEditorContent | undefined>;
   fetchGlossaryTerm: (
     uuid: string,
   ) => Promise<GlossaryTermInstance | undefined>;
-  setBuilder: (active: EditorBuilderType) => void;
+  setBuilder: (active: EditorMenuItemType) => void;
   setDoc: (doc: Doc) => void;
   save: () => Promise<void>;
   startObserving: () => void;
@@ -87,8 +87,8 @@ export const EditorContextProvider = ({
 
   const pathEnd = pathname.split('/').pop();
   const isUuidPath = pathEnd === uuid;
-  const initialBuilder = isUuidPath ? 'body' : (pathEnd as EditorBuilderType);
-  const [builder, setBuilder] = useState<EditorBuilderType>(initialBuilder);
+  const initialBuilder = isUuidPath ? 'body' : (pathEnd as EditorMenuItemType);
+  const [builder, setBuilder] = useState<EditorMenuItemType>(initialBuilder);
   const [doc, setDoc] = useState<Doc>(initialDoc || new Doc());
   const [fragments, setFragments] = useState<{
     [builder: string]: XmlFragment;
@@ -232,9 +232,8 @@ export const EditorContextProvider = ({
       }}
     >
       <EditorSidebar active={builder || 'body'} onClick={setBuilder}>
-        <div className="flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4 py-(--header-height)">
-          {children}
-        </div>
+        {children}
+        <div className="h-[var(--header-height)]" />
       </EditorSidebar>
     </EditorContext.Provider>
   );

--- a/libs/lib-editing/src/lib/components/page/EditorSidebar.tsx
+++ b/libs/lib-editing/src/lib/components/page/EditorSidebar.tsx
@@ -21,12 +21,12 @@ import {
   SidebarRail,
   SidebarTrigger,
 } from '@design-system';
-import { LetterTextIcon } from 'lucide-react';
-import { useCallback } from 'react';
-import type { EditorBuilderType } from './types';
+import { LetterTextIcon, SparklesIcon } from 'lucide-react';
+import { ReactNode, useCallback } from 'react';
+import type { EditorMenuItemType } from './types';
 
 interface EditorSidebarItem {
-  key: EditorBuilderType;
+  key: EditorMenuItemType;
   title: string;
 }
 
@@ -57,8 +57,60 @@ const englishEditorItems: EditorSidebarItem[] = [
   },
 ];
 
-const isActive = (key: EditorBuilderType, active: EditorBuilderType) =>
+const toolItems: EditorSidebarItem[] = [
+  {
+    key: 'summarizer',
+    title: 'Summarizer',
+  },
+];
+
+const isActive = (key: EditorMenuItemType, active: EditorMenuItemType) =>
   key === active;
+
+export const EditorSidebarMenu = ({
+  icon,
+  name,
+  items,
+  active,
+  onSetActive,
+}: {
+  icon: ReactNode;
+  name: string;
+  items: EditorSidebarItem[];
+  active: EditorMenuItemType;
+  onSetActive: (key: EditorMenuItemType) => void;
+}) => {
+  return (
+    <SidebarMenu>
+      <Collapsible defaultOpen className="group/collapsible">
+        <SidebarMenuItem>
+          <CollapsibleTrigger asChild>
+            <SidebarMenuButton>
+              {icon}
+              {name}
+              <CollapsibleIcon />
+            </SidebarMenuButton>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <SidebarMenuSub>
+              <SidebarMenuSubItem>
+                {items.map((item) => (
+                  <SidebarMenuSubButton
+                    key={item.key}
+                    onClick={() => onSetActive(item.key)}
+                    isActive={isActive(item.key, active)}
+                  >
+                    {item.title}
+                  </SidebarMenuSubButton>
+                ))}
+              </SidebarMenuSubItem>
+            </SidebarMenuSub>
+          </CollapsibleContent>
+        </SidebarMenuItem>
+      </Collapsible>
+    </SidebarMenu>
+  );
+};
 
 export const EditorSidebar = ({
   children,
@@ -66,11 +118,11 @@ export const EditorSidebar = ({
   onClick,
 }: {
   children: React.ReactNode;
-  active: EditorBuilderType;
-  onClick?: (key: EditorBuilderType) => void;
+  active: EditorMenuItemType;
+  onClick?: (key: EditorMenuItemType) => void;
 }) => {
   const onSetActive = useCallback(
-    (key: EditorBuilderType) => {
+    (key: EditorMenuItemType) => {
       onClick?.(key);
     },
     [onClick],
@@ -83,34 +135,25 @@ export const EditorSidebar = ({
           <SidebarGroup className="border-t border-sidebar-border">
             <SidebarGroupLabel>Editors</SidebarGroupLabel>
             <SidebarGroupContent>
-              <SidebarMenu>
-                <Collapsible defaultOpen className="group/collapsible">
-                  <SidebarMenuItem>
-                    <CollapsibleTrigger asChild>
-                      <SidebarMenuButton>
-                        <LetterTextIcon />
-                        English Editor
-                        <CollapsibleIcon />
-                      </SidebarMenuButton>
-                    </CollapsibleTrigger>
-                    <CollapsibleContent>
-                      <SidebarMenuSub>
-                        <SidebarMenuSubItem>
-                          {englishEditorItems.map((item) => (
-                            <SidebarMenuSubButton
-                              key={item.key}
-                              onClick={() => onSetActive(item.key)}
-                              isActive={isActive(item.key, active)}
-                            >
-                              {item.title}
-                            </SidebarMenuSubButton>
-                          ))}
-                        </SidebarMenuSubItem>
-                      </SidebarMenuSub>
-                    </CollapsibleContent>
-                  </SidebarMenuItem>
-                </Collapsible>
-              </SidebarMenu>
+              <EditorSidebarMenu
+                icon={<LetterTextIcon />}
+                name="English Editor"
+                items={englishEditorItems}
+                active={active}
+                onSetActive={onSetActive}
+              />
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarGroup>
+            <SidebarGroupLabel>Tools</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <EditorSidebarMenu
+                icon={<SparklesIcon />}
+                name="AI Tools"
+                items={toolItems}
+                active={active}
+                onSetActive={onSetActive}
+              />
             </SidebarGroupContent>
           </SidebarGroup>
         </SidebarContent>

--- a/libs/lib-editing/src/lib/components/page/TranslationSkeleton.tsx
+++ b/libs/lib-editing/src/lib/components/page/TranslationSkeleton.tsx
@@ -2,12 +2,14 @@ import { Skeleton } from '@design-system';
 
 export const TranslationSkeleton = () => {
   return (
-    <div className="flex flex-col gap-6 pt-8">
-      <Skeleton className="h-12 mb-4" />
-      <Skeleton className="h-20 w-1/2" />
-      <Skeleton className="h-48" />
-      <Skeleton className="h-24 w-5/6" />
-      <Skeleton className="h-64" />
+    <div className="flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4 py-(--header-height)">
+      <div className="flex flex-col gap-6 pt-8">
+        <Skeleton className="h-12 mb-4" />
+        <Skeleton className="h-20 w-1/2" />
+        <Skeleton className="h-48" />
+        <Skeleton className="h-24 w-5/6" />
+        <Skeleton className="h-64" />
+      </div>
     </div>
   );
 };

--- a/libs/lib-editing/src/lib/components/page/index.ts
+++ b/libs/lib-editing/src/lib/components/page/index.ts
@@ -1,3 +1,4 @@
+export * from './AiSummarizerPage';
 export * from './EditorPage';
 export * from './EditorProvider';
 export * from './EditorSidebar';

--- a/libs/lib-editing/src/lib/components/page/types.ts
+++ b/libs/lib-editing/src/lib/components/page/types.ts
@@ -7,3 +7,7 @@ export type EditorBuilderType =
   | 'end-notes'
   | 'bibliography'
   | 'glossary';
+
+export type EditorToolsType = 'summarizer';
+
+export type EditorMenuItemType = EditorBuilderType | EditorToolsType;

--- a/libs/lib-glossary/src/lib/DetailPage.tsx
+++ b/libs/lib-glossary/src/lib/DetailPage.tsx
@@ -27,6 +27,7 @@ export const DetailPage = async ({
         <GlossaryVariants detail={detail} />
         <GlossaryInstancesTable detail={detail} />
         <GlossaryRelatedTerms detail={detail} />
+        <div className="h-[var(--header-height)]" />
       </div>
     </div>
   );

--- a/libs/lib-glossary/src/lib/LandingPage.tsx
+++ b/libs/lib-glossary/src/lib/LandingPage.tsx
@@ -23,6 +23,7 @@ export const LandingPage = async () => {
           types={types}
           languages={languages}
         />
+        <div className="h-[var(--header-height)]" />
       </div>
     </div>
   );

--- a/libs/lib-user/src/lib/ProfileLayout.tsx
+++ b/libs/lib-user/src/lib/ProfileLayout.tsx
@@ -40,6 +40,7 @@ const InnerProfileLayout = ({ children }: { children: ReactNode }) => {
         </div>
         <ScrollArea className="w-full">{children}</ScrollArea>
       </div>
+      <div className="h-[var(--header-height)]" />
     </div>
   );
 };


### PR DESCRIPTION
### Summary

The AI Summary Tool has been integrated as an `iframe` with the work uuid passed in as a query parameter. You can get to the tool from within the editor, using the `AI Tools` menu has been added to the sidebar.

The intention is to eventually load a details screen within the summaries app. Until support for the query parameter is added, it loads the editor page. The url is configurable as an environment variable.

### Screenshots

<img width="1217" height="849" alt="Screenshot 2025-09-15 at 2 32 03 PM" src="https://github.com/user-attachments/assets/189e197d-797b-4c65-8db2-684c01eaaafe" />


### Notes

This exposed some minor but trick issues with how the general layout is defined. It is no longer safe to assume that a general application of padding is possible.
