### PR TITLE
Soft launch items, part 3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,10 @@
 
 ### Linear
 
-<!-- A link to realted Linear issues. -->
+<!-- A link to related Linear issues. -->
 <!-- Remove if not applicable. -->
 
-- [ISSUE-ID](https://linear.app/your-project/issue/ISSUE-ID)
+- [DEV-ID](https://linear.app/84000/issue/DEV-ID)
 
 ### Screenshots
 

--- a/apps/web-main/src/app/(DashboardLayout)/publications/editor/[slug]/glossary/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/publications/editor/[slug]/glossary/page.tsx
@@ -1,14 +1,5 @@
-import { H1, Skeleton } from '@design-system';
+import { TranslationGlossaryPage } from '@lib-editing';
 
-const Page = () => {
-  return (
-    <div className="flex flex-col justify-center gap-8">
-      <H1>Glossary</H1>
-      <div className="size-full pe-6">
-        <Skeleton className="w-full h-96" />
-      </div>
-    </div>
-  );
-};
+const Page = TranslationGlossaryPage;
 
 export default Page;

--- a/libs/data-access/src/lib/glossary.ts
+++ b/libs/data-access/src/lib/glossary.ts
@@ -9,6 +9,7 @@ import {
   glossaryTermInstanceFromDTO,
   glossaryLandingItemFromDTO,
   glossaryPageItemFromDTO,
+  GlossaryTermInstancesDTO,
 } from './types';
 
 export const getAllGlossaryTerms = async ({
@@ -53,6 +54,28 @@ export const getAllGlossaryTerms = async ({
   }
 
   return terms;
+};
+
+export const getGlossaryInstances = async ({
+  client,
+  uuid,
+}: {
+  client: DataClient;
+  uuid: string;
+}) => {
+  const { data, error } = await client.rpc('show_glossary_entries', {
+    v_work_uuid: uuid,
+  });
+  if (error) {
+    console.error(
+      `Error fetching glossary instances for work: ${uuid} `,
+      error,
+    );
+    return [];
+  }
+
+  const dto = data as GlossaryTermInstancesDTO;
+  return dto.glossary_entries.map(glossaryTermInstanceFromDTO);
 };
 
 export const getGlossaryInstance = async ({

--- a/libs/data-access/src/lib/types/glossary.ts
+++ b/libs/data-access/src/lib/types/glossary.ts
@@ -60,6 +60,11 @@ export type GlossaryTermInstanceDTO = {
   };
 };
 
+export type GlossaryTermInstancesDTO = {
+  work_uuid: string;
+  glossary_entries: GlossaryTermInstanceDTO[];
+};
+
 export const glossaryNameFromDTO = (dto: GlossaryNameDTO): GlossaryName => {
   return {
     content: dto.content,

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/extensions/GlossaryInstance/GlossaryInstance.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/extensions/GlossaryInstance/GlossaryInstance.tsx
@@ -3,14 +3,14 @@ import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
-  Separator,
   Skeleton,
 } from '@design-system';
 import { useEffect, useState } from 'react';
 import { GlossaryTermInstance } from '@data-access';
-import { removeHtmlTags } from '@lib-utils';
 import { usePathname } from 'next/navigation';
 import { ensureNodeUuid } from '../../../util';
+import { GlossaryInstanceBody } from '../../../../page';
+import Link from 'next/link';
 
 export const GlossaryInstanceCard = ({
   uuid,
@@ -20,8 +20,6 @@ export const GlossaryInstanceCard = ({
   fetch?: (uuid: string) => Promise<GlossaryTermInstance | undefined>;
 }) => {
   const [content, setContent] = useState<GlossaryTermInstance>();
-
-  const [definition, setDefinition] = useState<string>();
 
   useEffect(() => {
     if (!uuid || content || !fetch) {
@@ -34,49 +32,11 @@ export const GlossaryInstanceCard = ({
     })();
   }, [uuid, content, fetch]);
 
-  useEffect(() => {
-    if (!content?.definition) {
-      return;
-    }
-
-    const plainText = removeHtmlTags(content.definition);
-    setDefinition(plainText);
-  }, [content, setDefinition]);
-
   if (!content) {
     return <Skeleton className="p-2 h-20 w-full" />;
   }
 
-  return (
-    <div className="p-2 flex gap-1 flex-col">
-      {content.names.english && (
-        <div className="text-xl font-serif">{content.names.english}</div>
-      )}
-      {content.names.wylie && (
-        <div className="italic">{content.names.wylie}</div>
-      )}
-      {content.names.tibetan && (
-        <div className="text-lg">{content.names.tibetan}</div>
-      )}
-      {content.names.sanskrit && (
-        <div className="italic">{content.names.sanskrit}</div>
-      )}
-      {content.names.chinese && <div>{content.names.chinese}</div>}
-      {content.names.pali && <div className="italic">{content.names.pali}</div>}
-      <Separator className="w-4 h-0.25 my-5 bg-primary/80" />
-      {definition && <p>{definition}</p>}
-      <div className="text-sm text-muted-foreground mt-2">
-        <a
-          href={`/glossary/${content.authority}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline"
-        >
-          {'View full entry ›'}
-        </a>
-      </div>
-    </div>
-  );
+  return <GlossaryInstanceBody instance={content} />;
 };
 
 export const GlossaryInstance = ({
@@ -114,10 +74,10 @@ export const GlossaryInstance = ({
     <NodeViewWrapper as="span">
       <HoverCard>
         <HoverCardTrigger asChild>
-          <a href={url} {...extension.options.HTMLAttributes}>
+          <Link scroll={false} href={url} {...extension.options.HTMLAttributes}>
             {/* @ts-expect-error: Nodeview content declares only `div` is acceptable when passed to `as`, but we need a `span` */}
             <NodeViewContent as="span" />
-          </a>
+          </Link>
         </HoverCardTrigger>
         <HoverCardContent className="w-120 lg:w-4xl max-h-100 m-2 overflow-auto">
           <GlossaryInstanceCard uuid={node.attrs.glossary} fetch={fetch} />

--- a/libs/lib-editing/src/lib/components/page/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/page/EditorProvider.tsx
@@ -261,7 +261,7 @@ export const EditorContextProvider = ({
     >
       <EditorSidebar
         builders={builders}
-        active={builder || 'body'}
+        active={builder || 'titles'}
         onClick={toNewBuilder}
       >
         <EditorHeader />

--- a/libs/lib-editing/src/lib/components/page/TranslationGlossaryPage.tsx
+++ b/libs/lib-editing/src/lib/components/page/TranslationGlossaryPage.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import {
+  createBrowserClient,
+  getGlossaryInstances,
+  GlossaryTermInstance,
+} from '@data-access';
+import { ReactNode, useEffect, useState } from 'react';
+import { useEditorState } from './EditorProvider';
+import { TranslationSkeleton } from './TranslationSkeleton';
+import { H2, Separator } from '@design-system';
+import { cn, removeHtmlTags, useScrollToHash } from '@lib-utils';
+import Link from 'next/link';
+
+export const LabeledElement = ({
+  label,
+  id = undefined,
+  className,
+  children,
+}: {
+  label?: string;
+  id?: string;
+  className?: string;
+  children: ReactNode;
+}) => {
+  return (
+    <div id={id} className="relative leading-7 ml-6">
+      <Link
+        href={`#${id}`}
+        className={cn(
+          'absolute -left-16 w-16 text-end text-slate hover:cursor-pointer',
+          className,
+        )}
+      >
+        {label || ''}
+      </Link>
+      <div className="pl-6">{children}</div>
+    </div>
+  );
+};
+
+export const GlossaryInstanceBody = ({
+  instance,
+  className,
+}: {
+  instance: GlossaryTermInstance;
+  className?: string;
+}) => {
+  const [definition, setDefinition] = useState<string>();
+
+  useEffect(() => {
+    if (!instance?.definition) {
+      return;
+    }
+
+    const plainText = removeHtmlTags(instance.definition);
+    setDefinition(plainText);
+  }, [instance.definition, setDefinition]);
+
+  return (
+    <div className={cn('p-2 flex gap-1 flex-col', className)}>
+      {instance.names.english && (
+        <div className="text-xl font-serif font-semibold">
+          {instance.names.english}
+        </div>
+      )}
+      {instance.names.wylie && (
+        <div className="italic">{instance.names.wylie}</div>
+      )}
+      {instance.names.tibetan && (
+        <div className="text-lg">{instance.names.tibetan}</div>
+      )}
+      {instance.names.sanskrit && (
+        <div className="italic">{instance.names.sanskrit}</div>
+      )}
+      {instance.names.chinese && <div>{instance.names.chinese}</div>}
+      {instance.names.pali && (
+        <div className="italic">{instance.names.pali}</div>
+      )}
+      <Separator className="w-4 h-0.5 my-5 bg-slate/80" />
+      {definition && <p>{definition}</p>}
+      <div className="text-sm text-mut mt-2">
+        <a
+          href={`/glossary/${instance.authority}`}
+          target="_blank"
+          rel="noreferrer"
+          className="hover:underline decoration-slate hover:text-slate"
+        >
+          {'View full entry ›'}
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export const TranslationGlossaryPage = () => {
+  const [content, setContent] = useState<GlossaryTermInstance[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const { uuid } = useEditorState();
+  useScrollToHash({ isReady: !loading });
+
+  useEffect(() => {
+    (async () => {
+      const client = createBrowserClient();
+      const items = (await getGlossaryInstances({ client, uuid })) ?? [];
+      items.sort((a, b) => {
+        if (a.names.english && b.names.english) {
+          return a.names.english.localeCompare(b.names.english);
+        }
+        if (a.names.wylie && b.names.wylie) {
+          return a.names.wylie.localeCompare(b.names.wylie);
+        }
+        return 0;
+      });
+
+      setContent(items);
+      setLoading(false);
+    })();
+  }, [uuid]);
+
+  if (loading) {
+    return <TranslationSkeleton />;
+  }
+
+  return (
+    <div className="flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4">
+      <LabeledElement className="mt-8" id={'glossary'} label="g.">
+        <H2>Glossary</H2>
+      </LabeledElement>
+      <div className="mt-4 flex flex-col gap-8">
+        {content.length === 0 && (
+          <div className="text-muted-foreground">No glossary terms found.</div>
+        )}
+        {content.map((instance, index) => (
+          <LabeledElement
+            id={instance.uuid}
+            key={instance.uuid}
+            label={`g.${index + 1}`}
+          >
+            <GlossaryInstanceBody instance={instance} className="p-0" />
+            <div className="mt-8">
+              <Separator />
+            </div>
+          </LabeledElement>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/libs/lib-editing/src/lib/components/page/builder/CollaborativeBuilder.tsx
+++ b/libs/lib-editing/src/lib/components/page/builder/CollaborativeBuilder.tsx
@@ -9,8 +9,7 @@ import { useEditorState } from '../EditorProvider';
 import { PassagesEditor } from '../../editor';
 import { TranslationSkeleton } from '../TranslationSkeleton';
 
-const WRAPPER_CLASS =
-  'flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4 py-(--header-height)';
+const WRAPPER_CLASS = 'flex flex-col w-full xl:px-32 lg:px-16 md:px-8 px-4';
 
 export const CollaborativeBuilder = ({
   builder,

--- a/libs/lib-editing/src/lib/components/page/index.ts
+++ b/libs/lib-editing/src/lib/components/page/index.ts
@@ -2,6 +2,7 @@ export * from './AiSummarizerPage';
 export * from './EditorPage';
 export * from './EditorProvider';
 export * from './EditorSidebar';
+export * from './TranslationGlossaryPage';
 export * from './TranslationSkeleton';
 export * from './TranslationTable';
 export * from './builder';

--- a/libs/lib-utils/src/lib/hooks/index.ts
+++ b/libs/lib-utils/src/lib/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-mobile';
+export * from './use-scroll-to-hash';

--- a/libs/lib-utils/src/lib/hooks/use-scroll-to-hash.tsx
+++ b/libs/lib-utils/src/lib/hooks/use-scroll-to-hash.tsx
@@ -1,0 +1,50 @@
+// hooks/useScrollToHash.js
+'use client';
+
+import { DependencyList, useEffect } from 'react';
+
+/**
+ * Hook that scrolls to an element matching the URL hash.
+ * Uses MutationObserver to wait for dynamically loaded content.
+ */
+export function useScrollToHash({
+  isReady,
+  delay = 0,
+  behavior = 'auto',
+  block = 'start',
+  dependencies = [],
+}: {
+  isReady: boolean;
+  delay?: number;
+  behavior?: ScrollBehavior;
+  block?: ScrollLogicalPosition;
+  dependencies?: DependencyList;
+}) {
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    const hash = window.location.hash;
+    if (!hash) {
+      return;
+    }
+
+    const scrollToElement = () => {
+      const id = hash.replace('#', '');
+      const element = document.getElementById(id);
+
+      if (element) {
+        element.scrollIntoView({ behavior, block });
+      }
+    };
+
+    if (delay > 0) {
+      const timeoutId = setTimeout(scrollToElement, delay);
+      return () => clearTimeout(timeoutId);
+    } else {
+      // Use requestAnimationFrame to ensure DOM is painted
+      requestAnimationFrame(scrollToElement);
+    }
+  }, [isReady, delay, behavior, block, dependencies]);
+}


### PR DESCRIPTION
### Summary

Add a read-only glossary page to the editor. Clicking on glossary instance links will send user to entries on this page, while clicking on "View full entry" within a glossary instance will send the user to the authority page.

### Linear

- part of [DEV-328](https://linear.app/your-project/issue/DEV-328)
