### PR TITLE
Theme Link Style

### DIFF
--- a/libs/design-system/src/lib/Typography/Typography.tsx
+++ b/libs/design-system/src/lib/Typography/Typography.tsx
@@ -186,7 +186,7 @@ export function A({
   ...props
 }: React.ComponentProps<'a'>) {
   return (
-    <a className={cn(LINK_STYLE, className)} {...props}>
+    <a className={className} {...props}>
       {children}
     </a>
   );

--- a/libs/design-system/src/lib/theme/global.css
+++ b/libs/design-system/src/lib/theme/global.css
@@ -58,6 +58,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  a {
+    @apply text-brick underline decoration-brick underline-offset-[3px] transition-colors cursor-pointer;
+  }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
@@ -1,4 +1,3 @@
-import { LINK_STYLE } from '@design-system';
 import { Mark, mergeAttributes } from '@tiptap/core';
 import { ReactMarkViewRenderer } from '@tiptap/react';
 import { v4 as uuidv4 } from 'uuid';
@@ -39,9 +38,7 @@ export const InternalLink = Mark.create<InternalLinkOptions>({
   },
   addOptions() {
     return {
-      HTMLAttributes: {
-        class: LINK_STYLE,
-      },
+      HTMLAttributes: {},
     };
   },
   parseHTML() {
@@ -64,7 +61,7 @@ export const InternalLink = Mark.create<InternalLinkOptions>({
         const { dom } = createMarkViewDom({
           ...props,
           element: 'a',
-          className: cn(LINK_STYLE, props.mark.attrs.toh),
+          className: props.mark.attrs.toh,
         });
 
         dom.setAttribute('href', props.mark.attrs.href);

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLinkView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLinkView.tsx
@@ -3,7 +3,6 @@ import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
-  LINK_STYLE,
 } from '@design-system';
 import { MarkViewContent, MarkViewProps } from '@tiptap/react';
 import { ChevronRightIcon, PencilIcon, Trash2Icon } from 'lucide-react';
@@ -59,12 +58,7 @@ export const InternalLinkView = ({
   return (
     <HoverCard open={isOpen} onOpenChange={setIsOpen}>
       <HoverCardTrigger asChild>
-        <Link
-          href={mark.attrs.href}
-          target="_blank"
-          rel="noreferrer"
-          className={LINK_STYLE}
-        >
+        <Link href={mark.attrs.href} target="_blank" rel="noreferrer">
           <MarkViewContent as="span" />
         </Link>
       </HoverCardTrigger>

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ts
@@ -3,7 +3,6 @@ import { ReactMarkViewRenderer } from '@tiptap/react';
 import { v4 as uuidv4 } from 'uuid';
 import { LinkView } from './LinkView';
 import { createMarkViewDom } from '../../util';
-import { LINK_STYLE } from '@design-system';
 
 export const Link = TipTapLink.extend({
   addCommands() {
@@ -31,7 +30,6 @@ export const Link = TipTapLink.extend({
         const { dom } = createMarkViewDom({
           ...props,
           element: 'a',
-          className: LINK_STYLE,
         });
 
         dom.setAttribute('href', props.mark.attrs.href);

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkView.tsx
@@ -3,7 +3,6 @@ import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
-  LINK_STYLE,
 } from '@design-system';
 import { MarkViewContent, MarkViewProps } from '@tiptap/react';
 import { GlobeIcon, PencilIcon, Trash2Icon } from 'lucide-react';
@@ -51,12 +50,7 @@ export const LinkView = ({ mark, editor, updateAttributes }: MarkViewProps) => {
   return (
     <HoverCard open={isOpen} onOpenChange={setIsOpen}>
       <HoverCardTrigger asChild>
-        <Link
-          href={mark.attrs.href}
-          target="_blank"
-          rel="noreferrer"
-          className={LINK_STYLE}
-        >
+        <Link href={mark.attrs.href} target="_blank" rel="noreferrer">
           <MarkViewContent as="span" />
         </Link>
       </HoverCardTrigger>


### PR DESCRIPTION
### Summary

Defines a base link style at the theme level and relies on it throughout the app. Previously, this style was defined in code. However, this meant that links in external content like bibliography and glossary entries were un-styled.
