### PR TITLE
`long-term` utility class

### DIFF
--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -42,4 +42,8 @@
       }
     }
   }
+
+  .long-term {
+    @apply break-all;
+  }
 }


### PR DESCRIPTION
### Summary

Adds a utility class `long-term` to the theme. When applied, this allows a word to break according to the width of the view when the browser can't be relied on to handle it gracefully (i.e. Sanskrit terms) and soft hyphens aren't an option.

### Linear

- part [ED-620](https://linear.app/84000/issue/ED-620)
