### PR TITLE
Generalize definition style

### DIFF
--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -33,7 +33,13 @@
     @apply text-brick cursor-pointer text-xs;
   }
 
-  .definition {
-    @apply mb-4;
+  .glossary-instance-definition {
+    p {
+      @apply mb-1 mt-2;
+
+      @variant position-sidebar {
+        @apply pt-1;
+      }
+    }
   }
 }

--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryInstanceBody.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryInstanceBody.tsx
@@ -37,7 +37,10 @@ export const GlossaryInstanceBody = ({
       </Ul>
       <div className="my-2" />
       {instance.definition && (
-        <div dangerouslySetInnerHTML={{ __html: instance.definition }} />
+        <div
+          className="glossary-instance-definition"
+          dangerouslySetInnerHTML={{ __html: instance.definition }}
+        />
       )}
       <div className="text-sm text-mut my-2">
         <a


### PR DESCRIPTION
### Summary

The `authorities` table uses slightly different, simpler HTML conventions in its definitions content. This updates the style of glossary instance components to handle either case in the same way, styling the paragraphs in the same way passage paragraphs are styled.

### Linear

- part of [DEV-384](https://linear.app/84000/issue/DEV-384)
- part of [ED-603](https://linear.app/84000/issue/ED-603)
