### PR TITLE
Blockquote Style

### DIFF
--- a/libs/design-system/src/lib/Typography/Typography.tsx
+++ b/libs/design-system/src/lib/Typography/Typography.tsx
@@ -235,7 +235,7 @@ export function A({
   );
 }
 
-export const BLOCKQUOTE_STYLE = 'mt-6 border-l-2 border-l-border pl-6 italic';
+export const BLOCKQUOTE_STYLE = 'mt-6 border-l-2 border-l-border pl-6';
 export function Blockquote({
   children,
   className,


### PR DESCRIPTION
### Summary

Block quotes are no longer styled as `italic`, which was just the shadcn default.

### Linear

- [DEV-666](https://linear.app/84000/issue/DEV-666)
