### PR TITLE
Allow indent on more block types

### DIFF
--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -122,9 +122,9 @@ const TEMPLATES_FOR_BLOCK_TYPE: {
 
 enum BlockPriority {
   OuterBlock = 0,
-  Attribute = 1,
-  ParentBlock = 2,
-  Block = 3,
+  ParentBlock = 1,
+  Block = 2,
+  Attribute = 3,
   Inline = 4,
   Mark = 5,
   Unknown = Number.MIN_SAFE_INTEGER,

--- a/libs/lib-editing/src/lib/components/editor/extensions/Indent.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Indent.ts
@@ -30,7 +30,7 @@ export const Indent = Extension.create<IndentOptions>({
   name: 'indent',
   addOptions() {
     return {
-      types: ['paragraph'],
+      types: ['paragraph', 'lineGroup', 'list', 'blockquote'],
       defaultHasIndent: false,
     };
   },

--- a/libs/lib-editing/src/lib/transformers/indent.ts
+++ b/libs/lib-editing/src/lib/transformers/indent.ts
@@ -5,10 +5,10 @@ export const indent: Transformer = (ctx) => {
   const indentUuid = ctx.annotation.uuid;
   recurse({
     ...ctx,
-    until: ['paragraph'],
-    transform: ({ block: item }) => {
-      item.attrs = {
-        ...item.attrs,
+    until: ['paragraph', 'lineGroup', 'list', 'blockquote'],
+    transform: ({ block }) => {
+      block.attrs = {
+        ...block.attrs,
         hasIndent: true,
         indentUuid,
       };


### PR DESCRIPTION
### Summary

Previously, the `indent` annotation was only applied to `paragraph` blocks and ignored for other types. Now, it can be applied to `paragraph`, `list`, `lineGroup` and `blockquote` types.

### Linear

- [ED-664](https://linear.app/84000/issue/ED-664)
