### PR TITLE
Fix Compare Tab Links

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -116,7 +116,11 @@ export const PaginationProvider = ({
   // matches — this prevents a PaginationProvider for one tab (e.g. endnotes)
   // from reacting to hashes set by a different tab (e.g. glossary).
   const panelHash =
-    !tab || panels[panel]?.tab === tab ? panels[panel]?.hash : undefined;
+    !tab ||
+      panels[panel]?.tab === tab ||
+      (tab === 'translation' && panels[panel]?.tab === 'compare') ||
+      (tab === 'compare' && panels[panel]?.tab === 'translation')
+      ? panels[panel]?.hash : undefined;
 
   const { extensions } = useTranslationExtensions({
     fragment,

--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -116,11 +116,9 @@ export const PaginationProvider = ({
   // matches — this prevents a PaginationProvider for one tab (e.g. endnotes)
   // from reacting to hashes set by a different tab (e.g. glossary).
   const panelHash =
-    !tab ||
-      panels[panel]?.tab === tab ||
-      (tab === 'translation' && panels[panel]?.tab === 'compare') ||
-      (tab === 'compare' && panels[panel]?.tab === 'translation')
-      ? panels[panel]?.hash : undefined;
+    !tab || panels[panel]?.tab === tab || (tab === 'translation' && panels[panel]?.tab === 'compare')
+      ? panels[panel]?.hash
+      : undefined;
 
   const { extensions } = useTranslationExtensions({
     fragment,

--- a/libs/lib-editing/src/lib/components/shared/NavigationContext.ts
+++ b/libs/lib-editing/src/lib/components/shared/NavigationContext.ts
@@ -9,7 +9,7 @@ import type {
   Work,
 } from '@eightyfourthousand/data-access';
 import { createContext, useContext } from 'react';
-import { PanelName, PanelsState, PanelState, TabName } from './types';
+import { PanelName, PanelsState, PanelState } from './types';
 
 export interface NavigationState {
   uuid: string;

--- a/libs/lib-editing/src/lib/components/shared/ReaderSearchButton.tsx
+++ b/libs/lib-editing/src/lib/components/shared/ReaderSearchButton.tsx
@@ -19,6 +19,7 @@ export const ReaderSearchButton = () => {
   const isDirty = useSyncExternalStore(
     dirtyStore.subscribe.bind(dirtyStore),
     dirtyStore.getSnapshot.bind(dirtyStore),
+    () => false,
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

In the main body panel, the `translation` tab and `compare` tab share an underlying editor instance to ensure switching between the two modes is smooth. However, the mechanism that handles internal navigation expected a one -> one mapping. This handles the edge case of navigating to a passage within the `compare` tab.

### Linear

- [DEV-587](https://linear.app/84000/issue/DEV-587)