### PR TITLE
Less Small Small Caps

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/SmallCaps.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/SmallCaps.ts
@@ -76,7 +76,7 @@ export const SmallCaps = Mark.create<SmallCapsOptions>({
     return [
       'sm',
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-        class: 'uppercase text-xs',
+        class: 'uppercase',
       }),
       0,
     ];


### PR DESCRIPTION
### Summary

Remove the styling that makes small caps too small. The `sm` tag is enough.