### PR TITLE
Body Title Styles

### DIFF
--- a/libs/design-system/src/lib/Typography/Typography.tsx
+++ b/libs/design-system/src/lib/Typography/Typography.tsx
@@ -45,6 +45,48 @@ export function Section({
   );
 }
 
+export const SECTION_TITLE_STYLE =
+  'font-serif text-navy mt-6 scroll-m-20 pb-4 text-3xl position-sidebar:pb-2 position-sidebar:mt-4 text-center';
+export function SectionTitle({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'h2'>) {
+  return (
+    <h2 className={cn(SECTION_TITLE_STYLE, className)} {...props}>
+      {children}
+    </h2>
+  );
+}
+
+export const BODY_TITLE_STYLE =
+  'font-serif text-navy scroll-m-20 pb-6 mt-2 text-2xl position-sidebar:text-xl position-sidebar:pb-4 position-sidebar:mt-0 text-center';
+export function BodyTitle({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'h2'>) {
+  return (
+    <h2 className={cn(BODY_TITLE_STYLE, className)} {...props}>
+      {children}
+    </h2>
+  );
+}
+
+export const HONORIFIC_TITLE_STYLE =
+  'font-serif text-navy scroll-m-20 text-xl text-center';
+export function HonorificTitle({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'h2'>) {
+  return (
+    <h2 className={cn(HONORIFIC_TITLE_STYLE, className)} {...props}>
+      {children}
+    </h2>
+  );
+}
+
 export const H1_STYLE = 'font-serif mt-8 scroll-m-20 pb-8 text-5xl lg:text-6xl';
 export function H1({
   children,

--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -17,6 +17,15 @@
     @apply font-sans font-semibold text-brick leading-7 text-sm;
   }
 
+  .section-title,
+  .body-title-main,
+  .body-title-honorific {
+    font-variation-settings:
+      'wdth' 120,
+      'opsz' 144,
+      'GRAD' -50;
+  }
+
   .paragraph {
     @apply mb-1 mt-2;
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Heading/Heading.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Heading/Heading.ts
@@ -1,11 +1,14 @@
 import TiptapHeading from '@tiptap/extension-heading';
 import type { Level } from '@tiptap/extension-heading';
 import {
+  BODY_TITLE_STYLE,
   H1_STYLE,
   H2_STYLE,
   H3_STYLE,
   H4_STYLE,
   H5_STYLE,
+  HONORIFIC_TITLE_STYLE,
+  SECTION_TITLE_STYLE,
 } from '@design-system';
 import { createNodeViewDom } from '../../util';
 import { HTMLElementType } from 'react';
@@ -19,14 +22,33 @@ const CLASS_FOR_LEVEL: Record<Level, string> = {
   6: H5_STYLE,
 };
 
+const CLASS_FOR_CLASS: Record<string, string> = {
+  'section-title': SECTION_TITLE_STYLE,
+  'body-title-main': BODY_TITLE_STYLE,
+  'body-title-honorific': HONORIFIC_TITLE_STYLE,
+};
+
 export const Heading = TiptapHeading.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      class: {
+        default: null,
+        parseHTML(element) {
+          return element.getAttribute('class');
+        },
+      },
+    };
+  },
+
   addNodeView() {
     return ({ node, editor, extension, getPos, HTMLAttributes }) => {
       const nodeLevel = parseInt(node.attrs.level, 10) as Level;
       const hasLevel = this.options.levels.includes(nodeLevel);
       const level = hasLevel ? nodeLevel : this.options.levels[0];
       const element = `h${level}` as HTMLElementType;
-      const className = CLASS_FOR_LEVEL[nodeLevel];
+      const className =
+        CLASS_FOR_CLASS[node.attrs.class] || CLASS_FOR_LEVEL[nodeLevel];
 
       const { dom } = createNodeViewDom({
         editor,


### PR DESCRIPTION
### Summary

Apply styles based on the `class` property of `heading` annotations. This class takes priority over the styles associated with the `level` property.

Title styles are nudged in the direction of the next design; although some qualities, like color, are still the same.

### Linear

- [DEV-429](https://linear.app/84000/issue/DEV-429)

