### PR TITLE
Apply List Styles

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/List.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/List.ts
@@ -1,4 +1,3 @@
-import { cn } from '@lib-utils';
 import { BulletList } from '@tiptap/extension-list';
 import { mergeAttributes } from '@tiptap/react';
 
@@ -7,12 +6,12 @@ const ITEM_STYLE_TO_CLASS: { [key: string]: string } = {
   dots: 'list-[disc]',
   circles: 'list-[circle]',
   numbers: 'list-decimal',
-  letters: 'list-[upper-latin]',
+  letters: 'list-[lower-latin]',
 };
 
 const LIST_SPACING_TO_CLASS: { [key: string]: string } = {
   horizontal: 'ml-4',
-  vertical: '',
+  vertical: 'mt-4',
 };
 
 export const List = BulletList.extend({
@@ -33,7 +32,10 @@ export const List = BulletList.extend({
         parseHTML: (element) => element.getAttribute('data-spacing'),
         renderHTML(attributes) {
           return mergeAttributes(attributes, {
-            'data-spacing': attributes.listSpacing,
+            'data-spacing': attributes.spacing,
+            class:
+              LIST_SPACING_TO_CLASS[attributes.spacing || 'horizontal'] ||
+              'ml-4',
           });
         },
       },
@@ -46,10 +48,6 @@ export const List = BulletList.extend({
         renderHTML(attributes) {
           return mergeAttributes(attributes, {
             'data-nesting': `${attributes.nesting}`,
-            class: cn(
-              LIST_SPACING_TO_CLASS[attributes.spacing || 'horizontal'] ||
-                'ml-4',
-            ),
           });
         },
       },
@@ -57,15 +55,12 @@ export const List = BulletList.extend({
         default: 'none',
         parseHTML: (element) => element.getAttribute('data-item-style'),
         renderHTML(attributes) {
-          return {
-            ...mergeAttributes(attributes, {
-              'data-item-style': attributes.itemStyle,
-            }),
-            class: cn(
+          return mergeAttributes(attributes, {
+            'data-item-style': attributes.itemStyle,
+            class:
               ITEM_STYLE_TO_CLASS[attributes.itemStyle || 'none'] ||
-                'list-none',
-            ),
-          };
+              'list-none',
+          });
         },
       },
     };


### PR DESCRIPTION
### Summary

Apply `list-spacing` and `list-item-style` properties to `list` annotations. `list-spacing` applies padding. `list-item-style` sets the bullet point style. The supported values for `list-item-style` are:

- `dots` -> •
- `circles` -> ◦
- `numbers` -> 1. 2. 3. etc
- `letters` -> a. b. c. etc
- `none` -> no bullet (default)

### Linear

- complete [ED-705](https://linear.app/84000/issue/ED-705)

### Notes

`nesting` is not currently applied since it is naturally handled by the document hierarchy.
