### PR TITLE
More loading improvements

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/TranslationEditor.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationEditor.tsx
@@ -5,6 +5,7 @@ import type { XmlFragment } from 'yjs';
 import { useBlockEditor, useTranslationExtensions } from './hooks';
 import { TranslationBubbleMenu } from './menus';
 import { cn } from '@lib-utils';
+import { Passage } from '@data-access';
 
 export type TranslationEditorContentItem = JSONContent & {
   attrs?: {
@@ -32,9 +33,7 @@ export const TranslationEditor = ({
   isEditable?: boolean;
   className?: string;
   onCreate?: (params: { editor: Editor }) => void;
-  fetchEndNote?: (
-    uuid: string,
-  ) => Promise<TranslationEditorContent | undefined>;
+  fetchEndNote?: (uuid: string) => Promise<Passage | undefined>;
 }) => {
   const { extensions } = useTranslationExtensions({
     fragment,

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLink.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLink.tsx
@@ -2,18 +2,17 @@
 
 import { Skeleton } from '@design-system';
 import { useEffect, useState } from 'react';
-import TranslationEditor, {
-  TranslationEditorContent,
-} from '../../TranslationEditor';
+import { Passage } from '@data-access';
+import { LabeledElement } from '../../../shared';
 
 export const EndNoteLink = ({
   uuid,
   fetch,
 }: {
   uuid: string;
-  fetch?: (uuid: string) => Promise<TranslationEditorContent | undefined>;
+  fetch?: (uuid: string) => Promise<Passage | undefined>;
 }) => {
-  const [content, setContent] = useState<TranslationEditorContent>();
+  const [content, setContent] = useState<Passage>();
 
   useEffect(() => {
     if (!uuid || !fetch) {
@@ -28,7 +27,7 @@ export const EndNoteLink = ({
 
   return content ? (
     <div className="p-2">
-      <TranslationEditor content={content} isEditable={false} />
+      <LabeledElement label={content.label}>{content.content}</LabeledElement>
     </div>
   ) : (
     <Skeleton className="p-2 h-20 w-full" />

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkNode.ts
@@ -1,13 +1,10 @@
 import { Node } from '@tiptap/core';
 import { createNodeViewDom } from '../../util';
-import {
-  TranslationEditorContent,
-  TranslationEditorContentItem,
-} from '../../TranslationEditor';
+import { Passage } from '@data-access';
 
 export interface EndNoteLinkOptions {
   HTMLAttributes: Record<string, unknown>;
-  fetch: (uuid: string) => Promise<TranslationEditorContent | undefined>;
+  fetch: (uuid: string) => Promise<Passage | undefined>;
 }
 
 declare module '@tiptap/core' {
@@ -85,11 +82,8 @@ export const EndNoteLinkNode = Node.create<EndNoteLinkOptions>({
       dom.textContent = defaultLabel;
 
       (async () => {
-        const [item] =
-          ((await this.options.fetch(
-            endNote,
-          )) as TranslationEditorContentItem[]) || [];
-        const itemLabel = item?.attrs?.label?.split('.').pop() || defaultLabel;
+        const item = await this.options.fetch(endNote);
+        const itemLabel = item?.label.split('.').pop() || defaultLabel;
         dom.textContent = itemLabel;
       })();
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
@@ -3,6 +3,7 @@ import { Mark, mergeAttributes } from '@tiptap/core';
 import { ReactMarkViewRenderer } from '@tiptap/react';
 import { v4 as uuidv4 } from 'uuid';
 import { InternalLinkView } from './InternalLinkView';
+import { createMarkViewDom } from '../../util';
 
 export interface InternalLinkOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -57,6 +58,24 @@ export const InternalLink = Mark.create<InternalLinkOptions>({
     ];
   },
   addMarkView() {
+    if (!this.editor.isEditable) {
+      return (props) => {
+        const { dom } = createMarkViewDom({
+          ...props,
+          element: 'a',
+          className: LINK_STYLE,
+        });
+
+        dom.setAttribute('href', props.mark.attrs.href);
+        dom.setAttribute('target', '_blank');
+        dom.setAttribute('rel', 'noreferrer');
+
+        return {
+          dom,
+          contentDOM: dom,
+        };
+      };
+    }
     return ReactMarkViewRenderer(InternalLinkView);
   },
   addCommands() {

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLinkView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLinkView.tsx
@@ -6,13 +6,7 @@ import {
   LINK_STYLE,
 } from '@design-system';
 import { MarkViewContent, MarkViewProps } from '@tiptap/react';
-import {
-  ChevronRightIcon,
-  FileSymlinkIcon,
-  GlobeIcon,
-  PencilIcon,
-  Trash2Icon,
-} from 'lucide-react';
+import { ChevronRightIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { findMarkRange } from '../../util';
 import Link from 'next/link';
@@ -61,19 +55,6 @@ export const InternalLinkView = ({
     },
     [updateAttributes],
   );
-
-  if (!editor.isEditable) {
-    // TODO: support hover cards for various entity types
-    return (
-      <MarkViewContent
-        className={LINK_STYLE}
-        as="a"
-        href={mark.attrs.href}
-        target="_blank"
-        rel="noreferrer"
-      />
-    );
-  }
 
   return (
     <HoverCard open={isOpen} onOpenChange={setIsOpen}>

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ts
@@ -2,6 +2,8 @@ import { Link as TipTapLink } from '@tiptap/extension-link';
 import { ReactMarkViewRenderer } from '@tiptap/react';
 import { v4 as uuidv4 } from 'uuid';
 import { LinkView } from './LinkView';
+import { createMarkViewDom } from '../../util';
+import { LINK_STYLE } from '@design-system';
 
 export const Link = TipTapLink.extend({
   addCommands() {
@@ -24,6 +26,24 @@ export const Link = TipTapLink.extend({
     };
   },
   addMarkView() {
+    if (!this.editor.isEditable) {
+      return (props) => {
+        const { dom } = createMarkViewDom({
+          ...props,
+          element: 'a',
+          className: LINK_STYLE,
+        });
+
+        dom.setAttribute('href', props.mark.attrs.href);
+        dom.setAttribute('target', '_blank');
+        dom.setAttribute('rel', 'noreferrer');
+
+        return {
+          dom,
+          contentDOM: dom,
+        };
+      };
+    }
     return ReactMarkViewRenderer(LinkView);
   },
 }).configure({

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
@@ -48,18 +48,6 @@ export const LinkView = ({ mark, editor, updateAttributes }: MarkViewProps) => {
     [updateAttributes],
   );
 
-  if (!editor.isEditable) {
-    return (
-      <MarkViewContent
-        className={LINK_STYLE}
-        as="a"
-        href={mark.attrs.href}
-        target="_blank"
-        rel="noreferrer"
-      />
-    );
-  }
-
   return (
     <HoverCard open={isOpen} onOpenChange={setIsOpen}>
       <HoverCardTrigger asChild>

--- a/libs/lib-editing/src/lib/components/editor/hooks/useTranslationExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/hooks/useTranslationExtensions.ts
@@ -47,11 +47,11 @@ import {
   HasAbbreviation,
 } from '../extensions/Abbreviation/Abbreviation';
 import { ParagraphIndent } from '../extensions/ParagraphIndent';
-import { TranslationEditorContent } from '../TranslationEditor';
 import { Bold } from '../extensions/Bold';
 import { List } from '../extensions/List';
 import { Underline } from '../extensions/Underline';
 import { GlobalConfig } from '../extensions/GlobalConfig';
+import { Passage } from '@data-access';
 
 const PassageSuggestion: CommandSuggestionItem = {
   title: 'Passage',
@@ -75,9 +75,7 @@ export const useTranslationExtensions = ({
   fetchEndNote,
 }: {
   fragment?: XmlFragment;
-  fetchEndNote?: (
-    uuid: string,
-  ) => Promise<TranslationEditorContent | undefined>;
+  fetchEndNote?: (uuid: string) => Promise<Passage | undefined>;
 }) => {
   const suggestions = [
     TextSuggestion,

--- a/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
@@ -16,9 +16,8 @@ import {
 } from 'react';
 import { TranslationHoverCard } from './TranslationHoverCard';
 import { GlossaryInstance } from '../editor/extensions/GlossaryInstance/GlossaryInstance';
-import EndNoteLink from '../editor/extensions/EndNoteLink/EndNoteLink';
-import { TranslationEditorContent } from '../editor';
-import { GlossaryTermInstance } from '@data-access';
+import { EndNoteLink } from '../editor/extensions/EndNoteLink/EndNoteLink';
+import { GlossaryTermInstance, Passage } from '@data-access';
 
 const HOVER_CARD_TYPES = ['glossaryInstance', 'endNoteLink'] as const;
 
@@ -62,9 +61,7 @@ export const HoverCardProvider = ({
   closeDelay?: number;
   openDelay?: number;
   typeMap?: Record<string, string>;
-  fetchEndNote?: (
-    uuid: string,
-  ) => Promise<TranslationEditorContent | undefined>;
+  fetchEndNote?: (uuid: string) => Promise<Passage | undefined>;
   fetchGlossaryInstance?: (
     uuid: string,
   ) => Promise<GlossaryTermInstance | undefined>;

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -10,6 +10,7 @@ import {
   getTranslationMetadataByUuid,
   GlossaryTermInstance,
   Imprint,
+  Passage,
   TohokuCatalogEntry,
   Work,
 } from '@data-access';
@@ -22,8 +23,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import { TranslationEditorContent } from '../editor';
-import { blockFromPassage } from '../../block';
 import { scrollToHash } from '@lib-utils';
 import { useSearchParams } from 'next/navigation';
 import {
@@ -50,11 +49,11 @@ interface NavigationState {
   fetchBibliographyEntry: (
     uuid: string,
   ) => Promise<BibliographyEntryItem | undefined>;
-  fetchEndNote: (uuid: string) => Promise<TranslationEditorContent | undefined>;
+  fetchEndNote: (uuid: string) => Promise<Passage | undefined>;
   fetchGlossaryTerm: (
     uuid: string,
   ) => Promise<GlossaryTermInstance | undefined>;
-  fetchPassage: (uuid: string) => Promise<TranslationEditorContent | undefined>;
+  fetchPassage: (uuid: string) => Promise<Passage | undefined>;
   fetchWork: (uuid: string) => Promise<Work | undefined>;
 }
 
@@ -108,9 +107,9 @@ export const NavigationProvider = ({
   const bibliographyCache = useRef<{ [uuid: string]: BibliographyEntryItem }>(
     {},
   );
-  const endnoteCache = useRef<{ [uuid: string]: TranslationEditorContent }>({});
+  const endnoteCache = useRef<{ [uuid: string]: Passage }>({});
   const glossaryCache = useRef<{ [uuid: string]: GlossaryTermInstance }>({});
-  const passageCache = useRef<{ [uuid: string]: TranslationEditorContent }>({});
+  const passageCache = useRef<{ [uuid: string]: Passage }>({});
   const workCache = useRef<{ [uuid: string]: Work }>({});
 
   const fetchBibliographyEntry = useCallback(
@@ -135,13 +134,13 @@ export const NavigationProvider = ({
   );
 
   const fetchEndNote = useCallback(
-    async (uuid: string): Promise<TranslationEditorContent | undefined> => {
+    async (uuid: string): Promise<Passage | undefined> => {
       if (!endnoteCache.current) {
         endnoteCache.current = {};
       }
 
       if (endnoteCache.current[uuid]) {
-        return [endnoteCache.current[uuid]];
+        return endnoteCache.current[uuid];
       }
 
       const endnote = await getPassage({ client, uuid });
@@ -149,9 +148,8 @@ export const NavigationProvider = ({
         return undefined;
       }
 
-      const block = blockFromPassage(endnote);
-      endnoteCache.current[uuid] = block;
-      return [block];
+      endnoteCache.current[uuid] = endnote;
+      return endnote;
     },
     [client],
   );
@@ -178,13 +176,13 @@ export const NavigationProvider = ({
   );
 
   const fetchPassage = useCallback(
-    async (uuid: string): Promise<TranslationEditorContent | undefined> => {
+    async (uuid: string): Promise<Passage | undefined> => {
       if (!passageCache.current) {
         passageCache.current = {};
       }
 
       if (passageCache.current[uuid]) {
-        return [passageCache.current[uuid]];
+        return passageCache.current[uuid];
       }
 
       const passage = await getPassage({ client, uuid });
@@ -192,9 +190,8 @@ export const NavigationProvider = ({
         return undefined;
       }
 
-      const block = blockFromPassage(passage);
-      passageCache.current[uuid] = block;
-      return [block];
+      passageCache.current[uuid] = passage;
+      return passage;
     },
     [client],
   );


### PR DESCRIPTION
### Summary

- Replace editor instances in endnote hover cards with plain content, as the large number of editor instances introduced large overhead and the awkward possibility of launching a hover card from a hover card. If we decide it is important to render links in these cards, we can develop a pared down parser or interpreter for these passages.
- Use simple dom elements for links in the reader. Only the editor needs to be stateful for these.

### Linear

- [DEV-379](https://linear.app/84000/issue/DEV-379)
