### PR TITLE
update handling of foreign styles and other legacy tei tags

### DIFF
--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -47,19 +47,27 @@
     }
   }
 
+  [rend='small-caps'],
+  .small-caps {
+    font-variant-caps: small-caps;
+  }
+
   .long-term {
     @apply break-all;
   }
 
-  .title {
+  [xml\:lang]:not(
+      [xml\:lang='en'],
+      [xml\:lang='bo'],
+      [xml\:lang='ja'],
+      [xml\:lang='zh']
+    ) {
     @apply italic;
   }
 
+  emph,
+  distinct,
   .text-sa {
     @apply italic;
-  }
-
-  foreign {
-    @apply [&[xml\:lang*="-Ltn"]]:italic;
   }
 }


### PR DESCRIPTION
### Summary

- Apply italics based on `xml:lang` attribute rather than `foreign` tag.
- Handle other simple TEI tags and attributes like `emph`, `distinct` and `rend`

### Linear

- [DEV-417](https://linear.app/84000/issue/DEV-417)
