### PR TITLE
redirect for tohoku number paths

### DIFF
--- a/apps/web-reader/src/middleware.ts
+++ b/apps/web-reader/src/middleware.ts
@@ -7,7 +7,12 @@ export async function middleware(request: NextRequest) {
   // match tohoku catalog shortlinks like /toh1234
   if (pathname.match(/^\/toh\d+/)) {
     const url = request.nextUrl.clone();
-    const toh = pathname.split('/')[1];
+    const toh = pathname.split('/')[1]?.split('.')[0];
+
+    if (!toh) {
+      return NextResponse.next();
+    }
+
     const client = await createServerClient();
     const { data, error } = await client
       .from('works')


### PR DESCRIPTION
### Summary

Using a tohoku number as a route (e.g. `/toh251`) in the public reader will now redirect to the correct work uuid with `toh` query paramter.
