### PR TITLE
Parent Blocks

### DIFF
--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -121,8 +121,9 @@ const TEMPLATES_FOR_BLOCK_TYPE: {
 };
 
 enum BlockPriority {
-  OuterBlock = 1,
-  Attribute = 2,
+  OuterBlock = 0,
+  Attribute = 1,
+  ParentBlock = 2,
   Block = 3,
   Inline = 4,
   Mark = 5,
@@ -146,9 +147,9 @@ const PRIORITY_FOR_ANNOTAION_TYPE: { [key in AnnotationType]: BlockPriority } =
     internalLink: BlockPriority.Mark,
     leadingSpace: BlockPriority.Attribute,
     line: BlockPriority.Block,
-    lineGroup: BlockPriority.OuterBlock,
+    lineGroup: BlockPriority.ParentBlock,
     link: BlockPriority.Mark,
-    list: BlockPriority.OuterBlock,
+    list: BlockPriority.ParentBlock,
     listItem: BlockPriority.Block,
     mantra: BlockPriority.Mark,
     paragraph: BlockPriority.OuterBlock,
@@ -158,8 +159,8 @@ const PRIORITY_FOR_ANNOTAION_TYPE: { [key in AnnotationType]: BlockPriority } =
     span: BlockPriority.Mark,
     table: BlockPriority.OuterBlock,
     tableBodyData: BlockPriority.Block,
-    tableBodyHeader: BlockPriority.OuterBlock,
-    tableBodyRow: BlockPriority.OuterBlock,
+    tableBodyHeader: BlockPriority.ParentBlock,
+    tableBodyRow: BlockPriority.ParentBlock,
     trailer: BlockPriority.OuterBlock,
     unknown: BlockPriority.Unknown,
   };


### PR DESCRIPTION
### Summary

When two annotations have the same start and end values _and_ mutate the block type, there needs to be a notion of priority. This is a first stab at that. There is now a concept of a parent block that has slightly lower than an outer block. Parent blocks generally have children of a specific type, such as lists and line groups. Outer blocks are usually the first child of a passage; although not always. Specifically, the goal here is to get line groups nested within blockquotes to render. in Tohs 1181 and 1189

### Linear

- part of [ED-277](https://linear.app/84000/issue/ED-277)
- part of [ED-85](https://linear.app/84000/issue/ED-85)
