### PR TITLE
Update glossary processing script

### DIFF
--- a/apps/node-scripts/src/fetch.ts
+++ b/apps/node-scripts/src/fetch.ts
@@ -5,12 +5,16 @@ export const fetchPage = async ({
   type,
   contentType,
   contentIndex = 0,
+  nullType = 'uuid',
+  nullIndex = 0,
   limit,
 }: {
   supabase: SupabaseClient;
   type: string;
   contentType: string;
   contentIndex?: 0 | 1;
+  nullType?: string;
+  nullIndex?: 0 | 1;
   limit: number;
 }) => {
   return await supabase
@@ -29,6 +33,7 @@ export const fetchPage = async ({
       `,
     )
     .eq('type', type)
-    .is('content->0->>"uuid"', null)
+    .is(`content->${nullIndex}->>"${nullType}"`, null)
+    .not(`content->${contentIndex}->>"${contentType}"`, 'is', null)
     .limit(limit);
 };

--- a/apps/node-scripts/src/migrate-glossary-instances.ts
+++ b/apps/node-scripts/src/migrate-glossary-instances.ts
@@ -15,6 +15,7 @@ const main = async () => {
       limit,
       type: 'glossary-instance',
       contentType: 'glossary_xmlId',
+      nullType: 'type',
     });
 
     if (error) {


### PR DESCRIPTION
### Summary

The `migrate-glossary-instances.ts` script now populates `glossary-instance` annotations with glossary uuids instead of authority uuids.

It has been run against the database, and all `glossary-instance` annotations now have a glossaries table uuid.
