### PR TITLE
make chinese entry a li, fixes ed-589

### DIFF
--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryInstanceBody.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryInstanceBody.tsx
@@ -42,7 +42,7 @@ export const GlossaryInstanceBody = ({
         {instance.names.sanskrit && (
           <Li className="italic">{instance.names.sanskrit}</Li>
         )}
-        {instance.names.chinese && <div>{instance.names.chinese}</div>}
+        {instance.names.chinese && <Li>{instance.names.chinese}</Li>}
         {instance.names.pali && (
           <Li className="italic">{instance.names.pali}</Li>
         )}


### PR DESCRIPTION
### Summary

Chinese glossary entry variants were mistakenly `div` elements instead of `li`. Now they are `li` elements like the others.

### Linear

- [ED-589](https://linear.app/84000/issue/ED-589)
