### PR TITLE
check if user has edit permissions for the editor, part of dev-336

### DIFF
--- a/libs/data-access/src/lib/auth.ts
+++ b/libs/data-access/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { jwtDecode } from 'jwt-decode';
-import { DataClient, UserClaims, UserRole } from './types';
+import { DataClient, UserClaims, UserPermission, UserRole } from './types';
 
 export const getSession = async ({ client }: { client: DataClient }) => {
   const { data, error } = await client.auth.getSession();
@@ -67,6 +67,23 @@ export const getUser = async ({ client }: { client: DataClient }) => {
     role,
     subscriptions: subsArray,
   };
+};
+
+export const hasPermission = async ({
+  client,
+  permission,
+}: {
+  client: DataClient;
+  permission: UserPermission;
+}) => {
+  const { data, error } = await client.rpc('authorize', {
+    requested_permission: permission,
+  });
+  if (error) {
+    console.error(`Failed to check permission: ${error.message}`);
+    return false;
+  }
+  return data as boolean;
 };
 
 export const loginWithGoogle = async ({

--- a/libs/data-access/src/lib/types/user.ts
+++ b/libs/data-access/src/lib/types/user.ts
@@ -2,3 +2,14 @@ export type UserRole = 'reader' | 'scholar' | 'translator' | 'editor' | 'admin';
 export type UserClaims = {
   role: UserRole;
 };
+
+export const USER_PERMISIONS = [
+  'projects.read',
+  'projects.edit',
+  'projects.admin',
+  'editor.read',
+  'editor.edit',
+  'editor.admin',
+];
+
+export type UserPermission = (typeof USER_PERMISIONS)[number];

--- a/libs/lib-editing/src/lib/components/editor/PassagesEditor.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PassagesEditor.tsx
@@ -13,6 +13,7 @@ import { blocksFromTranslationBody } from '../../block';
 export const PassagesEditor = ({
   passages,
   fragment,
+  isEditable = true,
   className,
   onCreate,
   fetchEndNote,
@@ -20,6 +21,7 @@ export const PassagesEditor = ({
 }: {
   passages: Passage[];
   fragment: XmlFragment;
+  isEditable?: boolean;
   className?: string;
   onCreate?: (params: { editor: Editor }) => void;
   fetchEndNote?: (
@@ -39,6 +41,7 @@ export const PassagesEditor = ({
   return (
     <TranslationEditor
       content={content}
+      isEditable={isEditable}
       className={className}
       fragment={fragment}
       onCreate={onCreate}

--- a/libs/lib-editing/src/lib/components/page/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/page/EditorProvider.tsx
@@ -21,6 +21,7 @@ import {
   createBrowserClient,
   getGlossaryInstance,
   getPassage,
+  hasPermission,
   savePassages,
 } from '@data-access';
 import { blockFromPassage } from '../../block';
@@ -34,6 +35,7 @@ interface EditorContextState {
   builder: EditorMenuItemType;
   dirtyUuids: string[];
   work: Work;
+  canEdit(): Promise<boolean>;
   getFragment: () => XmlFragment;
   fetchEndNote: (uuid: string) => Promise<TranslationEditorContent | undefined>;
   fetchGlossaryTerm: (
@@ -60,6 +62,9 @@ export const EditorContext = createContext<EditorContextState>({
   },
   builder: 'translation',
   dirtyUuids: [],
+  canEdit: async () => {
+    throw Error('Not implemented');
+  },
   getFragment: () => {
     throw Error('Not implemented');
   },
@@ -235,6 +240,10 @@ export const EditorContextProvider = ({
     [stopObserving],
   );
 
+  const canEdit = useCallback(async () => {
+    return await hasPermission({ client, permission: 'editor.edit' });
+  }, [client]);
+
   useEffect(() => {
     const nextPath = `/publications/editor/${uuid}/${builder}`;
 
@@ -262,6 +271,7 @@ export const EditorContextProvider = ({
         doc,
         editor,
         dirtyUuids,
+        canEdit,
         getFragment,
         fetchEndNote,
         fetchGlossaryTerm,

--- a/libs/lib-editing/src/lib/components/page/builder/CollaborativeBuilder.tsx
+++ b/libs/lib-editing/src/lib/components/page/builder/CollaborativeBuilder.tsx
@@ -28,11 +28,13 @@ export const CollaborativeBuilder = ({
   const [body, setBody] = useState<Passage[]>();
   const [fragment, setFragment] = useState<XmlFragment>();
   const [isObserving, setIsObserving] = useState(false);
+  const [isEditable, setIsEditable] = useState(false);
   const [loading, setLoading] = useState(true);
 
   const {
     uuid,
     builder: currentBuilder,
+    canEdit,
     setEditor,
     startObserving,
     getFragment,
@@ -53,9 +55,13 @@ export const CollaborativeBuilder = ({
       const body = await fetchContent({ client, uuid });
 
       if (!body) {
+        setLoading(false);
         return;
       }
 
+      const isEditable = await canEdit();
+
+      setIsEditable(isEditable);
       setBody(body);
       setLoading(false);
     };
@@ -68,6 +74,7 @@ export const CollaborativeBuilder = ({
     currentBuilder,
     client,
     builder,
+    canEdit,
     getFragment,
     fetchContent,
   ]);
@@ -81,6 +88,7 @@ export const CollaborativeBuilder = ({
       passages={body}
       className={WRAPPER_CLASS}
       fragment={getFragment()}
+      isEditable={isEditable}
       fetchEndNote={fetchEndNote}
       fetchGlossaryInstance={fetchGlossaryTerm}
       onCreate={({ editor }) => {

--- a/libs/lib-editing/src/lib/components/page/builder/TitlesBuilder.tsx
+++ b/libs/lib-editing/src/lib/components/page/builder/TitlesBuilder.tsx
@@ -13,33 +13,39 @@ const WRAPPER_CLASS =
 
 export const TitlesBuilder = () => {
   const [content, setContent] = useState<BlockEditorContent>();
+  const [isEditable, setIsEditable] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  const { uuid } = useEditorState();
+  const { uuid, canEdit } = useEditorState();
 
   useEffect(() => {
     const getTitles = async () => {
-      const client = createBrowserClient();
-      const titles = await getTranslationTitles({ client, uuid });
-
-      setLoading(false);
-
-      if (!titles) {
+      if (!loading) {
         return;
       }
 
+      const client = createBrowserClient();
+      const titles = await getTranslationTitles({ client, uuid });
       const doc = titlesToDocument(titles);
+      const editable = await canEdit();
+
+      setIsEditable(editable);
       setContent(doc);
+      setLoading(false);
     };
     getTitles();
-  }, [uuid]);
+  }, [uuid, loading, canEdit]);
 
   if (!content && !loading) {
     return notFound();
   }
 
   return content ? (
-    <TitlesEditor className={WRAPPER_CLASS} content={content} />
+    <TitlesEditor
+      isEditable={isEditable}
+      className={WRAPPER_CLASS}
+      content={content}
+    />
   ) : (
     <TranslationSkeleton className={WRAPPER_CLASS} />
   );


### PR DESCRIPTION
### Summary

The editor routes have been protected by role for awhile. So is the underlying data at the database level. However, once a user landed in the editor, the editor previously appeared to allow editing. Now, the applications verifies the user has `editor.edit` access when in the editor ui. If they do not have that access, the UI is read-only.

### Linear

- [DEV-336](https://linear.app/84000/issue/DEV-336)
