### PR TITLE
support foreign tag and glossary instance links in glossary elements

### DIFF
--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -50,4 +50,16 @@
   .long-term {
     @apply break-all;
   }
+
+  .title {
+    @apply italic;
+  }
+
+  .text-sa {
+    @apply italic;
+  }
+
+  foreign {
+    @apply [&[xml\:lang*="-Ltn"]]:italic;
+  }
 }

--- a/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyBody.tsx
+++ b/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyBody.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { BibliographyEntryItem } from '@data-access';
+import { LabeledElement } from '../LabeledElement';
+import { useRef } from 'react';
+import { useGlossaryInstanceListener } from '../hooks/useGlossaryInstanceListener';
+
+export const BibliographyBody = ({
+  entry,
+  label,
+}: {
+  entry: BibliographyEntryItem;
+  label: string;
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useGlossaryInstanceListener({ ref });
+
+  return (
+    <LabeledElement id={entry.uuid} key={entry.uuid} label={label}>
+      <div ref={ref} dangerouslySetInnerHTML={{ __html: entry.html }} />
+    </LabeledElement>
+  );
+};

--- a/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyList.tsx
+++ b/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyList.tsx
@@ -5,6 +5,7 @@ import { LabeledElement } from '../LabeledElement';
 import { BibliographyEntries } from '@data-access';
 import { cn } from '@lib-utils';
 import { useScrollInTab } from '../hooks/useScrollInTab';
+import { BibliographyBody } from './BibliographyBody';
 
 export const BibliographyList = ({
   content,
@@ -45,13 +46,11 @@ export const BibliographyList = ({
               </LabeledElement>
             )}
             {section.entries.map((entry, j) => (
-              <LabeledElement
-                id={entry.uuid}
-                key={entry.uuid}
+              <BibliographyBody
+                entry={entry}
                 label={`b.${i + 1}.${j + 1}`}
-              >
-                <div dangerouslySetInnerHTML={{ __html: entry.html }} />
-              </LabeledElement>
+                key={entry.uuid}
+              />
             ))}
           </div>
         ))}

--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryInstanceBody.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryInstanceBody.tsx
@@ -4,6 +4,8 @@ import { GlossaryTermInstance } from '@data-access';
 import { Li, Ul } from '@design-system';
 import { GatedFeature } from '@lib-instr';
 import { cn } from '@lib-utils';
+import { useRef } from 'react';
+import { useGlossaryInstanceListener } from '../hooks/useGlossaryInstanceListener';
 
 export const GlossaryInstanceBody = ({
   instance,
@@ -12,6 +14,9 @@ export const GlossaryInstanceBody = ({
   instance: GlossaryTermInstance;
   className?: string;
 }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useGlossaryInstanceListener({ ref });
+
   return (
     <div className={cn('p-2 flex gap-1 flex-col', className)}>
       {instance.names.english && (
@@ -38,6 +43,7 @@ export const GlossaryInstanceBody = ({
       </Ul>
       {instance.definition && (
         <div
+          ref={ref}
           className="glossary-instance-definition"
           dangerouslySetInnerHTML={{ __html: instance.definition }}
         />

--- a/libs/lib-editing/src/lib/components/shared/hooks/useGlossaryInstanceListener.tsx
+++ b/libs/lib-editing/src/lib/components/shared/hooks/useGlossaryInstanceListener.tsx
@@ -1,0 +1,42 @@
+import { RefObject, useEffect } from 'react';
+import { useNavigation } from '../NavigationProvider';
+
+export const useGlossaryInstanceListener = ({
+  ref,
+}: {
+  ref: RefObject<HTMLDivElement | null>;
+}) => {
+  const { updatePanel } = useNavigation();
+
+  useEffect(() => {
+    const div = ref.current;
+    if (!div) {
+      return;
+    }
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+
+      // Check if the clicked element or any parent is a glossary instance
+      const glossarySpan = target.closest(
+        'span[type="glossaryInstance"]',
+      ) as HTMLSpanElement;
+
+      if (glossarySpan) {
+        const glossaryUuid = glossarySpan.getAttribute('glossary');
+        if (glossaryUuid) {
+          updatePanel({
+            name: 'right',
+            state: { open: true, tab: 'glossary', hash: glossaryUuid },
+          });
+        }
+      }
+    };
+
+    div.addEventListener('click', handleClick);
+
+    return () => {
+      div.removeEventListener('click', handleClick);
+    };
+  }, [ref, updatePanel]);
+};


### PR DESCRIPTION
### Summary

- Add support for the `foreign` tag and apply italics when appropriate.
- Add support for glossary instance spans outside of the editor

### Linear

- [DEV-417](https://linear.app/84000/issue/DEV-417)
