### PR TITLE
Fix inconsistent ToC Navigation

### DIFF
--- a/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
@@ -18,7 +18,6 @@ import { TranslationHoverCard } from './TranslationHoverCard';
 import { GlossaryInstance } from '../editor/extensions/GlossaryInstance/GlossaryInstance';
 import { EndNoteLink } from '../editor/extensions/EndNoteLink/EndNoteLink';
 import { GlossaryTermInstance, Passage } from '@data-access';
-import { GatedFeature } from '@lib-instr';
 
 const HOVER_CARD_TYPES = ['glossaryInstance', 'endNoteLink'] as const;
 
@@ -269,26 +268,19 @@ export const HoverCardProvider = ({
       <div className="size-full" ref={editorRef}>
         {children}
       </div>
-      <GatedFeature flag="translation-hover-cards">
-        {anchor &&
-          uuid &&
-          cardType &&
-          fetchGlossaryInstance &&
-          fetchEndNote && (
-            <TranslationHoverCard
-              className={cn(
-                cardType === 'endNoteLink' &&
-                  'w-120 max-h-96 m-2 overflow-auto',
-                cardType === 'glossaryInstance' &&
-                  'w-120 lg:w-4xl max-h-100 m-2 overflow-auto',
-              )}
-              anchor={anchor}
-              setCard={setCard}
-            >
-              {renderCard(uuid, cardType)}
-            </TranslationHoverCard>
+      {anchor && uuid && cardType && fetchGlossaryInstance && fetchEndNote && (
+        <TranslationHoverCard
+          className={cn(
+            cardType === 'endNoteLink' && 'w-120 max-h-96 m-2 overflow-auto',
+            cardType === 'glossaryInstance' &&
+              'w-120 lg:w-4xl max-h-100 m-2 overflow-auto',
           )}
-      </GatedFeature>
+          anchor={anchor}
+          setCard={setCard}
+        >
+          {renderCard(uuid, cardType)}
+        </TranslationHoverCard>
+      )}
     </HoverCardContext.Provider>
   );
 };

--- a/libs/lib-editing/src/lib/components/shared/TableOfContents.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TableOfContents.tsx
@@ -75,7 +75,11 @@ export const TableOfContentsSection = ({
       const { section } = entry;
       updatePanel({
         name: PANEL_FOR_SECTION[section] || panel,
-        state: { open: true, tab: TAB_FOR_SECTION[section] || 'translation' },
+        state: {
+          open: true,
+          tab: TAB_FOR_SECTION[section] || 'translation',
+          hash: entry.uuid,
+        },
       });
     },
     [updatePanel, panel],
@@ -95,13 +99,9 @@ export const TableOfContentsSection = ({
             className="border-b-0"
           >
             <AccordionTrigger className={cn(baseStyle, className)}>
-              <a
-                className="line-clamp-2"
-                href={`#${child.uuid}`}
-                onClick={() => onClick(child)}
-              >
+              <span className="line-clamp-2" onClick={() => onClick(child)}>
                 {child.content}
-              </a>
+              </span>
             </AccordionTrigger>
             <AccordionContent className={cn(depthClass, 'py-0')}>
               <TableOfContentsSection node={child} depth={depth + 1} />
@@ -109,13 +109,9 @@ export const TableOfContentsSection = ({
           </AccordionItem>
         ) : (
           <div key={child.uuid} className={baseStyle}>
-            <a
-              href={`#${child.uuid}`}
-              className="line-clamp-2"
-              onClick={() => onClick(child)}
-            >
+            <span className="line-clamp-2" onClick={() => onClick(child)}>
               {child.content}
-            </a>
+            </span>
           </div>
         );
       })}

--- a/libs/lib-utils/src/lib/hooks/use-scroll-to-hash.tsx
+++ b/libs/lib-utils/src/lib/hooks/use-scroll-to-hash.tsx
@@ -1,4 +1,3 @@
-// hooks/useScrollToHash.js
 'use client';
 
 import { DependencyList, useEffect } from 'react';


### PR DESCRIPTION
### Summary

Instead of relying on two distinct behaviors in the table of contents -- calling `updatePanel` for panel state while using `href` for setting the url hash -- just use `updatePanel`. The compound action created a race condition that often forced user to click an item in the ToC twice before it would scroll to the correct anchor.

### Linear

- [ED-587](https://linear.app/84000/issue/ED-587)
