### PR TITLE
Fix saving

### DIFF
--- a/libs/data-access/src/lib/types/passage.ts
+++ b/libs/data-access/src/lib/types/passage.ts
@@ -67,7 +67,7 @@ export type PassageRowDTO = {
   sort: number;
   type: BodyItemType;
   uuid: string;
-  workUuid: string;
+  work_uuid: string;
   xmlId?: string;
   parent?: string;
 };
@@ -86,7 +86,7 @@ export const passageFromDTO = (
     sort: dto.sort,
     type: dto.type,
     uuid: dto.uuid,
-    workUuid: dto.workUuid,
+    workUuid: dto.work_uuid,
     xmlId: dto.xmlId,
     parent: dto.parent,
     annotations,
@@ -109,7 +109,7 @@ export const passageToRowDTO = (passage: Passage): PassageRowDTO => {
     sort: passage.sort,
     type: passage.type,
     uuid: passage.uuid,
-    workUuid: passage.workUuid,
+    work_uuid: passage.workUuid,
   };
 
   // NOTE: only include xmlId and parent if they exist, otherwise an upsert

--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -109,7 +109,7 @@ export const EditorContextProvider = ({
   );
 
   const save = useCallback(async () => {
-    const editors = Object.values(editorCache);
+    const editors = Object.values(editorCache.current);
     if (!editors.length) {
       console.warn('No editor instance found, cannot save.');
       return;


### PR DESCRIPTION
### Summary

After adopting an editor cache recently, a bug was introduced that prevents saving. This fixes that issue. There may be annotation-specific bugs out there preventing saves, but this made all attempts to save fail.
