### PR TITLE
Support contested authorship

### DIFF
--- a/libs/data-access/src/lib/types/imprint.ts
+++ b/libs/data-access/src/lib/types/imprint.ts
@@ -9,7 +9,8 @@ export type Imprint = {
   version?: SemVer;
   restriction?: boolean;
   publishYear?: string;
-  tibetanAuthors?: string;
+  tibetanAuthors?: string[];
+  isAuthorContested: boolean;
   sourceDescription?: string;
   publisherStatement?: string;
   tibetanTranslators?: string;
@@ -30,6 +31,7 @@ export type ImprintDTO = {
   restriction?: boolean;
   publishYear?: string;
   tibetanAuthors?: string;
+  isAuthorContested?: boolean;
   sourceDescription?: string;
   publisherStatement?: string;
   tibetanTranslators?: string;
@@ -50,7 +52,11 @@ export const imprintFromDTO = (dto: ImprintDTO): Imprint => {
     version: dto.version,
     restriction: dto.restriction,
     publishYear: dto.publishYear,
-    tibetanAuthors: dto.tibetanAuthors,
+    tibetanAuthors: dto.tibetanAuthors
+      ?.split(',')
+      .map((author) => author.trim())
+      .filter((author) => author.length > 0),
+    isAuthorContested: dto.isAuthorContested || false,
     sourceDescription: dto.sourceDescription,
     publisherStatement: dto.publisherStatement,
     tibetanTranslators: dto.tibetanTranslators,

--- a/libs/design-system/src/lib/Translation/Title/Titles.tsx
+++ b/libs/design-system/src/lib/Translation/Title/Titles.tsx
@@ -46,11 +46,7 @@ export const Titles = ({
 
   let header = '';
   let main = '';
-  const authors =
-    imprint?.tibetanAuthors
-      ?.split(',')
-      .map((a) => a.trim())
-      .filter((a) => !!a) || [];
+  const authors = imprint?.tibetanAuthors || [];
 
   const footer =
     imprint?.mainTitles?.['Sa-Ltn'] ||
@@ -99,6 +95,8 @@ export const Titles = ({
         toh={imprint?.toh}
         section={imprint?.section}
         authors={authors}
+        attribution={imprint?.isAuthorContested ? 'attributed to' : 'by'}
+        authorsJoiner={imprint?.isAuthorContested ? ' or' : ','}
         canEdit={canEdit}
         onEdit={() => setIsEditOpen(true)}
       />

--- a/libs/design-system/src/lib/Translation/Title/TitlesCard.tsx
+++ b/libs/design-system/src/lib/Translation/Title/TitlesCard.tsx
@@ -12,6 +12,8 @@ export const TitlesCard = ({
   toh = '',
   section = '',
   authors = [],
+  attribution = 'by',
+  authorsJoiner = ',',
   canEdit = false,
   onEdit,
 }: {
@@ -21,6 +23,8 @@ export const TitlesCard = ({
   toh?: string;
   section?: string;
   authors?: string[];
+  attribution?: string;
+  authorsJoiner?: string;
   canEdit?: boolean;
   onEdit?(): void;
 }) => {
@@ -84,7 +88,7 @@ export const TitlesCard = ({
         {authors.length > 0 && (
           <div className="font-serif title-sub">
             <div className="uppercase text-xs text-muted-foreground py-2">
-              By
+              {attribution}
             </div>
             <div className="flex gap-x-2 mx-auto flex-wrap justify-center text-secondary -mt-2 text-xl">
               {authors.map((author, idx) => (
@@ -93,7 +97,9 @@ export const TitlesCard = ({
                     {author}
                   </span>
                   {idx < authors.length - 1 && (
-                    <span key={`comma-${idx}`}>,</span>
+                    <span key={`comma-${idx}`} className="whitespace-pre">
+                      {authorsJoiner}
+                    </span>
                   )}
                 </div>
               ))}


### PR DESCRIPTION
### Summary

I added a flag `isAuthorContested` to the `get_imprint` function in Supabase. This change adds support for that flag. When present, the titles component changes the attribution from `by` to `attributed to`, and the list of authors is separated by `or` instead of a comma.

### Linear

- [DEV-468](https://linear.app/84000/issue/DEV-468)
