### PR TITLE
Fix Glossary Instance Editing

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/extensions/EndNoteLink/EndNoteLink.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/extensions/EndNoteLink/EndNoteLink.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react';
 import TranslationEditor, {
   TranslationEditorContent,
 } from '../../TranslationEditor';
-import { ensureNodeUuid } from '../../../util';
+import { validateAttrs } from '../../../util';
 
 export const EndNoteCard = ({
   uuid,
@@ -74,7 +74,7 @@ export const EndNoteLink = ({
   }, [editor.state.doc, getPos, node.type.name]);
 
   useEffect(() => {
-    ensureNodeUuid({ node, editor, getPos, updateAttributes });
+    validateAttrs({ node, editor, getPos, updateAttributes });
   }, [node, editor, getPos, updateAttributes]);
 
   const className = editor.isEditable

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/extensions/GlossaryInstance/GlossaryInstance.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/extensions/GlossaryInstance/GlossaryInstance.tsx
@@ -8,7 +8,7 @@ import {
 import { useEffect, useState } from 'react';
 import { GlossaryTermInstance } from '@data-access';
 import { usePathname } from 'next/navigation';
-import { ensureNodeUuid } from '../../../util';
+import { validateAttrs } from '../../../util';
 import { GlossaryInstanceBody } from '../../../../page';
 import Link from 'next/link';
 
@@ -55,7 +55,7 @@ export const GlossaryInstance = ({
   ) => Promise<GlossaryTermInstance | undefined>;
 
   useEffect(() => {
-    ensureNodeUuid({ node, editor, getPos, updateAttributes });
+    validateAttrs({ node, editor, getPos, updateAttributes });
   }, [node, editor, getPos, updateAttributes]);
 
   useEffect(() => {

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/extensions/Passage/Passage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/extensions/Passage/Passage.tsx
@@ -1,29 +1,25 @@
 import { cn } from '@lib-utils';
-import { useEffect, type ChangeEvent, type FocusEvent } from 'react';
+import type { ChangeEvent, FocusEvent } from 'react';
 import type { NodeViewProps } from '@tiptap/react';
-import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
-import { ensureNodeUuid } from '../../../util';
+import { NodeWrapper } from '../../../extensions/NodeWrapper';
 
-export const Passage = ({
-  node,
-  editor,
-  getPos,
-  updateAttributes,
-}: NodeViewProps) => {
+export const Passage = (props: NodeViewProps) => {
+  const { node, editor, updateAttributes } = props;
+
   const updateLabel = (
     event: ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>,
   ) => {
     updateAttributes({ label: event.target.value });
   };
 
-  useEffect(() => {
-    ensureNodeUuid({ node, editor, getPos, updateAttributes });
-  }, [node, editor, getPos, updateAttributes]);
-
   const className =
     'absolute -left-16 w-16 text-end text-slate hover:cursor-pointer';
   return (
-    <NodeViewWrapper className="passage relative leading-7 ml-6">
+    <NodeWrapper
+      className="passage relative leading-7 ml-6"
+      innerClassName="content is-editable pl-6"
+      {...props}
+    >
       {editor.isEditable ? (
         <input
           className={cn(className, 'px-1 placeholder:text-slate-100')}
@@ -39,8 +35,7 @@ export const Passage = ({
           {node.attrs.label || ''}
         </div>
       )}
-      <NodeViewContent className="content is-editable pl-6" />
-    </NodeViewWrapper>
+    </NodeWrapper>
   );
 };
 

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/selectors/GlossarySelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/selectors/GlossarySelector.tsx
@@ -43,16 +43,11 @@ export const GlossarySelector = ({ editor }: { editor: Editor }) => {
         <SelectorInputField
           editor={editor}
           type="glossaryInstance"
-          attr="authority"
-          placeholder="Add authority uuid..."
+          attr="glossary"
+          placeholder="Add glossary uuid..."
           onSubmit={(value) => {
             if (value) {
-              editor
-                .chain()
-                .focus()
-                .extendMarkRange('glossaryInstance')
-                .setGlossaryInstance(value)
-                .run();
+              editor.chain().focus().setGlossaryInstance(value).run();
             } else {
               editor.chain().focus().unsetGlossaryInstance().run();
             }

--- a/libs/lib-editing/src/lib/components/editor/extensions/Heading/Heading.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Heading/Heading.ts
@@ -1,55 +1,10 @@
-import { mergeAttributes } from '@tiptap/core';
 import TiptapHeading from '@tiptap/extension-heading';
-import type { Level } from '@tiptap/extension-heading';
-import {
-  H1_STYLE,
-  H2_STYLE,
-  H3_STYLE,
-  H4_STYLE,
-  H5_STYLE,
-} from '@design-system';
-
-const classForLevel: Record<Level, string> = {
-  1: H1_STYLE,
-  2: H2_STYLE,
-  3: H3_STYLE,
-  4: H4_STYLE,
-  5: H5_STYLE,
-  6: H5_STYLE,
-};
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import { HeadingView } from './HeadingView';
 
 export const Heading = TiptapHeading.extend({
-  addAttributes() {
-    return {
-      ...this.parent?.(),
-      class: {
-        default: null,
-        parseHTML: (element) => element.getAttribute('data-class'),
-        renderHTML: (attributes) => {
-          if (!attributes.class) {
-            return {};
-          }
-          return { 'data-class': attributes.class };
-        },
-      },
-    };
-  },
-
-  renderHTML({ node, HTMLAttributes }) {
-    const nodeLevel = parseInt(node.attrs.level, 10) as Level;
-    const hasLevel = this.options.levels.includes(nodeLevel);
-    const level = hasLevel ? nodeLevel : this.options.levels[0];
-
-    this.options.HTMLAttributes = {
-      ...this.options.HTMLAttributes,
-      class: classForLevel[level],
-    };
-
-    return [
-      `h${level}`,
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
-      0,
-    ];
+  addNodeView() {
+    return ReactNodeViewRenderer(HeadingView);
   },
 });
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Heading/HeadingView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Heading/HeadingView.tsx
@@ -1,0 +1,33 @@
+import { NodeViewProps } from '@tiptap/react';
+import type { Level } from '@tiptap/extension-heading';
+import {
+  H1_STYLE,
+  H2_STYLE,
+  H3_STYLE,
+  H4_STYLE,
+  H5_STYLE,
+} from '@design-system';
+import { NodeWrapper } from '../NodeWrapper';
+import { JSX } from 'react';
+
+const CLASS_FOR_LEVEL: Record<Level, string> = {
+  1: H1_STYLE,
+  2: H2_STYLE,
+  3: H3_STYLE,
+  4: H4_STYLE,
+  5: H5_STYLE,
+  6: H5_STYLE,
+};
+
+export const HeadingView = (props: NodeViewProps) => {
+  const { node, extension } = props;
+  const nodeLevel = parseInt(node.attrs.level, 10) as Level;
+  const hasLevel = extension.options.levels.includes(nodeLevel);
+  const level = hasLevel ? nodeLevel : extension.options.levels[0];
+  const element = `h${level}` as keyof JSX.IntrinsicElements;
+  const className = CLASS_FOR_LEVEL[nodeLevel];
+
+  return (
+    <NodeWrapper {...props} contentAs={element} innerClassName={className} />
+  );
+};

--- a/libs/lib-editing/src/lib/components/editor/extensions/NodeWrapper.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/NodeWrapper.tsx
@@ -1,0 +1,57 @@
+import {
+  NodeViewContent,
+  NodeViewProps,
+  NodeViewRendererOptions,
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+} from '@tiptap/react';
+import { JSX, ReactNode, useEffect } from 'react';
+import { validateAttrs } from '../util';
+
+export interface NodeWrapperProps extends NodeViewProps {
+  className?: string;
+  innerClassName?: string;
+  children?: ReactNode;
+  wrapperAs?: keyof JSX.IntrinsicElements;
+  contentAs?: keyof JSX.IntrinsicElements;
+}
+
+export const NodeWrapper = ({
+  node,
+  editor,
+  className,
+  innerClassName,
+  children,
+  wrapperAs = 'div',
+  contentAs = 'div',
+  getPos,
+  updateAttributes,
+}: NodeWrapperProps) => {
+  useEffect(() => {
+    validateAttrs({ node, editor, getPos, updateAttributes });
+  }, [node, editor, getPos, updateAttributes]);
+
+  return (
+    <NodeViewWrapper as={wrapperAs} className={className}>
+      {children}
+      {/* @ts-expect-error: NodeViewContent is only typed for div, but any element works */}
+      <NodeViewContent as={contentAs} className={innerClassName} />
+    </NodeViewWrapper>
+  );
+};
+
+export interface CreateNodeWrapperOptions extends NodeViewRendererOptions {
+  className?: string;
+  innerClassName?: string;
+  children?: ReactNode;
+  wrapperAs?: keyof JSX.IntrinsicElements;
+  contentAs?: keyof JSX.IntrinsicElements;
+}
+
+export const createNodeWrapper = (
+  options: Partial<Omit<NodeWrapperProps, keyof NodeViewProps>> = {},
+) => {
+  return ReactNodeViewRenderer((props: NodeViewProps) => (
+    <NodeWrapper {...props} {...options} />
+  ));
+};

--- a/libs/lib-editing/src/lib/components/editor/extensions/Paragraph/ParagraphView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Paragraph/ParagraphView.tsx
@@ -1,20 +1,6 @@
-import { NodeViewContent, NodeViewProps, NodeViewWrapper } from '@tiptap/react';
-import { useEffect } from 'react';
-import { ensureNodeUuid } from '../../util';
+import { NodeViewProps } from '@tiptap/react';
+import { NodeWrapper } from '../NodeWrapper';
 
-export const ParagraphView = ({
-  node,
-  editor,
-  getPos,
-  updateAttributes,
-}: NodeViewProps) => {
-  useEffect(() => {
-    ensureNodeUuid({ node, editor, getPos, updateAttributes });
-  }, [node, editor, getPos, updateAttributes]);
-
-  return (
-    <NodeViewWrapper className="leading-7 mb-1 mt-2">
-      <NodeViewContent />
-    </NodeViewWrapper>
-  );
+export const ParagraphView = (props: NodeViewProps) => {
+  return <NodeWrapper {...props} className="leading-7 mb-1 mt-2" />;
 };

--- a/libs/lib-editing/src/lib/components/editor/menus/SelectorInputField.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/SelectorInputField.tsx
@@ -37,7 +37,7 @@ export const SelectorInputField = ({
       <Input
         ref={inputRef}
         placeholder={placeholder}
-        defaultValue={editorState.getValue}
+        value={editorState.getValue}
       />
       {editorState.isActive ? (
         <Button

--- a/libs/lib-editing/src/lib/components/editor/util.ts
+++ b/libs/lib-editing/src/lib/components/editor/util.ts
@@ -42,7 +42,7 @@ export const validateAttrs = async ({
     };
 
     // reset all global attributes to default values
-    if (attrs.leadSpaceUuid) {
+    if (attrs.leadingSpaceUuid) {
       attrs.leadSpaceUuid = undefined;
     }
 

--- a/libs/lib-editing/src/lib/components/editor/util.ts
+++ b/libs/lib-editing/src/lib/components/editor/util.ts
@@ -1,7 +1,14 @@
 import { NodeViewProps } from '@tiptap/react';
 import { v4 as uuidv4 } from 'uuid';
 
-export const ensureNodeUuid = async ({
+/**
+ * Validates and updates the attributes of a Node.
+ * Specifically, it ensures that the node has a unique 'uuid' attribute.
+ * If the 'uuid' is missing or duplicates the previous node's 'uuid',
+ * a new UUID is generated and assigned. In the case of duplication, all
+ * global attributes are set to their default values.
+ */
+export const validateAttrs = async ({
   node,
   editor,
   getPos,
@@ -29,6 +36,40 @@ export const ensureNodeUuid = async ({
   }
 
   if (index > 0 && parent.child(index - 1).attrs.uuid === node.attrs.uuid) {
-    updateAttributes?.({ uuid: uuidv4() });
+    const attrs: { [attr: string]: unknown } = {
+      ...node.attrs,
+      uuid: uuidv4(),
+    };
+
+    // reset all global attributes to default values
+    if (attrs.leadSpaceUuid) {
+      attrs.leadSpaceUuid = undefined;
+    }
+
+    if (attrs.hasLeadingSpace) {
+      attrs.hasLeadingSpace = false;
+    }
+
+    if (attrs.indentUuid) {
+      attrs.indentUuid = undefined;
+    }
+
+    if (attrs.hasIndent) {
+      attrs.hasIndent = false;
+    }
+
+    if (attrs.trailerUuid) {
+      attrs.trailingSpaceUuid = undefined;
+    }
+
+    if (attrs.hasTrailer) {
+      attrs.hasTrailingSpace = false;
+    }
+
+    if (attrs.hasParagraphIndent) {
+      attrs.hasParagraphIndent = false;
+    }
+
+    updateAttributes?.(attrs);
   }
 };

--- a/libs/lib-editing/src/lib/exporters/italic.ts
+++ b/libs/lib-editing/src/lib/exporters/italic.ts
@@ -28,7 +28,7 @@ export const italic: Exporter<
   const uuid = mark?.attrs.uuid;
   const type = mark?.attrs.type as AnnotationType;
   const textContent = node.textContent || parent.textContent || '';
-  const textStyle = mark?.attrs.textStyle as string | 'emphasis';
+  const textStyle = (mark?.attrs.textStyle as string) || 'emphasis';
   const lang = mark?.attrs.lang as ExtendedTranslationLanguage;
   const end = start + textContent.length;
 

--- a/libs/lib-editing/src/lib/transformers/span.ts
+++ b/libs/lib-editing/src/lib/transformers/span.ts
@@ -41,7 +41,7 @@ export const span: Transformer = (ctx) => {
 
   recurse({
     ...ctx,
-    until: ['text'],
+    until: ['text', 'glossaryInstance'],
     transform: (ctx) => {
       splitContent({
         ...ctx,

--- a/libs/lib-editing/src/lib/transformers/split-block.ts
+++ b/libs/lib-editing/src/lib/transformers/split-block.ts
@@ -3,6 +3,7 @@ import { isBlockAnnotation } from './annotate';
 import { splitNode } from './split-node';
 import { Transformer } from './transformer';
 import { BlockEditorContentItem } from '../components/editor';
+import { filterAttrs } from './util';
 
 export const splitBlock: Transformer = ({
   root,
@@ -58,13 +59,14 @@ export const splitBlock: Transformer = ({
     suffixContent.push(...suffix);
   }
 
+  const attrs = filterAttrs(block.attrs);
   const newBlocks: BlockEditorContentItem[] = [];
   if (prefixContent.length) {
     newBlocks.push({
       ...block,
       content: prefixContent,
       attrs: {
-        ...block.attrs,
+        ...attrs,
         start: prefixContent[0].attrs?.start ?? 0,
         end: prefixContent[prefixContent.length - 1].attrs?.end ?? 0,
       },
@@ -77,7 +79,7 @@ export const splitBlock: Transformer = ({
       type: annotation.type,
       content: midContent,
       attrs: {
-        ...block.attrs,
+        ...attrs,
         start: midContent[0].attrs?.start ?? annStart,
         end: midContent[midContent.length - 1].attrs?.end ?? annEnd,
         uuid: annotation.uuid,
@@ -97,7 +99,7 @@ export const splitBlock: Transformer = ({
       ...block,
       content: suffixContent,
       attrs: {
-        ...block.attrs,
+        ...attrs,
         start: suffixContent[0].attrs?.start ?? 0,
         end: suffixContent[suffixContent.length - 1].attrs?.end ?? 0,
       },

--- a/libs/lib-editing/src/lib/transformers/split-content.ts
+++ b/libs/lib-editing/src/lib/transformers/split-content.ts
@@ -3,6 +3,7 @@ import { isInlineAnnotation } from './annotate';
 import { Transformer } from './transformer';
 import { splitNode } from './split-node';
 import type { BlockEditorContentItem } from '../components/editor';
+import { filterAttrs } from './util';
 
 export const splitContent: Transformer = ({
   root,
@@ -29,6 +30,7 @@ export const splitContent: Transformer = ({
   const annEndAbs = annotation.end;
   const currentContent = parent.content || [];
   const newContent = [];
+  const attrs = filterAttrs(block.attrs);
 
   for (const item of currentContent) {
     const { prefix, middle, suffix } = splitNode(item, annStartAbs, annEndAbs);
@@ -47,11 +49,11 @@ export const splitContent: Transformer = ({
     newContent.push(...suffix);
   }
 
-  if (annStartAbs === annEndAbs && annStartAbs === block.attrs?.end) {
+  if (annStartAbs === annEndAbs && annStartAbs === attrs?.end) {
     const newBlock: BlockEditorContentItem = {
       type: annotation.type,
       attrs: {
-        ...block.attrs,
+        ...attrs,
         start: annStartAbs,
         end: annEndAbs,
       },

--- a/libs/lib-editing/src/lib/transformers/split-insert.ts
+++ b/libs/lib-editing/src/lib/transformers/split-insert.ts
@@ -1,6 +1,7 @@
 import { Transformer } from './transformer';
 import { splitNode } from './split-node';
 import type { BlockEditorContentItem } from '../components/editor';
+import { filterAttrs } from './util';
 
 export const sort = (nodes: BlockEditorContentItem[]) => {
   return nodes.sort((a, b) => (a.attrs?.start ?? 0) - (b.attrs?.start ?? 0));
@@ -36,7 +37,7 @@ export const splitAndInsert: Transformer = (ctx) => {
   const newBlock: BlockEditorContentItem = {
     type: annotation.type,
     attrs: {
-      ...block.attrs,
+      ...filterAttrs(block.attrs),
       start,
       end,
     },

--- a/libs/lib-editing/src/lib/transformers/split-node.ts
+++ b/libs/lib-editing/src/lib/transformers/split-node.ts
@@ -1,4 +1,5 @@
 import type { BlockEditorContentItem } from '../components/editor';
+import { filterAttrs } from './util';
 
 type SplitBlock = {
   prefix: BlockEditorContentItem[];
@@ -40,6 +41,7 @@ export function splitNode(
   const postStartIdx = preLen + midLen;
 
   const splits: SplitBlock = { prefix: [], middle: [], suffix: [] };
+  const attrs = filterAttrs(item.attrs);
 
   if (preLen > 0) {
     const preText = text.slice(0, preLen);
@@ -48,7 +50,7 @@ export function splitNode(
         ...item,
         text: preText,
         attrs: {
-          ...item.attrs,
+          ...attrs,
           start: itemStart,
           end: itemStart + preText.length,
         },
@@ -63,7 +65,7 @@ export function splitNode(
         ...item,
         text: midText,
         attrs: {
-          ...item.attrs,
+          ...attrs,
           start: itemStart + preLen,
           end: itemStart + preLen + midText.length,
         },
@@ -78,7 +80,7 @@ export function splitNode(
         ...item,
         text: postText,
         attrs: {
-          ...item.attrs,
+          ...attrs,
           start: itemStart + postStartIdx,
           end: itemStart + text.length,
         },

--- a/libs/lib-editing/src/lib/transformers/util.ts
+++ b/libs/lib-editing/src/lib/transformers/util.ts
@@ -1,0 +1,20 @@
+const ATTRS_TO_IGNORE = [
+  'hasLeadingSpace',
+  'leadingSpaceUuid',
+  'hasIndent',
+  'indentUuid',
+  'hasTrailingSpace',
+  'trailingSpaceUuid',
+  'hasParagraphIndent',
+  'uuid',
+];
+
+export const filterAttrs = (attrs: Record<string, unknown> | undefined) => {
+  if (!attrs) {
+    return attrs;
+  }
+
+  return Object.fromEntries(
+    Object.entries(attrs).filter(([key]) => !ATTRS_TO_IGNORE.includes(key)),
+  );
+};


### PR DESCRIPTION
### Summary

After glossary instances were turned into inline nodes instead of marks in the editor, the ability to manage them in the UI broke. This restores that basic functionality. A few additional issues were addressed along the way:

- Do not pass some attributes to child nodes when parsing database content. This can break saving if uuids for attribute based annotations like indentation and leading space are duplicated.
- Reset values for attribute based annotations when splitting a node. This breaks saving for the same reason.
- When parsing, allow `span` annotations to be inside `glossaryInstance` annotations now that they are inline nodes instead of marks.
- Define a react wrapper for custom nodes that enforces and validates global attributes.

### Linear

- [DEV-337](https://linear.app/84000/issue/DEV-337)

### Notes

The editing experience can be improved more, but that will wait until the layout it updated to be multi-column. Then editing things like links and glossary instances can feel a lot more like Notion.
