### PR TITLE
English in Inline Titles

### DIFF
--- a/libs/lib-editing/src/lib/transformers/annotate.ts
+++ b/libs/lib-editing/src/lib/transformers/annotate.ts
@@ -74,6 +74,7 @@ const TRANSFORMERS: Partial<Record<AnnotationType, Transformer>> = {
 } as const;
 
 export const ITALIC_LANGUAGES: ExtendedTranslationLanguage[] = [
+  'en',
   'Bo-Ltn',
   'Pi-Ltn',
   'Sa-Ltn',


### PR DESCRIPTION
### Summary

I think I removed `en` from the list of italics languages used by `inline-title` in a fit of rage while fixing mantras. Even though mantras don't rely on it. This adds it back

### Linear

- [ED-671](https://linear.app/84000/issue/ED-671)

