### PR TITLE
Split Marks

### DIFF
--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -150,7 +150,7 @@ const PRIORITY_FOR_ANNOTAION_TYPE: { [key in AnnotationType]: BlockPriority } =
     link: BlockPriority.Mark,
     list: BlockPriority.OuterBlock,
     listItem: BlockPriority.Block,
-    mantra: BlockPriority.Inline,
+    mantra: BlockPriority.Mark,
     paragraph: BlockPriority.OuterBlock,
     quote: BlockPriority.Inline,
     quoted: BlockPriority.Unknown,

--- a/libs/lib-editing/src/lib/transformers/split-marks.ts
+++ b/libs/lib-editing/src/lib/transformers/split-marks.ts
@@ -1,0 +1,42 @@
+export type TranslationMark = {
+  type: string;
+  attrs?: {
+    start?: number;
+    end?: number;
+    [key: string]: unknown;
+  };
+};
+
+export const splitMarks = ({
+  marks,
+  start,
+  end,
+}: {
+  marks?: TranslationMark[];
+  start: number;
+  end: number;
+}) => {
+  if (!marks) {
+    return;
+  }
+
+  const nextMarks = marks
+    .filter(
+      (mark) =>
+        (mark.attrs?.end ?? 0) <= end && (mark.attrs?.start ?? 0) <= end,
+    )
+    .map((mark) => {
+      const markStart = Math.max(mark.attrs?.start ?? 0, start);
+      const markEnd = Math.min(mark.attrs?.end ?? 0, end);
+      return {
+        ...mark,
+        attrs: {
+          ...mark.attrs,
+          start: markStart,
+          end: markEnd,
+        },
+      };
+    });
+
+  return nextMarks;
+};

--- a/libs/lib-editing/src/lib/transformers/split-node.ts
+++ b/libs/lib-editing/src/lib/transformers/split-node.ts
@@ -1,4 +1,5 @@
 import type { TranslationEditorContentItem } from '../components/editor';
+import { splitMarks } from './split-marks';
 import { filterAttrs } from './util';
 
 type SplitBlock = {
@@ -42,49 +43,94 @@ export function splitNode(
 
   const splits: SplitBlock = { prefix: [], middle: [], suffix: [] };
   const attrs = filterAttrs(item.attrs);
+  const marks = item.marks ? [...item.marks] : undefined;
 
   if (preLen > 0) {
     const preText = text.slice(0, preLen);
     if (preText) {
-      splits.prefix.push({
+      const prefixStart = itemStart;
+      const prefixEnd = prefixStart + preText.length;
+
+      const prefix = {
         ...item,
         text: preText,
         attrs: {
           ...attrs,
-          start: itemStart,
-          end: itemStart + preText.length,
+          start: prefixStart,
+          end: prefixEnd,
         },
+      };
+
+      const prefixMarks = splitMarks({
+        marks,
+        start: prefixStart,
+        end: prefixEnd,
       });
+
+      if (prefixMarks?.length) {
+        prefix.marks = prefixMarks;
+      }
+
+      splits.prefix.push(prefix);
     }
   }
 
   if (midLen > 0) {
     const midText = text.slice(preLen, preLen + midLen);
     if (midText) {
-      splits.middle.push({
+      const midStart = itemStart + preLen;
+      const midEnd = midStart + midText.length;
+
+      const mid = {
         ...item,
         text: midText,
         attrs: {
           ...attrs,
-          start: itemStart + preLen,
-          end: itemStart + preLen + midText.length,
+          start: midStart,
+          end: midEnd,
         },
+      };
+
+      const midMarks = splitMarks({
+        marks,
+        start: midStart,
+        end: midEnd,
       });
+
+      if (midMarks?.length) {
+        mid.marks = midMarks;
+      }
+
+      splits.middle.push(mid);
     }
   }
 
   if (postStartIdx < text.length) {
     const postText = text.slice(postStartIdx);
     if (postText) {
-      splits.suffix.push({
+      const postStart = itemStart + postStartIdx;
+      const postEnd = postStart + postText.length;
+      const post = {
         ...item,
         text: postText,
         attrs: {
           ...attrs,
-          start: itemStart + postStartIdx,
-          end: itemStart + text.length,
+          start: postStart,
+          end: postEnd,
         },
+      };
+
+      const postMarks = splitMarks({
+        marks,
+        start: postStart,
+        end: postEnd,
       });
+
+      if (postMarks?.length) {
+        post.marks = postMarks;
+      }
+
+      splits.suffix.push(post);
     }
   }
 


### PR DESCRIPTION
### Summary

When splitting a node during annotation parsing, also split the running list of marks for that node. That is, add marks to the prefix, middle, and suffix nodes if depending on how the mark's start and end values compare to the parent's. And when appropriate, add a mark to multiple split nodes when their start and values span more than one.

### Linear

- Fixes [ED-648](https://linear.app/84000/issue/ED-648)

### Notes

I am surprised this change wasn't necessary much sooner. There may not be a ton of overlapping mark annotations, so it may not have been obvious. This update addresses the combination of a `mantra` annotation and several `endNoteLink` annotations in particular -- where both annotations were applied multiple times to the same content -- but the fix should address many subtle bugs that we may have been overlooking.
