### PR TITLE
Fix: ensure no unicode in cookies

### DIFF
--- a/libs/client-graphql/src/lib/client-ssr.ts
+++ b/libs/client-graphql/src/lib/client-ssr.ts
@@ -16,9 +16,10 @@ export async function createServerGraphQLClient(): Promise<GraphQLClient> {
   const cookieStore = await cookies();
   const allCookies = cookieStore.getAll();
 
-  // Build cookie header string
+  // Build cookie header string with encoded values to ensure HTTP header compatibility
+  // Cookie values may contain non-ASCII characters which are invalid in HTTP headers (ByteString)
   const cookieHeader = allCookies
-    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .map((cookie) => `${cookie.name}=${encodeURIComponent(cookie.value)}`)
     .join('; ');
 
   const client = new GraphQLClient(url, {


### PR DESCRIPTION
### Summary

Jeff reported 404 errors in the reader. The logs suggested some unicode was sneaking into response headers. This ensures that doesn't happen by enforcing url encoding.
