### PR TITLE
Fix vertical scroll

### DIFF
--- a/libs/lib-editing/src/lib/components/shared/ThreeColumnRenderer.tsx
+++ b/libs/lib-editing/src/lib/components/shared/ThreeColumnRenderer.tsx
@@ -65,7 +65,6 @@ export const ThreeColumnRenderer = ({
         <MainPanel>{main}</MainPanel>
         <RightPanel>{right}</RightPanel>
       </ThreeColumns>
-      ;
     </>
   );
 };


### PR DESCRIPTION
### Summary

A rogue `;` found its way into the reader and editor UI that caused some wonky scrolling behavior. This removes it.
