### PR TITLE
Fix Imprint Resolver Missing Toh

### DIFF
--- a/apps/api-graphql/src/graphql/schema/imprint/imprint.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/imprint/imprint.resolver.ts
@@ -1,14 +1,15 @@
 import { getTranslationImprint } from '@data-access';
 import type { GraphQLContext } from '../../context';
 import type { WorkParent } from '../work/work.types';
+import { parseToh } from '@lib-utils';
 
 export const imprintResolver = async (
   parent: WorkParent,
-  args: { toh?: string },
+  _args: unknown,
   ctx: GraphQLContext,
 ) => {
-  // Use provided toh or default to first toh in the work
-  const toh = args.toh ?? parent.toh[0];
+  // Use selectedToh from work query or default to first toh in the work
+  const toh = parent.selectedToh ?? parent.toh[0];
 
   if (!toh) {
     return null;
@@ -26,7 +27,7 @@ export const imprintResolver = async (
 
   // Transform to GraphQL schema format
   return {
-    toh: imprint.toh,
+    toh: imprint.toh ?? parseToh(toh),
     section: imprint.section,
     version: imprint.version ?? null,
     restriction: imprint.restriction,

--- a/apps/api-graphql/src/graphql/schema/work/work.graphql
+++ b/apps/api-graphql/src/graphql/schema/work/work.graphql
@@ -44,14 +44,10 @@ type Work {
 
   """
   Publication imprint information.
-  For works with multiple Tohoku numbers, optionally specify which one.
+  If the work query specified a toh argument, that value will be used.
+  Otherwise, imprint for the first toh in the work is returned.
   """
-  imprint(
-    """
-    Specific Tohoku number to get imprint for (defaults to first toh in the work)
-    """
-    toh: String
-  ): Imprint
+  imprint: Imprint
 
   """
   Paginated passages from this work
@@ -86,7 +82,20 @@ extend type Query {
   works: [Work!]!
 
   """
-  Get a single work by UUID or Tohoku catalog number
+  Get a single work by UUID or Tohoku catalog number.
+  When both uuid and toh are provided, toh acts as a composite key
+  and will be used as the default for nested resolvers (like imprint).
   """
-  work(uuid: ID, toh: String): Work
+  work(
+    """
+    Unique identifier for the work
+    """
+    uuid: ID
+
+    """
+    Tohoku catalog entry number. Can be combined with uuid to select
+    a specific toh for multi-toh works (composite key).
+    """
+    toh: String
+  ): Work
 }

--- a/apps/api-graphql/src/graphql/schema/work/work.query.ts
+++ b/apps/api-graphql/src/graphql/schema/work/work.query.ts
@@ -2,6 +2,7 @@ import {
   getTranslationsMetadata,
   getTranslationMetadataByUuid,
   getTranslationMetadataByToh,
+  type TohokuCatalogEntry,
 } from '@data-access';
 import type { GraphQLContext } from '../../context';
 
@@ -25,6 +26,15 @@ export const workQueries = {
         client: ctx.supabase,
         uuid: args.uuid,
       });
+
+      // Validate toh if both uuid and toh are provided
+      if (
+        args.toh &&
+        work &&
+        !work.toh.includes(args.toh as TohokuCatalogEntry)
+      ) {
+        throw new Error(`Work ${args.uuid} does not contain toh ${args.toh}`);
+      }
     } else if (args.toh) {
       work = await getTranslationMetadataByToh({
         client: ctx.supabase,
@@ -37,6 +47,7 @@ export const workQueries = {
     if (!work) return null;
     return {
       ...work,
+      selectedToh: args.toh, // Pass the selected toh to child resolvers
       publicationDate: work.publicationDate.toISOString(),
     };
   },

--- a/apps/api-graphql/src/graphql/schema/work/work.types.ts
+++ b/apps/api-graphql/src/graphql/schema/work/work.types.ts
@@ -4,6 +4,7 @@
 export interface WorkParent {
   uuid: string;
   toh: string[];
+  selectedToh?: string; // The toh selected in the work query (composite key)
   title: string;
   publicationDate: string;
   publicationVersion: string;

--- a/libs/data-access/src/lib/publications.ts
+++ b/libs/data-access/src/lib/publications.ts
@@ -145,23 +145,32 @@ export const getTranslationMetadataByToh = async ({
   toh: string;
 }) => {
   const { data } = await client
-    .from('works')
+    .from('work_toh')
     .select(
       `
-      uuid,
-      title,
-      toh,
-      publicationDate,
-      publicationVersion,
-      pages:source_pages,
-      restriction,
-      breadcrumb
+      work_uuid,
+      works!inner(
+        uuid,
+        title,
+        toh,
+        publicationDate,
+        publicationVersion,
+        pages:source_pages,
+        restriction,
+        breadcrumb
+      )
     `,
     )
-    .eq('toh', toh)
+    .eq('toh_clean', toh)
     .single();
 
-  return workFromDTO(data as WorkDTO);
+  // Extract the work data from the joined result
+  const workData = data?.works as WorkDTO | undefined;
+  if (!workData) {
+    return null;
+  }
+
+  return workFromDTO(workData);
 };
 
 export const getTranslationsMetadata = async ({


### PR DESCRIPTION
### Summary

The first pass of the imprint resolver had an optional `toh` argument with a fallback to the first `toh` value in the work response. Now, the top-level `toh` input is used. In addition, looking up a work by Tohoku number now uses the `work_toh` table instead of simply querying the `toh` column of `works`. The old approach would fail if a work had more than one Tohoku.

