### PR TITLE
Add missing bottom padding

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/publications/editor/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/editor/page.tsx
@@ -14,6 +14,7 @@ const page = async () => {
       <div className="w-full max-w-[1466px]">
         <H2 className="text-navy-500">{'Translation Editor'}</H2>
         <TranslationsTable works={works} />
+        <div className="h-[var(--header-height)]" />
       </div>
     </div>
   );

--- a/apps/web-main/src/components/project/ProjectsPage.tsx
+++ b/apps/web-main/src/components/project/ProjectsPage.tsx
@@ -35,6 +35,7 @@ export const ProjectsPage = () => {
             <Skeleton className="w-full h-[500px] mt-6" />
           </>
         )}
+        <div className="h-[var(--header-height)]" />
       </div>
     </div>
   );


### PR DESCRIPTION
### Summary

The editor landing page and projects landing page were missing padding at the bottom that offsets the app header. The result was pagination became inaccessible on shorter screens. This fixes that issue.
