### PR TITLE
support tab query param and pass the reset through

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
+++ b/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
@@ -1,16 +1,17 @@
 import { lookupEntity } from '@data-access/ssr';
 import { notFound, redirect } from 'next/navigation';
+import { NextRequest } from 'next/server';
 
 export async function GET(
-  _request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ type: string; slug: string }> },
 ) {
   const { type, slug: entity } = await params;
-  const path = await lookupEntity({
-    type,
-    entity,
-    prefix: '/publications/reader',
-  });
+  const {
+    nextUrl: { searchParams },
+  } = request;
+
+  const path = await lookupEntity({ type, entity, searchParams });
 
   if (!path) {
     return notFound();

--- a/apps/web-main/src/app/(DashboardLayout)/translation/[slug]/route.ts
+++ b/apps/web-main/src/app/(DashboardLayout)/translation/[slug]/route.ts
@@ -9,11 +9,13 @@ export async function GET(
   const { slug: entity } = await params;
   const query = request.nextUrl.searchParams;
   const xmlId = query.get('xmlId') || undefined;
+  query.delete('xmlId');
   const path = await lookupEntity({
     type: 'translation',
     entity,
     prefix: '/publications/reader',
     xmlId,
+    searchParams: query,
   });
 
   if (!path) {

--- a/apps/web-reader-mfe/src/app/entity/[type]/[slug]/route.ts
+++ b/apps/web-reader-mfe/src/app/entity/[type]/[slug]/route.ts
@@ -1,12 +1,17 @@
 import { lookupEntity } from '@data-access/ssr';
 import { notFound, redirect } from 'next/navigation';
+import { NextRequest } from 'next/server';
 
 export async function GET(
-  _request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ type: string; slug: string }> },
 ) {
   const { type, slug: entity } = await params;
-  const path = await lookupEntity({ type, entity });
+  const {
+    nextUrl: { searchParams },
+  } = request;
+
+  const path = await lookupEntity({ type, entity, searchParams });
 
   if (!path) {
     return notFound();

--- a/apps/web-reader-mfe/src/app/translation/[slug]/route.ts
+++ b/apps/web-reader-mfe/src/app/translation/[slug]/route.ts
@@ -9,10 +9,12 @@ export async function GET(
   const { slug: entity } = await params;
   const query = request.nextUrl.searchParams;
   const xmlId = query.get('xmlId') || undefined;
+  query.delete('xmlId');
   const path = await lookupEntity({
     type: 'translation',
     entity,
     xmlId,
+    searchParams: query,
   });
 
   if (!path) {

--- a/apps/web-reader/src/app/entity/[type]/[slug]/route.ts
+++ b/apps/web-reader/src/app/entity/[type]/[slug]/route.ts
@@ -1,12 +1,17 @@
 import { lookupEntity } from '@data-access/ssr';
 import { notFound, redirect } from 'next/navigation';
+import { NextRequest } from 'next/server';
 
 export async function GET(
-  _request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ type: string; slug: string }> },
 ) {
   const { type, slug: entity } = await params;
-  const path = await lookupEntity({ type, entity });
+  const {
+    nextUrl: { searchParams },
+  } = request;
+
+  const path = await lookupEntity({ type, entity, searchParams });
 
   if (!path) {
     return notFound();

--- a/apps/web-reader/src/app/translation/[slug]/route.ts
+++ b/apps/web-reader/src/app/translation/[slug]/route.ts
@@ -9,10 +9,12 @@ export async function GET(
   const { slug: entity } = await params;
   const query = request.nextUrl.searchParams;
   const xmlId = query.get('xmlId') || undefined;
+  query.delete('xmlId');
   const path = await lookupEntity({
     type: 'translation',
     entity,
     xmlId,
+    searchParams: query,
   });
 
   if (!path) {

--- a/libs/data-access/src/lib/layout.ts
+++ b/libs/data-access/src/lib/layout.ts
@@ -2,14 +2,20 @@ import {
   PANEL_FOR_CONTENT_SECTION,
   PanelContentType,
   TAB_FOR_CONTENT_SECTION,
+  VARIANT_TABS_FOR_TAB,
 } from './types';
 
 export const panelAndTabForContentType = (
   contentType: PanelContentType,
+  desiredTab?: string,
 ): { panel: string; tab: string } => {
   const section = contentType.replace('Header', '');
   const panel = PANEL_FOR_CONTENT_SECTION[section] || 'main';
-  const tab = TAB_FOR_CONTENT_SECTION[section] || 'translation';
+  const defaultTab = TAB_FOR_CONTENT_SECTION[section] || 'translation';
+  const variantTabs = VARIANT_TABS_FOR_TAB[section] || [];
+  const tab =
+    desiredTab && variantTabs.includes(desiredTab) ? desiredTab : defaultTab;
+
   return { panel, tab };
 };
 

--- a/libs/data-access/src/lib/types/layout.ts
+++ b/libs/data-access/src/lib/types/layout.ts
@@ -13,13 +13,10 @@ export const TAB_FOR_CONTENT_SECTION: Partial<
   abbreviations: 'abbreviations',
   acknowledgment: 'front',
   bibliography: 'bibliography',
-  compare: 'compare',
   endnotes: 'endnotes',
-  glossary: 'glossary',
   introduction: 'front',
-  source: 'source',
   summary: 'front',
-};
+} as const;
 
 // NOTE: default to 'main' for content types not listed here
 export const PANEL_FOR_CONTENT_SECTION: Partial<
@@ -30,4 +27,10 @@ export const PANEL_FOR_CONTENT_SECTION: Partial<
   endnotes: 'right',
   glossary: 'right',
   source: 'main',
-};
+} as const;
+
+// Support different tabs for some content
+export const VARIANT_TABS_FOR_TAB: Partial<Record<PanelContentType, string[]>> =
+  {
+    translation: ['compare'],
+  } as const;


### PR DESCRIPTION
### Summary

- Support a `tab` query parameter on requests to the `/entity` endpoint. The goal is to allow passages to be routed to either the main translation tab or the compare tab`. It will only open the `compare` tab if the requested passage is in the main translation body.
- Pass other query parameters to the target url

### Linear

- [DEV-474](https://linear.app/84000/issue/DEV-474)
