### PR TITLE
Gdamron/glossary formatting

### DIFF
--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -32,4 +32,8 @@
   .end-note-link {
     @apply text-brick cursor-pointer text-xs;
   }
+
+  .definition {
+    @apply mb-4;
+  }
 }

--- a/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyList.tsx
+++ b/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyList.tsx
@@ -42,10 +42,7 @@ export const BibliographyList = ({
                 key={entry.uuid}
                 label={`b.${i + 1}.${j + 1}`}
               >
-                <div
-                  className="flex flex-col gap-4"
-                  dangerouslySetInnerHTML={{ __html: entry.html }}
-                />
+                <div dangerouslySetInnerHTML={{ __html: entry.html }} />
               </LabeledElement>
             ))}
           </div>

--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryInstanceBody.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryInstanceBody.tsx
@@ -2,8 +2,7 @@
 
 import { GlossaryTermInstance } from '@data-access';
 import { Li, Ul } from '@design-system';
-import { cn, removeHtmlTags } from '@lib-utils';
-import { useEffect, useState } from 'react';
+import { cn } from '@lib-utils';
 
 export const GlossaryInstanceBody = ({
   instance,
@@ -12,17 +11,6 @@ export const GlossaryInstanceBody = ({
   instance: GlossaryTermInstance;
   className?: string;
 }) => {
-  const [definition, setDefinition] = useState<string>();
-
-  useEffect(() => {
-    if (!instance?.definition) {
-      return;
-    }
-
-    const plainText = removeHtmlTags(instance.definition);
-    setDefinition(plainText);
-  }, [instance.definition, setDefinition]);
-
   return (
     <div className={cn('p-2 flex gap-1 flex-col', className)}>
       {instance.names.english && (
@@ -49,10 +37,7 @@ export const GlossaryInstanceBody = ({
       </Ul>
       <div className="my-2" />
       {instance.definition && (
-        <div
-          className="flex flex-col gap-4"
-          dangerouslySetInnerHTML={{ __html: instance.definition }}
-        />
+        <div dangerouslySetInnerHTML={{ __html: instance.definition }} />
       )}
       <div className="text-sm text-mut my-2">
         <a


### PR DESCRIPTION
### Summary

The HTML tags of glossary instance definitions were being stripped. They are now preserved, and the `definition` utility class has been added to the theme to provide some space between paragraphs.