### PR TITLE
Migration Script Comments

### DIFF
--- a/apps/node-scripts/README.md
+++ b/apps/node-scripts/README.md
@@ -1,0 +1,61 @@
+# Node Scripts
+
+Database migration scripts for enriching passage annotations with UUID references.
+
+## Overview
+
+These scripts migrate passage annotations in Supabase to include UUID references alongside existing XML ID references. This enables faster lookups by avoiding the need to resolve XML IDs at query time.
+
+## Prerequisites
+
+Create a `.env` file with:
+
+```env
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_SERVICE_KEY=<your-service-key>
+```
+
+## Scripts
+
+### migrate-glossary-instances.ts
+
+Migrates `glossary-instance` annotations to include glossary UUIDs.
+
+- Fetches annotations with `glossary_xmlId` but no `uuid`
+- Looks up UUIDs from the `glossaries` table (termType: translationMain)
+- Upserts enriched content with both `glossary_xmlId` and `uuid`
+
+```bash
+npx ts-node apps/node-scripts/src/migrate-glossary-instances.ts
+```
+
+### migrate-passage-refs.ts
+
+Migrates `abbreviation` annotations to include passage UUIDs.
+
+- Fetches annotations with `abbreviation_xmlId` but no `uuid`
+- Restructures content to include the passage UUID
+
+```bash
+npx ts-node apps/node-scripts/src/migrate-passage-refs.ts
+```
+
+### migrate-endnotes.ts
+
+Migrates `end-note-link` annotations to include endnote passage UUIDs.
+
+- Fetches annotations with `endnote_xmlId` but no `uuid`
+- Looks up UUIDs from the `passages` table
+- Upserts enriched content with both `endnote_xmlId` and `uuid`
+
+```bash
+npx ts-node apps/node-scripts/src/migrate-endnotes.ts
+```
+
+## Shared Modules
+
+| File        | Purpose                                                    |
+| ----------- | ---------------------------------------------------------- |
+| `config.ts` | Loads environment variables and creates Supabase client    |
+| `fetch.ts`  | Paginated query helper for fetching unmigrated annotations |
+| `types.ts`  | TypeScript type definitions                                |

--- a/apps/node-scripts/src/config.ts
+++ b/apps/node-scripts/src/config.ts
@@ -1,6 +1,20 @@
+/**
+ * Configuration module for node scripts.
+ *
+ * Loads environment variables and initializes a Supabase client
+ * with service-level credentials for database operations.
+ */
+
 import { config } from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 
+/**
+ * Loads environment configuration and creates a Supabase client.
+ *
+ * @returns An object containing:
+ *   - supabase: Authenticated Supabase client using service key
+ *   - pageSize: Default batch size for paginated queries (100)
+ */
 export const loadConfig = () => {
   config();
 

--- a/apps/node-scripts/src/fetch.ts
+++ b/apps/node-scripts/src/fetch.ts
@@ -1,5 +1,29 @@
+/**
+ * Fetch utilities for passage annotation queries.
+ *
+ * Provides paginated fetching of passage annotations from Supabase
+ * with flexible filtering by annotation type and content structure.
+ */
+
 import { SupabaseClient } from '@supabase/supabase-js';
 
+/**
+ * Fetches a page of passage annotations that need migration.
+ *
+ * Queries the `passage_annotations` table for records that:
+ * - Match the specified annotation type
+ * - Have a non-null value at the specified content path (need migration)
+ * - Have a null value at the null check path (not yet migrated)
+ *
+ * @param supabase - Authenticated Supabase client
+ * @param type - Annotation type to filter by (e.g., 'glossary-instance', 'end-note-link')
+ * @param contentType - JSON key to extract from content array (e.g., 'glossary_xmlId')
+ * @param contentIndex - Index in content array to read from (default: 0)
+ * @param nullType - JSON key to check for null (indicates unmigrated record)
+ * @param nullIndex - Index in content array for null check (default: 0)
+ * @param limit - Maximum number of records to fetch per page
+ * @returns Supabase query result with annotation data
+ */
 export const fetchPage = async ({
   supabase,
   type,

--- a/apps/node-scripts/src/migrate-endnotes.ts
+++ b/apps/node-scripts/src/migrate-endnotes.ts
@@ -1,3 +1,22 @@
+/**
+ * Migration script: Endnote Link Annotations
+ *
+ * This script migrates end-note-link passage annotations to include
+ * the endnote passage UUID alongside the existing endnote_xmlId.
+ *
+ * Problem solved:
+ * - Annotations originally only stored `endnote_xmlId` references
+ * - This script looks up the corresponding passage UUID from the `passages` table
+ * - Updates the annotation content to include both xmlId and uuid for faster lookups
+ *
+ * Process:
+ * 1. Fetch batches of end-note-link annotations that have xmlId but no uuid
+ * 2. Look up the endnote passage UUIDs from the `passages` table
+ * 3. Upsert the annotations with the enriched content structure
+ *
+ * Run: npx ts-node apps/node-scripts/src/migrate-endnotes.ts
+ */
+
 import { loadConfig } from './config';
 import { fetchPage } from './fetch';
 import { AnnotationTransformer, PassageAnnotationModel } from './types';

--- a/apps/node-scripts/src/migrate-glossary-instances.ts
+++ b/apps/node-scripts/src/migrate-glossary-instances.ts
@@ -1,3 +1,22 @@
+/**
+ * Migration script: Glossary Instance Annotations
+ *
+ * This script migrates glossary-instance passage annotations to include
+ * the glossary UUID alongside the existing glossary_xmlId.
+ *
+ * Problem solved:
+ * - Annotations originally only stored `glossary_xmlId` references
+ * - This script looks up the corresponding glossary UUID from the `glossaries` table
+ * - Updates the annotation content to include both xmlId and uuid for faster lookups
+ *
+ * Process:
+ * 1. Fetch batches of glossary-instance annotations that have xmlId but no uuid
+ * 2. Look up the glossary UUIDs from the `glossaries` table (termType: translationMain)
+ * 3. Upsert the annotations with the enriched content structure
+ *
+ * Run: npx ts-node apps/node-scripts/src/migrate-glossary-instances.ts
+ */
+
 import { loadConfig } from './config';
 import { fetchPage } from './fetch';
 import { AnnotationTransformer, PassageAnnotationModel } from './types';

--- a/apps/node-scripts/src/migrate-passage-refs.ts
+++ b/apps/node-scripts/src/migrate-passage-refs.ts
@@ -1,3 +1,21 @@
+/**
+ * Migration script: Passage Reference (Abbreviation) Annotations
+ *
+ * This script migrates abbreviation passage annotations to include
+ * the passage UUID alongside the existing abbreviation_xmlId.
+ *
+ * Problem solved:
+ * - Annotations originally only stored `abbreviation_xmlId` references
+ * - This script restructures the content to include both xmlId and uuid
+ *
+ * Process:
+ * 1. Fetch batches of abbreviation annotations that have xmlId but no uuid
+ * 2. Transform the content structure to include the passage uuid
+ * 3. Upsert the annotations with the enriched content structure
+ *
+ * Run: npx ts-node apps/node-scripts/src/migrate-passage-refs.ts
+ */
+
 import { loadConfig } from './config';
 import { fetchPage } from './fetch';
 import { PassageAnnotationModel } from './types';

--- a/apps/node-scripts/src/types.ts
+++ b/apps/node-scripts/src/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Type definitions for passage annotation migration scripts.
+ */
+
+/**
+ * Represents a passage annotation record as stored in the database.
+ * Used for upserting migrated annotation data.
+ */
 export type PassageAnnotationModel = {
   uuid: string;
   created_at: unknown | null;
@@ -12,6 +20,11 @@ export type PassageAnnotationModel = {
   toh: unknown | null;
 };
 
+/**
+ * Intermediate type used during annotation migration.
+ * Extends fetched annotation data with a target UUID field
+ * that gets populated by looking up the referenced entity.
+ */
 export type AnnotationTransformer = {
   annotationUuid: string;
   createdAt: unknown;


### PR DESCRIPTION
### Summary

Adds some documentation to the migration helper scripts in the monorepo. They aren't run very often, so it would be nice to not need to re-read the code _every_ time.
