### PR TITLE
Toh Redirect Fix

### DIFF
--- a/apps/web-reader/src/middleware.ts
+++ b/apps/web-reader/src/middleware.ts
@@ -15,17 +15,17 @@ export async function middleware(request: NextRequest) {
 
     const client = await createServerClient();
     const { data, error } = await client
-      .from('works')
-      .select('uuid')
-      .eq('toh', toh)
+      .from('work_toh')
+      .select('work_uuid')
+      .eq('toh_clean', toh)
       .single();
 
     if (error || !data) {
       return NextResponse.next();
     }
 
-    if (data?.uuid) {
-      url.pathname = `/${data.uuid}`;
+    if (data?.work_uuid) {
+      url.pathname = `/${data.work_uuid}`;
       url.searchParams.set('toh', toh);
     }
     return NextResponse.redirect(url);


### PR DESCRIPTION
### Summary

Use the `work_toh` table to find the work uuid to redirect to based on a Tohuku number instead of the `works` table because the latter may have have a comma delimited string in its `toh` column value. The `work_toh` table, by contrast, maps a singe Tohoku number to a single work uuid.