### PR TITLE
Render abbreviations

### DIFF
--- a/libs/data-access/src/lib/types/annotation-type.ts
+++ b/libs/data-access/src/lib/types/annotation-type.ts
@@ -97,7 +97,6 @@ const ANNOATION_TYPE_DTO_TO_TYPE: Record<AnnotationDTOType, AnnotationType> = {
 
 export const ANNOTATIONS_TO_IGNORE: AnnotationDTOType[] = [
   'deprecated-internal-link',
-  'has-abbreviation',
   'quoted',
   'reference',
   'unknown',

--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -65,37 +65,18 @@ const paragraphTemplate = (passage: Passage): BlockEditorContentItem => {
 };
 
 const abbreviationTemplate = (passage: Passage): BlockEditorContentItem => {
-  const content = [textTemplate(passage.content)];
   const block: BlockEditorContentItem = {
-    type: 'table',
+    type: 'paragraph',
     attrs: {
+      class: 'flex flex-row gap-2',
       start: 0,
       end: passage.content.length,
       uuid: passage.uuid,
     },
-    content: [
-      {
-        type: 'tableRow',
-        attrs: {
-          start: 0,
-          end: passage.content.length,
-          uuid: passage.uuid,
-        },
-        content: [
-          {
-            type: 'abbreviation',
-            attrs: {
-              start: 0,
-              end: passage.content.length,
-              uuid: passage.uuid,
-            },
-            content,
-          },
-        ],
-      },
-    ],
+    content: [],
   };
 
+  block.content = [textTemplate(passage.content)];
   return block;
 };
 
@@ -105,7 +86,7 @@ const TEMPLATES_FOR_BLOCK_TYPE: {
   acknowledgment: paragraphTemplate,
   acknowledgmentHeader: headingTemplate,
   abbreviations: abbreviationTemplate,
-  abbreviationHeader: headingTemplate,
+  abbreviationsHeader: headingTemplate,
   appendix: paragraphTemplate,
   appendixHeader: headingTemplate,
   colophon: paragraphTemplate,
@@ -122,7 +103,6 @@ const TEMPLATES_FOR_BLOCK_TYPE: {
   prologueHeader: headingTemplate,
   summary: paragraphTemplate,
   summaryHeader: headingTemplate,
-  toc: paragraphTemplate,
   translation: paragraphTemplate,
   translationHeader: headingTemplate,
   unknown: paragraphTemplate,

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/hooks/useTranslationExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/hooks/useTranslationExtensions.ts
@@ -45,10 +45,10 @@ import { MantraMark } from '../extensions/Mantra/Mantra';
 import { EndNoteLinkNode } from '../extensions/EndNoteLink/EndNoteLinkNode';
 import { GlossaryInstanceNode } from '../extensions/GlossaryInstance/GlossaryInstanceNode';
 import {
-  AbbreviationCell,
+  Abbreviation,
   AbbreviationCommand,
   AbbreviationSuggestion,
-  HasAbbreviationCell,
+  HasAbbreviation,
 } from '../../extensions/Abbreviation/Abbreviation';
 import { ParagraphIndent } from '../../extensions/ParagraphIndent';
 import { TranslationEditorContent } from '../TranslationEditor';
@@ -101,8 +101,8 @@ export const useTranslationExtensions = ({
   const extensions = [
     TranslationDocument,
     Audio,
-    AbbreviationCell,
-    HasAbbreviationCell,
+    Abbreviation,
+    HasAbbreviation,
     AbbreviationCommand,
     Bold,
     EndNoteLinkNode.configure({

--- a/libs/lib-editing/src/lib/components/editor/extensions/Abbreviation/Abbreviation.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Abbreviation/Abbreviation.ts
@@ -1,8 +1,11 @@
-import { Extension } from '@tiptap/core';
+import { Extension, Node } from '@tiptap/core';
 import { mergeAttributes } from '@tiptap/react';
-import { TableCell } from '../Table';
 import { CommandSuggestionItem } from '../SlashCommand/SuggestionList';
 import { TableIcon } from 'lucide-react';
+
+export interface AbbreviationOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -21,20 +24,15 @@ export const AbbreviationCommand = Extension.create({
         () =>
         ({ commands }) => {
           return commands.insertContent({
-            type: 'table',
+            type: 'paragraph',
             content: [
               {
-                type: 'tableRow',
-                content: [
-                  {
-                    type: 'abbreviation',
-                    content: [{ type: 'text', text: 'A' }],
-                  },
-                  {
-                    type: 'hasAbbreviation',
-                    content: [{ type: 'text', text: 'Abbreviation' }],
-                  },
-                ],
+                type: 'abbreviation',
+                content: [{ type: 'text', text: 'A' }],
+              },
+              {
+                type: 'hasAbbreviation',
+                content: [{ type: 'text', text: 'Abbreviation' }],
               },
             ],
           });
@@ -53,46 +51,76 @@ export const AbbreviationSuggestion: CommandSuggestionItem = {
   },
 };
 
-export const AbbreviationCell = TableCell.extend({
+export const Abbreviation = Node.create<AbbreviationOptions>({
   name: 'abbreviation',
-  group: 'tableCell',
+  group: 'inline',
   content: 'inline*',
+  inline: true,
 
   addAttributes() {
     return {
       abbreviation: {
-        default: null,
+        default: undefined,
+        parseHTML(element: HTMLElement) {
+          return element.getAttribute('abbreviation');
+        },
+      },
+    };
+  },
+
+  addOptions() {
+    return {
+      HTMLAttributes: {
+        class: 'italic min-w-8',
       },
     };
   },
 
   parseHTML() {
-    return [{ tag: 'td[type=abbreviation]' }];
+    return [{ tag: 'span[type="abbreviation"]' }];
   },
 
   renderHTML({ HTMLAttributes }: { HTMLAttributes: Record<string, unknown> }) {
     return [
-      'td',
+      'span',
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         type: 'abbreviation',
-        class: 'italic',
       }),
       0,
     ];
   },
 });
 
-export const HasAbbreviationCell = TableCell.extend({
+export const HasAbbreviation = Node.create<AbbreviationOptions>({
   name: 'hasAbbreviation',
-  group: 'tableCell',
+  group: 'inline',
   content: 'inline*',
+  inline: true,
+
+  addAttributes() {
+    return {
+      abbreviation: {
+        default: undefined,
+        parseHTML(element: HTMLElement) {
+          return element.getAttribute('abbreviation');
+        },
+      },
+    };
+  },
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
   parseHTML() {
-    return [{ tag: 'td[type=hasAbbreviation]' }];
+    return [{ tag: 'span[type=hasAbbreviation]' }];
   },
 
   renderHTML({ HTMLAttributes }: { HTMLAttributes: Record<string, unknown> }) {
     return [
-      'td',
+      'span',
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         type: 'hasAbbreviation',
       }),

--- a/libs/lib-editing/src/lib/components/editor/extensions/Table.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Table.ts
@@ -11,6 +11,4 @@ export const Table = TipTapTable.configure({
 
 export const TableCell = TipTapTableCell;
 export const TableHeader = TipTapTableHeader;
-export const TableRow = TipTapTableRow.extend({
-  content: '(tableCell | tableHeader | abbreviation | hasAbbreviation)*',
-});
+export const TableRow = TipTapTableRow;

--- a/libs/lib-editing/src/lib/exporters/abbreviation.ts
+++ b/libs/lib-editing/src/lib/exporters/abbreviation.ts
@@ -10,11 +10,6 @@ export const abbreviation: Exporter<AnnotationExport> = ({
   const abbreviation = node.attrs.abbreviation;
   const uuid = node.attrs.uuid;
 
-  if (!abbreviation) {
-    console.warn(`Abbreviation ${uuid} is incomplete`);
-    return undefined;
-  }
-
   return {
     uuid,
     type: 'abbreviation',

--- a/libs/lib-editing/src/lib/exporters/has-abbreviation.ts
+++ b/libs/lib-editing/src/lib/exporters/has-abbreviation.ts
@@ -9,11 +9,6 @@ export const hasAbbreviation: Exporter<AnnotationExport> = ({
   const abbreviation = node.attrs.abbreviation;
   const uuid = node.attrs.uuid;
 
-  if (!abbreviation || !textContent) {
-    console.warn(`Has abbreviation node ${uuid} is incomplete`);
-    return undefined;
-  }
-
   return {
     uuid,
     type: 'hasAbbreviation',

--- a/libs/lib-editing/src/lib/transformers/abbreviation.ts
+++ b/libs/lib-editing/src/lib/transformers/abbreviation.ts
@@ -1,24 +1,28 @@
 import { AbbreviationAnnotation } from '@data-access';
 import { recurse } from './recurse';
-import { splitBlock } from './split-block';
 import { Transformer } from './transformer';
+import { splitContent } from './split-content';
 
 export const abbreviation: Transformer = (ctx) => {
   const { annotation } = ctx;
-  const { abbreviation } = annotation as AbbreviationAnnotation;
+  const { abbreviation, uuid } = annotation as AbbreviationAnnotation;
 
   recurse({
-    until: ['abbreviation'],
+    until: ['text'],
     ...ctx,
     transform: (ctx) => {
-      splitBlock({
+      splitContent({
         ...ctx,
         transform: ({ block }) => {
           block.type = 'abbreviation';
           block.attrs = {
             ...block.attrs,
             abbreviation,
+            uuid,
           };
+          block.content = [
+            { type: 'text', text: block.text, marks: block.marks },
+          ];
         },
       });
     },

--- a/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
+++ b/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
@@ -1,22 +1,28 @@
+import { HasAbbreviationAnnotation } from '@data-access';
 import { recurse } from './recurse';
-import { splitBlock } from './split-block';
+import { splitContent } from './split-content';
 import { Transformer } from './transformer';
 
 export const hasAbbreviation: Transformer = (ctx) => {
+  const { annotation } = ctx;
+  const { abbreviation, uuid } = annotation as HasAbbreviationAnnotation;
+
   recurse({
-    until: ['abbreviation'],
+    until: ['text'],
     ...ctx,
     transform: (ctx) => {
-      splitBlock({
+      splitContent({
         ...ctx,
         transform: ({ block }) => {
           block.type = 'hasAbbreviation';
           block.attrs = {
             ...block.attrs,
-            start: ctx.annotation?.start,
-            end: ctx.annotation?.end,
-            uuid: ctx.annotation?.uuid,
+            abbreviation,
+            uuid,
           };
+          block.content = [
+            { type: 'text', text: block.text, marks: block.marks },
+          ];
         },
       });
     },

--- a/libs/lib-editing/src/lib/transformers/split-block.ts
+++ b/libs/lib-editing/src/lib/transformers/split-block.ts
@@ -13,7 +13,7 @@ export const splitBlock: Transformer = ({
 }) => {
   if (!isBlockAnnotation((block.type || 'unknown') as AnnotationType)) {
     console.warn(
-      `splitBlock transformer expects to find a block annotation, but found: ${block.attrs?.type}`,
+      `splitBlock transformer expects to find a block annotation, but found: ${block?.type}`,
     );
     return;
   }


### PR DESCRIPTION
### Summary

Previously, abbreviations were rendered as tables. This followed the pattern used on the public website. However, this only makes sense if a table wraps multiple passages, which does not fit well into the new data structure. Instead, this change renders abbreviations as spans and adds spacing. A future update might be to calculate a width that all `abbreviation` annotations use to ensure we always have a nicely aligned gutter.