### PR TITLE
update translator parsing, fixes ed-588

### DIFF
--- a/libs/design-system/src/lib/Translation/Title/LongTitles.tsx
+++ b/libs/design-system/src/lib/Translation/Title/LongTitles.tsx
@@ -68,7 +68,7 @@ export const LongTitles = ({ imprint }: { imprint?: Imprint }) => {
             {translators.map((translator, idx) => (
               <>
                 <span key={`${translator}-${idx}`}>{translator}</span>
-                <span>{DOT}</span>
+                <span key={`dot-${idx}`}>{DOT}</span>
               </>
             ))}
           </div>


### PR DESCRIPTION
### Summary

This fixes an issue where "Translated into Tibetan by" displayed when there was no list of Tibetan translators. The issue was that, when parsing the original comma-delimited string, the result of an empty string was `[""]` instead of an empty array.

### Linear

- [ED-588](https://linear.app/84000/issue/ED-588)