### PR TITLE
Remove quotes from title in header

### DIFF
--- a/libs/lib-editing/src/lib/components/shared/TranslationHeader.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationHeader.tsx
@@ -73,7 +73,7 @@ export const TranslationHeader = ({ className }: { className?: string }) => {
       <div className="flex gap-2 md:gap-5 min-w-0">
         <MiniLogo className="ms-3 me-1" width={32} height={32} />
         <span className="font-serif font-light truncate text-darkgray text-xs sm:text-sm my-auto flex-shrink">
-          {`${imprint?.mainTitles?.en ? `“${imprint?.mainTitles?.en}”` : ''}${imprint?.section ? ` from ${imprint?.section}` : ''}`}
+          {`${imprint?.mainTitles?.en ? `${imprint?.mainTitles?.en}` : ''}${imprint?.section ? ` from ${imprint?.section}` : ''}`}
         </span>
       </div>
       <SearchButton


### PR DESCRIPTION
### Summary

Because sometimes titles have their own quotes.

### Linear

- [ED-676](https://linear.app/84000/issue/ED-676)
