### PR TITLE
convert trailer extension to a node

### DIFF
--- a/libs/lib-editing/src/fixtures/basic/json.ts
+++ b/libs/lib-editing/src/fixtures/basic/json.ts
@@ -40,9 +40,9 @@ export const content = {
       type: 'passage',
       content: [
         {
-          type: 'paragraph',
+          type: 'trailer',
           attrs: {
-            hasTrailer: true,
+            uuid: 'some-uuid-for-trailer',
           },
           content: [
             {

--- a/libs/lib-editing/src/fixtures/toh251/json.ts
+++ b/libs/lib-editing/src/fixtures/toh251/json.ts
@@ -967,12 +967,11 @@ export const content: TranslationEditorContent = [
     },
     content: [
       {
-        type: 'paragraph',
+        type: 'trailer',
         attrs: {
           start: 0,
           end: 62,
-          uuid: 'de103c91-0bb2-4f90-9d98-c84718baecc9',
-          hasTrailer: true,
+          uuid: '76612414-df30-4c73-89fa-139e794a4a4d',
         },
         content: [
           {

--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -160,7 +160,7 @@ const PRIORITY_FOR_ANNOTAION_TYPE: { [key in AnnotationType]: BlockPriority } =
     tableBodyData: BlockPriority.Block,
     tableBodyHeader: BlockPriority.OuterBlock,
     tableBodyRow: BlockPriority.OuterBlock,
-    trailer: BlockPriority.Attribute,
+    trailer: BlockPriority.OuterBlock,
     unknown: BlockPriority.Unknown,
   };
 

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/ParagraphButtons.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/ParagraphButtons.tsx
@@ -2,16 +2,11 @@ import { cn } from '@lib-utils';
 import { Editor } from '@tiptap/core';
 import { useEditorState } from '@tiptap/react';
 import { Button } from '@design-system';
-import {
-  ArrowDownToLineIcon,
-  ArrowUpToLineIcon,
-  IndentIcon,
-} from 'lucide-react';
+import { ArrowUpToLineIcon, IndentIcon } from 'lucide-react';
 
 interface SelectorResult {
   hasIndent: boolean;
   hasLeadingSpace: boolean;
-  hasTrailer: boolean;
 }
 
 const items = [
@@ -21,13 +16,6 @@ const items = [
       editor.chain().focus().toggleLeadingSpace().run();
     },
     isActive: (state: { hasLeadingSpace: boolean }) => state.hasLeadingSpace,
-  },
-  {
-    icon: ArrowDownToLineIcon,
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleTrailer().run();
-    },
-    isActive: (state: { hasTrailer: boolean }) => state.hasTrailer,
   },
   {
     icon: IndentIcon,
@@ -46,11 +34,6 @@ export const ParagraphButtons = ({ editor }: { editor: Editor }) => {
         hasIndent: !!instance.editor.getAttributes('paragraph')['hasIndent'],
         hasLeadingSpace:
           !!instance.editor.getAttributes('paragraph')['hasLeadingSpace'],
-
-        hasTrailer:
-          !!instance.editor.getAttributes('paragraph')['hasTrailer'] ||
-          !!instance.editor.getAttributes('lineGroup')['hasTrailer'] ||
-          !!instance.editor.getAttributes('heading')['hasTrailer'],
       };
       return atts;
     },

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/TranslationNodeSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/TranslationNodeSelector.tsx
@@ -13,6 +13,7 @@ import {
   Heading2,
   Heading3,
   LetterTextIcon,
+  ListEndIcon,
   ListStartIcon,
   LucideIcon,
   QuoteIcon,
@@ -25,6 +26,7 @@ interface SelectorResult {
   isHeading3: boolean;
   isLineGroup: boolean;
   isBlockquote: boolean;
+  isTrailer: boolean;
 }
 
 interface MenuItem {
@@ -81,6 +83,12 @@ const items: MenuItem[] = [
         .run(),
     isActive: (state) => state.isBlockquote,
   },
+  {
+    name: 'Trailer',
+    icon: ListEndIcon,
+    onClick: (editor) => editor.chain().focus().toggleTrailer().run(),
+    isActive: (state) => state.isTrailer,
+  },
 ];
 
 export const TranslationNodeSelector = ({ editor }: { editor: Editor }) => {
@@ -93,6 +101,7 @@ export const TranslationNodeSelector = ({ editor }: { editor: Editor }) => {
       isHeading3: instance.editor.isActive('heading', { level: 3 }),
       isLineGroup: instance.editor.isActive('lineGroup'),
       isBlockquote: instance.editor.isActive('blockquote'),
+      isTrailer: instance.editor.isActive('trailer'),
     }),
   });
 

--- a/libs/lib-editing/src/lib/components/editor/util.ts
+++ b/libs/lib-editing/src/lib/components/editor/util.ts
@@ -64,14 +64,6 @@ export const validateAttrs = async ({
       attrs.hasIndent = false;
     }
 
-    if (attrs.trailerUuid) {
-      attrs.trailingSpaceUuid = undefined;
-    }
-
-    if (attrs.hasTrailer) {
-      attrs.hasTrailingSpace = false;
-    }
-
     if (attrs.hasParagraphIndent) {
       attrs.hasParagraphIndent = false;
     }

--- a/libs/lib-editing/src/lib/exporters/annotation.ts
+++ b/libs/lib-editing/src/lib/exporters/annotation.ts
@@ -85,7 +85,6 @@ const EXPORTERS: Partial<
 const PARAMETER_ANNOTATION_MAP: { [key: string]: AnnotationType } = {
   hasIndent: 'indent',
   hasLeadingSpace: 'leadingSpace',
-  hasTrailer: 'trailer',
 };
 
 export const parameterAnnotationFromNode = (

--- a/libs/lib-editing/src/lib/exporters/trailer.ts
+++ b/libs/lib-editing/src/lib/exporters/trailer.ts
@@ -3,13 +3,19 @@ import { Exporter } from './export';
 
 export const trailer: Exporter<TrailerAnnotation> = ({
   node,
-  parent,
   start,
   passageUuid,
 }) => {
-  const textContent = node.textContent || parent.textContent || '';
+  const textContent = node.textContent;
+  const uuid = node.attrs.uuid;
+
+  if (!textContent) {
+    console.warn(`Trailer node ${uuid} is missing body text`);
+    return undefined;
+  }
+
   return {
-    uuid: node.attrs.trailerUuid,
+    uuid,
     type: 'trailer',
     passageUuid,
     start,

--- a/libs/lib-editing/src/lib/transformers/annotate.ts
+++ b/libs/lib-editing/src/lib/transformers/annotate.ts
@@ -81,7 +81,7 @@ export const ITALIC_LANGUAGES: ExtendedTranslationLanguage[] = [
 ] as const;
 
 export const isAttributeAnnotation = (type: TranslationEditorContentType) => {
-  return ['indent', 'leadingSpace', 'trailer'].includes(type);
+  return ['indent', 'leadingSpace'].includes(type);
 };
 
 export const isBlockAnnotation = (type: TranslationEditorContentType) => {
@@ -98,6 +98,7 @@ export const isBlockAnnotation = (type: TranslationEditorContentType) => {
     'tableBodyData',
     'tableBodyHeader',
     'tableBodyRow',
+    'trailer',
   ].includes(type);
 };
 

--- a/libs/lib-editing/src/lib/transformers/trailer.ts
+++ b/libs/lib-editing/src/lib/transformers/trailer.ts
@@ -1,18 +1,26 @@
 import { recurse } from './recurse';
+import { splitBlock } from './split-block';
 import { Transformer } from './transformer';
 
 export const trailer: Transformer = (ctx) => {
-  const trailerUuid = ctx.annotation.uuid;
+  const { annotation } = ctx;
+  const { start, end, uuid } = annotation || {};
 
   recurse({
     ...ctx,
     until: ['paragraph'],
-    transform: ({ block: item }) => {
-      item.attrs = {
-        ...item.attrs,
-        hasTrailer: true,
-        trailerUuid,
-      };
-    },
+    transform: (ctx) =>
+      splitBlock({
+        ...ctx,
+        transform: ({ block }) => {
+          block.type = 'trailer';
+          block.attrs = {
+            ...block.attrs,
+            start,
+            end,
+            uuid,
+          };
+        },
+      }),
   });
 };


### PR DESCRIPTION
### Summary

Waaaaay back, I misinterpreted the `trailer` annotation to mean additional space at the end of a passage, and it has been applied that way ever since. Now it adheres to its intended meaning: A paragraph-like block with extra space at the top and italic text.

### Linear

- [DEV-354](https://linear.app/84000/issue/DEV-354)

