### PR TITLE
Optional Tibetan Decoration

### DIFF
--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.tsx
@@ -57,7 +57,7 @@ export const Titles = ({
       const boMain =
         imprint?.mainTitles?.bo ||
         mainTitles.find((t) => t.language === 'bo')?.title;
-      header = `${BO_TITLE_PREFIX}${boMain || ''}`;
+      header = boMain ? `${BO_TITLE_PREFIX}${boMain || ''}` : '';
       break;
     }
     case 'comparison': {
@@ -68,7 +68,7 @@ export const Titles = ({
         imprint?.mainTitles?.en ||
         mainTitles.find((t) => t.language === 'en')?.title ||
         '';
-      header = `${BO_TITLE_PREFIX}${boMain || ''}`;
+      header = boMain ? `${BO_TITLE_PREFIX}${boMain || ''}` : '';
       main = enMain;
       break;
     }
@@ -76,7 +76,7 @@ export const Titles = ({
       const boMain =
         imprint?.mainTitles?.bo ||
         mainTitles.find((t) => t.language === 'bo')?.title;
-      header = `${BO_TITLE_PREFIX}${boMain || ''}`;
+      header = boMain ? `${BO_TITLE_PREFIX}${boMain || ''}` : '';
       main =
         imprint?.mainTitles?.en ||
         mainTitles.find((t) => t.language === 'en')?.title ||


### PR DESCRIPTION
### Summary

If a Tibetan title is not returned from the backend, don't show the decoration. The original logic didn't worry about this because it assumed there would always be a Tibetan title.

### Linear

- [ED-1181](https://linear.app/84000/issue/ED-1181)
