### PR TITLE
Fix Annotations in Abbreviations

### DIFF
--- a/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
+++ b/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
@@ -21,7 +21,12 @@ export const hasAbbreviation: Transformer = (ctx) => {
             uuid,
           };
           block.content = [
-            { type: 'text', text: block.text, marks: block.marks },
+            {
+              type: 'text',
+              text: block.text,
+              marks: block.marks,
+              attrs: { ...block.attrs }
+            },
           ];
         },
       });

--- a/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
+++ b/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
@@ -5,7 +5,7 @@ import { Transformer } from './transformer';
 
 export const hasAbbreviation: Transformer = (ctx) => {
   const { annotation } = ctx;
-  const { abbreviation, uuid } = annotation as HasAbbreviationAnnotation;
+  const { abbreviation, uuid, start, end } = annotation as HasAbbreviationAnnotation;
 
   recurse({
     until: ['text'],
@@ -25,7 +25,7 @@ export const hasAbbreviation: Transformer = (ctx) => {
               type: 'text',
               text: block.text,
               marks: block.marks,
-              attrs: { ...block.attrs }
+              attrs: { start, end }
             },
           ];
         },


### PR DESCRIPTION
### Summary

The key attributes of `start` and `end` were not being passed down to the text content block of `has-abbreviation` annotations after transformation. This prevented other annotations from being applied.

### Linear

- [ED-1179](https://linear.app/84000/issue/ED-1179)