### PR TITLE
Glossary Attestations Feature Flag

### DIFF
--- a/libs/data-access/src/lib/glossary.ts
+++ b/libs/data-access/src/lib/glossary.ts
@@ -59,12 +59,15 @@ export const getAllGlossaryTerms = async ({
 export const getGlossaryInstances = async ({
   client,
   uuid,
+  withAttestations = false,
 }: {
   client: DataClient;
   uuid: string;
+  withAttestations?: boolean;
 }) => {
   const { data, error } = await client.rpc('show_glossary_entries', {
     v_work_uuid: uuid,
+    v_with_attestation: withAttestations,
   });
   if (error) {
     console.error(

--- a/libs/lib-editing/src/lib/components/editor/EditorBackMatterPage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorBackMatterPage.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from 'react';
 import { TranslationEditorContent } from '../editor';
 import { TranslationSkeleton } from '../shared/TranslationSkeleton';
 import { TranslationBuilder } from '../editor';
+import { isStaticFeatureEnabled } from '@lib-instr/static';
 
 export const EditorBackMatterPage = () => {
   const { work } = useEditorState();
@@ -45,7 +46,12 @@ export const EditorBackMatterPage = () => {
       );
       setAbbreviations(abbreviations);
 
-      const glossary = await getGlossaryInstances({ client, uuid });
+      const withAttestations = isStaticFeatureEnabled('glossary-attestations');
+      const glossary = await getGlossaryInstances({
+        client,
+        uuid,
+        withAttestations,
+      });
       setGlossary(glossary);
 
       const bibliography = await getBibliographyEntries({ client, uuid });

--- a/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPage.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPage.tsx
@@ -1,10 +1,10 @@
 import {
   createBrowserClient,
-  BACK_MATTER_FILTER,
   getTranslationPassages,
   getGlossaryInstances,
   getBibliographyEntries,
 } from '@data-access';
+import { isStaticFeatureEnabled } from '@lib-instr/static';
 import { blocksFromTranslationBody } from '../../block';
 import { ReaderBackMatterPanel } from './ReaderBackMatterPanel';
 import { isUuid } from '@lib-utils';
@@ -37,7 +37,12 @@ export const ReaderBackMatterPage = async ({
   });
   const abbreviations = blocksFromTranslationBody(abbreviationPassages);
 
-  const glossary = await getGlossaryInstances({ client, uuid: slug });
+  const withAttestations = isStaticFeatureEnabled('glossary-attestations');
+  const glossary = await getGlossaryInstances({
+    client,
+    uuid: slug,
+    withAttestations,
+  });
   const bibliography = await getBibliographyEntries({ client, uuid: slug });
 
   return (

--- a/libs/lib-instr/src/lib/static-features.ts
+++ b/libs/lib-instr/src/lib/static-features.ts
@@ -1,0 +1,21 @@
+// NOTE: PostHog does not currently support checking feature flags or remote
+// config values during server-side rendering. Until that is supported, we will
+// use this hard coded configuration.
+
+export type StaticFeature = 'glossary-attestations';
+
+const STATIC_FEATURE_FLAGS: Record<StaticFeature, string[]> = {
+  'glossary-attestations': ['scholars-room'],
+};
+
+export const isStaticFeatureEnabled = (flagKey: StaticFeature) => {
+  const APPLICATION_NAME = process.env.NEXT_PUBLIC_APPLICATION_NAME || '';
+
+  const apps = STATIC_FEATURE_FLAGS[flagKey] || [];
+
+  if (!apps.length) {
+    return true;
+  }
+
+  return apps.includes(APPLICATION_NAME);
+};

--- a/libs/lib-instr/src/static.ts
+++ b/libs/lib-instr/src/static.ts
@@ -1,0 +1,1 @@
+export * from './lib/static-features';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
       "@lib-glossary/ssr": ["libs/lib-glossary/src/ssr.ts"],
       "@lib-instr": ["libs/lib-instr/src/index.ts"],
       "@lib-instr/ssr": ["libs/lib-instr/src/ssr.ts"],
+      "@lib-instr/static": ["libs/lib-instr/src/static.ts"],
       "@lib-search": ["libs/lib-search/src/index.ts"],
       "@lib-user": ["libs/lib-user/src/index.ts"],
       "@lib-user/ssr": ["libs/lib-user/src/ssr.ts"],


### PR DESCRIPTION
### Summary

Only show glossary attestation in the Scholar's Room app.

### Linear

- [DEV-444](https://linear.app/84000/issue/DEV-444)

### Notes

Unfortunately, PostHog does not support checking feature flags or remote configurations when static generating a page. Instead of using their SDK, I had to improvise a hacky solution to mimic the existence of a feature flag. I look forward to replacing this in the future.