### PR TITLE
Configure Global Public Routes

### DIFF
--- a/apps/web-main/next.config.js
+++ b/apps/web-main/next.config.js
@@ -34,7 +34,11 @@ async function fetchAndWriteStudioRoutes() {
       return emptyConfig;
     }
 
-    const config = { rewrites: [], publicRoutes: [], restrictedRoutes: {} };
+    const config = {
+      rewrites: [],
+      publicRoutes: payload.publicRoutes || [],
+      restrictedRoutes: {}
+    };
 
     for (const menuItem of payload.items) {
       for (const subItem of menuItem.items || []) {


### PR DESCRIPTION
### Summary

Looks for a top-level `publicRoutes` entry in the remote config. These will be public but not shown in the Studio app header. This is useful for hosting embeddable widgets or possibly webhooks.
