### PR TITLE
Link editing

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/BlockEditor/hooks/useDefaultExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/BlockEditor/hooks/useDefaultExtensions.ts
@@ -6,7 +6,7 @@ import Heading from '../../extensions/Heading/Heading';
 import Paragraph from '../../extensions/Paragraph/Paragraph';
 import { SlashCommand } from '../../extensions/SlashCommand/SlashCommand';
 import { getSuggestion } from '../../extensions/SlashCommand/Suggestions';
-import Link from '../../extensions/Link';
+import { Link } from '../../extensions/Link';
 import Placeholder from '../../extensions/Placeholder';
 import TextAlign from '../../extensions/TextAlign';
 import StarterKit from '../../extensions/StarterKit';

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/hooks/useTranslationExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/hooks/useTranslationExtensions.ts
@@ -18,7 +18,7 @@ import {
   TextSuggestion,
   getSuggestion,
 } from '../../extensions/SlashCommand/Suggestions';
-import Link from '../../extensions/Link';
+import { Link } from '../../extensions/Link';
 import Placeholder from '../../extensions/Placeholder';
 import TextAlign from '../../extensions/TextAlign';
 import { STARTER_KIT_CONFIG, StarterKit } from '../../extensions/StarterKit';

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/TranslationBubbleMenu.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/TranslationBubbleMenu.tsx
@@ -1,6 +1,8 @@
 import { Editor } from '@tiptap/core';
+// @ts-expect-error: The docs say to import this but it throws an error.
 import { BubbleMenu } from '@tiptap/react/menus';
 import { ScrollArea, Separator, ScrollBar } from '@design-system';
+import { EditorState } from 'prosemirror-state';
 import { TextButtons } from './selectors/TextButtons';
 import { ParagraphButtons } from './selectors/ParagraphButtons';
 import { NodeSelector } from './selectors/NodeSelector';
@@ -21,7 +23,13 @@ export const TranslationBubbleMenu = ({
         placement: 'top',
         offset: 6,
       }}
-      shouldShow={({ editor, state }) => {
+      shouldShow={({
+        editor,
+        state,
+      }: {
+        editor: Editor;
+        state: EditorState;
+      }) => {
         const { selection } = state;
         const { empty } = selection;
 
@@ -40,7 +48,7 @@ export const TranslationBubbleMenu = ({
         return true;
       }}
     >
-      <ScrollArea className="max-w-[90vw] rounded-md border bg-popover shadow-xl">
+      <ScrollArea className="max-w-[90vw] rounded-md border bg-popover shadow-xl z-10">
         <div className="flex">
           <NodeSelector editor={editor} />
           <Separator orientation="vertical" className="h-10" />

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/TranslationBubbleMenu.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/TranslationBubbleMenu.tsx
@@ -1,8 +1,6 @@
 import { Editor } from '@tiptap/core';
-// @ts-expect-error: The docs say to import this but it throws an error.
 import { BubbleMenu } from '@tiptap/react/menus';
 import { ScrollArea, Separator, ScrollBar } from '@design-system';
-import { EditorState } from 'prosemirror-state';
 import { TextButtons } from './selectors/TextButtons';
 import { ParagraphButtons } from './selectors/ParagraphButtons';
 import { NodeSelector } from './selectors/NodeSelector';
@@ -23,13 +21,7 @@ export const TranslationBubbleMenu = ({
         placement: 'top',
         offset: 6,
       }}
-      shouldShow={({
-        editor,
-        state,
-      }: {
-        editor: Editor;
-        state: EditorState;
-      }) => {
+      shouldShow={({ editor, state }) => {
         const { selection } = state;
         const { empty } = selection;
 

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/selectors/LinkSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/selectors/LinkSelector.tsx
@@ -54,7 +54,7 @@ export const LinkSelector = ({ editor }: { editor: Editor }) => {
                 .setLink({ href: value })
                 .run();
             } else {
-              editor.chain().focus().unsetLink().run();
+              editor.chain().focus().extendMarkRange('link').unsetLink().run();
             }
           }}
         />

--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/selectors/TextButtons.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor/menu/selectors/TextButtons.tsx
@@ -27,43 +27,55 @@ interface SelectorResult {
 const items = [
   {
     icon: BoldIcon,
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleBold().run();
+    onClick: (editor: Editor, state: SelectorResult) => {
+      state.isBold
+        ? editor.chain().focus().unsetBold().run()
+        : editor.chain().focus().setBold().run();
     },
     isActive: (state: SelectorResult) => state.isBold,
   },
   {
     icon: ItalicIcon,
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleItalic().run();
+    onClick: (editor: Editor, state: SelectorResult) => {
+      state.isItalic
+        ? editor.chain().focus().unsetItalic().run()
+        : editor.chain().focus().setItalic().run();
     },
     isActive: (state: SelectorResult) => state.isItalic,
   },
   {
     icon: UnderlineIcon,
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleUnderline().run();
+    onClick: (editor: Editor, state: SelectorResult) => {
+      state.isUnderline
+        ? editor.chain().focus().unsetUnderline().run()
+        : editor.chain().focus().setUnderline().run();
     },
     isActive: (state: SelectorResult) => state.isUnderline,
   },
   {
     icon: SubscriptIcon,
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleSubscript().run();
+    onClick: (editor: Editor, state: SelectorResult) => {
+      state.isSubscript
+        ? editor.chain().focus().unsetSubscript().run()
+        : editor.chain().focus().setSubscript().run();
     },
     isActive: (state: SelectorResult) => state.isSubscript,
   },
   {
     icon: SuperscriptIcon,
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleSuperscript().run();
+    onClick: (editor: Editor, state: SelectorResult) => {
+      state.isSuperscript
+        ? editor.chain().focus().unsetSuperscript().run()
+        : editor.chain().focus().setSuperscript().run();
     },
     isActive: (state: SelectorResult) => state.isSuperscript,
   },
   {
     icon: CaseUpperIcon,
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleSmallCaps().run();
+    onClick: (editor: Editor, state: SelectorResult) => {
+      state.isSmallCaps
+        ? editor.chain().focus().unsetSmallCaps().run()
+        : editor.chain().focus().setSmallCaps().run();
     },
     isActive: (state: SelectorResult) => state.isSmallCaps,
   },
@@ -92,13 +104,16 @@ export const TextButtons = ({ editor }: { editor: Editor }) => {
             size="icon"
             className="rounded-none flex-shrink-0"
             onClick={() => {
-              item.onClick(editor);
+              item.onClick(editor, editorState);
             }}
           >
             <item.icon
-              className={cn('size-4', {
-                'text-primary': item.isActive(editorState),
-              })}
+              className={cn(
+                'size-4',
+                item.isActive(editorState)
+                  ? 'text-primary'
+                  : 'text-muted-foreground',
+              )}
               strokeWidth={2.5}
             />
           </Button>

--- a/libs/lib-editing/src/lib/components/editor/extensions/HoverInputField.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/HoverInputField.tsx
@@ -1,37 +1,26 @@
 import { Button, Input } from '@design-system';
-import { Editor } from '@tiptap/core';
-import { useEditorState } from '@tiptap/react';
 import { CheckIcon, Trash2Icon } from 'lucide-react';
 import { useRef } from 'react';
 
-export const SelectorInputField = ({
-  editor,
-  type,
-  attr,
+export const HoverInputField = ({
   placeholder,
+  valueRef,
   onSubmit,
 }: {
-  editor: Editor;
   type: string;
   attr: string;
+  valueRef: string;
   placeholder: string;
   onSubmit: (value?: string) => void;
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const editorState = useEditorState({
-    editor,
-    selector: (instance) => ({
-      isActive: instance.editor.isActive(type),
-      getValue: instance.editor.getAttributes(type)[attr],
-    }),
-  });
 
   return (
     <div className="flex space-x-1 items-center">
       <Input
         ref={inputRef}
         placeholder={placeholder}
-        value={editorState.getValue}
+        value={valueRef}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             e.preventDefault();
@@ -45,13 +34,12 @@ export const SelectorInputField = ({
         disabled={!!inputRef.current}
         onClick={() => onSubmit(inputRef.current?.value)}
       >
-        <CheckIcon className="size-4" />
+        <CheckIcon />
       </Button>
       <Button
         variant="ghost"
         size="icon"
         type="button"
-        disabled={!editorState.isActive}
         onClick={() => {
           if (inputRef.current) {
             inputRef.current.value = '';
@@ -59,7 +47,7 @@ export const SelectorInputField = ({
           onSubmit();
         }}
       >
-        <Trash2Icon className="size-4 text-destructive" />
+        <Trash2Icon className="text-destructive" />
       </Button>
     </div>
   );

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link.ts
@@ -7,9 +7,12 @@ export default Link.extend({
     const name = this.name;
     return {
       ...this.parent?.(),
-      setLink() {
+      setLink(attributes) {
         return ({ commands }) => {
-          return commands.setMark(name, { uuid: uuidv4() });
+          return commands.setMark(name, {
+            ...attributes,
+            uuid: uuidv4(),
+          });
         };
       },
       toggleLink() {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ts
@@ -1,8 +1,9 @@
-import { LINK_STYLE } from '@design-system';
-import Link from '@tiptap/extension-link';
+import { Link as TipTapLink } from '@tiptap/extension-link';
+import { ReactMarkViewRenderer } from '@tiptap/react';
 import { v4 as uuidv4 } from 'uuid';
+import { LinkView } from './LinkView';
 
-export default Link.extend({
+export const Link = TipTapLink.extend({
   addCommands() {
     const name = this.name;
     return {
@@ -22,9 +23,9 @@ export default Link.extend({
       },
     };
   },
-}).configure({
-  HTMLAttributes: {
-    class: LINK_STYLE,
+  addMarkView() {
+    return ReactMarkViewRenderer(LinkView);
   },
+}).configure({
   openOnClick: true,
 });

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
@@ -7,26 +8,103 @@ import {
 import { MarkViewContent, MarkViewProps } from '@tiptap/react';
 import { GlobeIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import Link from 'next/link';
+import { useCallback, useState } from 'react';
+import { findMarkByUuid } from '../../util';
+import { HoverInputField } from '../HoverInputField';
 
-export const LinkView = ({ mark }: MarkViewProps) => {
+const EDITOR_UPDATE_DELAY_MS = 100;
+
+export const LinkView = ({ mark, editor, updateAttributes }: MarkViewProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const deleteLink = useCallback(() => {
+    setIsOpen(false);
+    setIsEditing(false);
+
+    setTimeout(() => {
+      const range = findMarkByUuid({ editor, mark });
+      if (!range) {
+        console.warn('Link mark not found in the document.');
+        return;
+      }
+
+      const { from, to } = range;
+      const { tr } = editor.state;
+      tr.removeMark(from, to, mark.type);
+      editor.view.dispatch(tr);
+    }, EDITOR_UPDATE_DELAY_MS);
+  }, [mark, editor]);
+
+  const updateLink = useCallback(
+    (href: string) => {
+      setIsOpen(false);
+      setIsEditing(false);
+
+      setTimeout(() => {
+        updateAttributes?.({ href });
+      }, EDITOR_UPDATE_DELAY_MS);
+    },
+    [updateAttributes],
+  );
+
+  const Content = <MarkViewContent className={LINK_STYLE} />;
+
+  if (!editor.isEditable) {
+    return Content;
+  }
+
   return (
-    <HoverCard>
+    <HoverCard open={isOpen} onOpenChange={setIsOpen}>
       <HoverCardTrigger asChild>
         <Link href={mark.attrs.href} target="_blank" rel="noreferrer">
-          <MarkViewContent className={LINK_STYLE} />
+          {Content}
         </Link>
       </HoverCardTrigger>
       <HoverCardContent
         align="start"
-        className="flex justify-between gap-2 p-2 w-fit max-w-64"
+        className="flex justify-between gap-2 p-2 w-fit max-w-72"
       >
-        <GlobeIcon size={14} className="text-muted-foreground my-auto" />
-        <span className="truncate text-muted-foreground text-sm">
-          {mark.attrs.href}
-        </span>
-        <span className="flex-grow" />
-        <PencilIcon size={14} className="text-primary my-auto" />
-        <Trash2Icon size={14} className="text-destructive my-auto" />
+        {isEditing ? (
+          <HoverInputField
+            type="link"
+            attr="href"
+            valueRef={mark.attrs.href}
+            placeholder="Add link..."
+            onSubmit={(value) => {
+              if (value) {
+                updateLink(value);
+              } else {
+                deleteLink();
+              }
+              setIsEditing(false);
+            }}
+          />
+        ) : (
+          <>
+            <GlobeIcon className="text-muted-foreground my-auto size-4" />
+            <span className="truncate text-muted-foreground text-sm my-auto">
+              {mark.attrs.href}
+            </span>
+            <span className="flex-grow" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6 [&_svg]:size-4"
+              onClick={() => setIsEditing(true)}
+            >
+              <PencilIcon className="text-primary my-auto" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6 [&_svg]:size-4"
+              onClick={deleteLink}
+            >
+              <Trash2Icon className="text-destructive my-auto" />
+            </Button>
+          </>
+        )}
       </HoverCardContent>
     </HoverCard>
   );

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
@@ -9,7 +9,7 @@ import { MarkViewContent, MarkViewProps } from '@tiptap/react';
 import { GlobeIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback, useState } from 'react';
-import { findMarkByUuid } from '../../util';
+import { findMarkRange } from '../../util';
 import { HoverInputField } from '../HoverInputField';
 
 const EDITOR_UPDATE_DELAY_MS = 100;
@@ -23,7 +23,7 @@ export const LinkView = ({ mark, editor, updateAttributes }: MarkViewProps) => {
     setIsEditing(false);
 
     setTimeout(() => {
-      const range = findMarkByUuid({ editor, mark });
+      const range = findMarkRange({ editor, mark });
       if (!range) {
         console.warn('Link mark not found in the document.');
         return;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
@@ -1,0 +1,33 @@
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+  LINK_STYLE,
+} from '@design-system';
+import { MarkViewContent, MarkViewProps } from '@tiptap/react';
+import { GlobeIcon, PencilIcon, Trash2Icon } from 'lucide-react';
+import Link from 'next/link';
+
+export const LinkView = ({ mark }: MarkViewProps) => {
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        <Link href={mark.attrs.href} target="_blank" rel="noreferrer">
+          <MarkViewContent className={LINK_STYLE} />
+        </Link>
+      </HoverCardTrigger>
+      <HoverCardContent
+        align="start"
+        className="flex justify-between gap-2 p-2 w-fit max-w-64"
+      >
+        <GlobeIcon size={14} className="text-muted-foreground my-auto" />
+        <span className="truncate text-muted-foreground text-sm">
+          {mark.attrs.href}
+        </span>
+        <span className="flex-grow" />
+        <PencilIcon size={14} className="text-primary my-auto" />
+        <Trash2Icon size={14} className="text-destructive my-auto" />
+      </HoverCardContent>
+    </HoverCard>
+  );
+};

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/index.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/index.ts
@@ -1,0 +1,1 @@
+export * from './Link';

--- a/libs/lib-editing/src/lib/components/editor/menus/SelectorInputField.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/SelectorInputField.tsx
@@ -27,17 +27,17 @@ export const SelectorInputField = ({
   });
 
   return (
-    <form
-      className="flex space-x-1 items-center"
-      onSubmit={(evt) => {
-        evt.preventDefault();
-        onSubmit(inputRef.current?.value);
-      }}
-    >
+    <div className="flex space-x-1 items-center">
       <Input
         ref={inputRef}
         placeholder={placeholder}
         value={editorState.getValue}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            onSubmit(inputRef.current?.value);
+          }
+        }}
       />
       {editorState.isActive ? (
         <Button
@@ -54,10 +54,14 @@ export const SelectorInputField = ({
           <Trash2Icon className="size-4 text-destructive" />
         </Button>
       ) : (
-        <Button size="icon" variant="ghost">
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={() => onSubmit(inputRef.current?.value)}
+        >
           <CheckIcon className="size-4" />
         </Button>
       )}
-    </form>
+    </div>
   );
 };

--- a/libs/lib-editing/src/lib/components/editor/util.ts
+++ b/libs/lib-editing/src/lib/components/editor/util.ts
@@ -78,7 +78,7 @@ export const validateAttrs = async ({
  * Finds the range of a given mark in the editor's document by its reference.
  * Returns an object with 'from' and 'to' positions if found, otherwise undefined.
  */
-export const findMarkByUuid = ({ editor, mark }: Partial<MarkViewProps>) => {
+export const findMarkRange = ({ editor, mark }: Partial<MarkViewProps>) => {
   if (!editor || !mark) {
     return undefined;
   }

--- a/libs/lib-editing/src/lib/components/editor/util.ts
+++ b/libs/lib-editing/src/lib/components/editor/util.ts
@@ -1,4 +1,4 @@
-import { NodeViewProps } from '@tiptap/react';
+import { MarkViewProps, NodeViewProps } from '@tiptap/react';
 import { v4 as uuidv4 } from 'uuid';
 
 /**
@@ -72,4 +72,38 @@ export const validateAttrs = async ({
 
     updateAttributes?.(attrs);
   }
+};
+
+/**
+ * Finds the range of a given mark in the editor's document by its reference.
+ * Returns an object with 'from' and 'to' positions if found, otherwise undefined.
+ */
+export const findMarkByUuid = ({ editor, mark }: Partial<MarkViewProps>) => {
+  if (!editor || !mark) {
+    return undefined;
+  }
+
+  const { state } = editor;
+  const { doc, tr } = state;
+
+  let foundRange: { from: number; to: number } | undefined = undefined;
+
+  const thisMark = mark;
+  doc.descendants((node, pos) => {
+    let foundMark = false;
+    const from = tr.mapping.map(pos);
+    const to = from + node.nodeSize;
+
+    node.marks.forEach((m) => {
+      if (m === thisMark) {
+        foundMark = true;
+        foundRange = { from, to };
+        return;
+      }
+    });
+
+    return !foundMark;
+  });
+
+  return foundRange;
 };

--- a/libs/lib-editing/tsconfig.lib.json
+++ b/libs/lib-editing/tsconfig.lib.json
@@ -8,7 +8,8 @@
       "@nx/react/typings/image.d.ts",
       "next",
       "@nx/next/typings/image.d.ts"
-    ]
+    ],
+    "moduleResolution": "bundler"
   },
   "exclude": [
     "jest.config.ts",


### PR DESCRIPTION
### Summary

Links can now be editing with a Notion-like UI. When content is editable, users will see a hover card for links that provides access to editing the url or removing it. In the future, we can improve this by letting users edit the link text as well -- which Notion allows -- but that is a slightly larger effort.

Along the way, the editing of several other text styles, such as italics, bold, etc, has been fixed as well.

### Linear

<!-- A link to related Linear issues. -->
<!-- Remove if not applicable. -->

- completes [DEV-338](https://linear.app/84000/issue/DEV-338)
