### PR TITLE
Search Results Priority

### DIFF
--- a/libs/data-access/src/lib/replace.ts
+++ b/libs/data-access/src/lib/replace.ts
@@ -6,6 +6,7 @@ export interface PassageOccurrence {
   passageOccurrenceIndex: number;
   passageUuid: string;
   start: number;
+  type: 'passage' | 'alignment';
 }
 
 export interface PassageReplacementResult {
@@ -50,7 +51,7 @@ export const findLiteralOccurrences = (
 };
 
 export const getPassageOccurrences = (
-  passages: Pick<Passage, 'content' | 'uuid'>[],
+  passages: { content: string; uuid: string; type: 'passage' | 'alignment' }[],
   searchText: string,
 ): PassageOccurrence[] => {
   let index = 0;
@@ -61,6 +62,7 @@ export const getPassageOccurrences = (
       index: index++,
       passageOccurrenceIndex: passageIndex,
       passageUuid: passage.uuid,
+      type: passage.type,
     })),
   );
 };

--- a/libs/lib-search/src/lib/types/search.ts
+++ b/libs/lib-search/src/lib/types/search.ts
@@ -1,11 +1,18 @@
 export const RESULTS_ENTITIES = [
-  'passages',
   'alignments',
+  'passages',
   'bibliographies',
   'glossaries',
 ] as const;
 
 export type ResultsEntity = (typeof RESULTS_ENTITIES)[number];
+
+export const RESULTS_ENTITY_LABELS: Record<ResultsEntity, string> = {
+  alignments: 'Translation Passages',
+  passages: 'Other Passages',
+  bibliographies: 'Bibliographies',
+  glossaries: 'Glossaries',
+} as const;
 
 export type BibliographySearchMatchDTO = {
   bibliography_uuid: string;

--- a/libs/lib-search/src/lib/ui/SearchButton.tsx
+++ b/libs/lib-search/src/lib/ui/SearchButton.tsx
@@ -109,10 +109,10 @@ export const SearchButton = ({
       const nextResults = await search({ text: searchQuery, uuid: workUuid, toh });
       setHasResults(
         !!nextResults &&
-          (nextResults.passages.length > 0 ||
-            nextResults.alignments.length > 0 ||
-            nextResults.bibliographies.length > 0 ||
-            nextResults.glossaries.length > 0),
+        (nextResults.passages.length > 0 ||
+          nextResults.alignments.length > 0 ||
+          nextResults.bibliographies.length > 0 ||
+          nextResults.glossaries.length > 0),
       );
       setResults(nextResults);
 
@@ -211,11 +211,11 @@ export const SearchButton = ({
       const nextPassageIndex =
         pendingSelection.kind === 'cursor' && currentPassageOrder != null
           ? passageOccurrences.findIndex((occurrence) => {
-              const occurrenceOrder = passageOrder.get(occurrence.passageUuid);
-              return (
-                occurrenceOrder != null && occurrenceOrder > currentPassageOrder
-              );
-            })
+            const occurrenceOrder = passageOrder.get(occurrence.passageUuid);
+            return (
+              occurrenceOrder != null && occurrenceOrder > currentPassageOrder
+            );
+          })
           : -1;
 
       setActiveOccurrenceIndexState(nextPassageIndex >= 0 ? nextPassageIndex : 0);
@@ -342,7 +342,7 @@ export const SearchButton = ({
               </div>
               {results && hasResults ? (
                 <Tabs
-                  defaultValue="passages"
+                  defaultValue="alignments"
                   className="flex flex-col grow min-h-0 pt-2"
                 >
                   <SearchResultTabs results={results} />
@@ -355,7 +355,7 @@ export const SearchButton = ({
                           value={tab}
                         >
                           <SearchResultsList
-                            activeOccurrenceStart={activeOccurrenceStart ?? undefined}
+                            activeOccurrenceStart={(activeOccurrenceStart && shouldScrollActiveOccurrence) ? activeOccurrenceStart : undefined}
                             activePassageUuid={activePassageUuid}
                             query={searchQuery}
                             results={results[tab]}

--- a/libs/lib-search/src/lib/ui/SearchButton.tsx
+++ b/libs/lib-search/src/lib/ui/SearchButton.tsx
@@ -17,7 +17,12 @@ import { Loader2Icon, SearchIcon, XIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { search } from '../data';
-import type { PassageMatch, SearchResult, SearchResults } from '../types';
+import type {
+  PassageMatch,
+  ResultsEntity,
+  SearchResult,
+  SearchResults,
+} from '../types';
 import { RESULTS_ENTITIES } from '../types';
 import { SearchResultsList } from './SearchResultsList';
 import { SearchResultTabs } from './SearchResultTab';
@@ -51,6 +56,25 @@ export interface SearchButtonProps {
   workUuid?: string;
 }
 
+const DEFAULT_RESULTS_TAB: ResultsEntity = 'alignments';
+
+const getFirstResultsTab = (results?: SearchResults): ResultsEntity => {
+  return (
+    RESULTS_ENTITIES.find((tab) => (results?.[tab].length ?? 0) > 0) ??
+    DEFAULT_RESULTS_TAB
+  );
+};
+
+const getOccurrenceResultsTab = (
+  occurrence?: PassageOccurrence,
+): ResultsEntity | undefined => {
+  if (!occurrence) {
+    return undefined;
+  }
+
+  return occurrence.type === 'alignment' ? 'alignments' : 'passages';
+};
+
 export const SearchButton = ({
   renderActions,
   workUuid,
@@ -63,14 +87,21 @@ export const SearchButton = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [results, setResults] = useState<SearchResults>();
   const [activeOccurrenceIndex, setActiveOccurrenceIndexState] = useState(0);
+  const [activeResultsTab, setActiveResultsTab] =
+    useState<ResultsEntity>(DEFAULT_RESULTS_TAB);
   const [shouldScrollActiveOccurrence, setShouldScrollActiveOccurrence] =
     useState(false);
-  const pendingOccurrenceSelectionRef =
-    useRef<SearchPendingSelection | null>(null);
+  const pendingOccurrenceSelectionRef = useRef<SearchPendingSelection | null>(
+    null,
+  );
 
   const passageOccurrences = useMemo(
-    () => getPassageOccurrences([...(results?.passages || []), ...(results?.alignments || [])], searchQuery),
-    [results?.passages, searchQuery],
+    () =>
+      getPassageOccurrences(
+        [...(results?.alignments || []), ...(results?.passages || [])],
+        searchQuery,
+      ),
+    [results?.alignments, results?.passages, searchQuery],
   );
   const activeOccurrence = passageOccurrences[activeOccurrenceIndex];
   const activeOccurrenceStart = activeOccurrence?.start ?? null;
@@ -81,7 +112,10 @@ export const SearchButton = ({
   const passageOrder = useMemo(
     () =>
       new Map(
-        (results?.passages || []).map((passage, index) => [passage.uuid, index]),
+        (results?.passages || []).map((passage, index) => [
+          passage.uuid,
+          index,
+        ]),
       ),
     [results?.passages],
   );
@@ -106,7 +140,11 @@ export const SearchButton = ({
       }
 
       setSearching(true);
-      const nextResults = await search({ text: searchQuery, uuid: workUuid, toh });
+      const nextResults = await search({
+        text: searchQuery,
+        uuid: workUuid,
+        toh,
+      });
       setHasResults(
         !!nextResults &&
         (nextResults.passages.length > 0 ||
@@ -129,7 +167,10 @@ export const SearchButton = ({
     (nextIndex: number) => {
       pendingOccurrenceSelectionRef.current = null;
       setActiveOccurrenceIndexState(
-        Math.max(0, Math.min(nextIndex, Math.max(passageOccurrences.length - 1, 0))),
+        Math.max(
+          0,
+          Math.min(nextIndex, Math.max(passageOccurrences.length - 1, 0)),
+        ),
       );
     },
     [passageOccurrences.length],
@@ -168,6 +209,17 @@ export const SearchButton = ({
     setShouldScrollActiveOccurrence(false);
     pendingOccurrenceSelectionRef.current = null;
   }, [open]);
+
+  useEffect(() => {
+    if (!results) {
+      setActiveResultsTab(DEFAULT_RESULTS_TAB);
+      return;
+    }
+
+    setActiveResultsTab((currentTab) =>
+      results[currentTab].length > 0 ? currentTab : getFirstResultsTab(results),
+    );
+  }, [results]);
 
   useEffect(() => {
     if (passageOccurrences.length === 0) {
@@ -218,7 +270,9 @@ export const SearchButton = ({
           })
           : -1;
 
-      setActiveOccurrenceIndexState(nextPassageIndex >= 0 ? nextPassageIndex : 0);
+      setActiveOccurrenceIndexState(
+        nextPassageIndex >= 0 ? nextPassageIndex : 0,
+      );
       pendingOccurrenceSelectionRef.current = null;
       return;
     }
@@ -227,6 +281,17 @@ export const SearchButton = ({
       Math.min(current, passageOccurrences.length - 1),
     );
   }, [passageOccurrences, passageOrder]);
+
+  useEffect(() => {
+    if (!shouldScrollActiveOccurrence || !activeOccurrence || !results) {
+      return;
+    }
+
+    const occurrenceTab = getOccurrenceResultsTab(activeOccurrence);
+    if (occurrenceTab && results[occurrenceTab].length > 0) {
+      setActiveResultsTab(occurrenceTab);
+    }
+  }, [activeOccurrence, results, shouldScrollActiveOccurrence]);
 
   useEffect(() => {
     if (
@@ -240,6 +305,7 @@ export const SearchButton = ({
     scrollActiveOccurrenceIntoView();
   }, [
     activeOccurrenceStart,
+    activeResultsTab,
     activePassageUuid,
     scrollActiveOccurrenceIntoView,
     shouldScrollActiveOccurrence,
@@ -342,7 +408,10 @@ export const SearchButton = ({
               </div>
               {results && hasResults ? (
                 <Tabs
-                  defaultValue="alignments"
+                  value={activeResultsTab}
+                  onValueChange={(tab) => {
+                    setActiveResultsTab(tab as ResultsEntity);
+                  }}
                   className="flex flex-col grow min-h-0 pt-2"
                 >
                   <SearchResultTabs results={results} />
@@ -355,7 +424,12 @@ export const SearchButton = ({
                           value={tab}
                         >
                           <SearchResultsList
-                            activeOccurrenceStart={(activeOccurrenceStart && shouldScrollActiveOccurrence) ? activeOccurrenceStart : undefined}
+                            activeOccurrenceStart={
+                              activeOccurrenceStart != null &&
+                                shouldScrollActiveOccurrence
+                                ? activeOccurrenceStart
+                                : undefined
+                            }
                             activePassageUuid={activePassageUuid}
                             query={searchQuery}
                             results={results[tab]}

--- a/libs/lib-search/src/lib/ui/SearchButton.tsx
+++ b/libs/lib-search/src/lib/ui/SearchButton.tsx
@@ -69,7 +69,7 @@ export const SearchButton = ({
     useRef<SearchPendingSelection | null>(null);
 
   const passageOccurrences = useMemo(
-    () => getPassageOccurrences(results?.passages || [], searchQuery),
+    () => getPassageOccurrences([...(results?.passages || []), ...(results?.alignments || [])], searchQuery),
     [results?.passages, searchQuery],
   );
   const activeOccurrence = passageOccurrences[activeOccurrenceIndex];

--- a/libs/lib-search/src/lib/ui/SearchResultCard.tsx
+++ b/libs/lib-search/src/lib/ui/SearchResultCard.tsx
@@ -74,15 +74,23 @@ export const PassageResult = ({
 };
 
 export const AlignmentResult = ({
+  activeOccurrenceStart,
   match,
   query,
 }: {
+  activeOccurrenceStart?: number;
   match: AlignmentMatch;
   query: string;
 }) => {
   return (
     <div className="grid md:grid-cols-2 gap-4">
-      <div>{highlightText(match.content, query)}</div>
+      <div>
+        {renderPassageHighlight({
+          activeOccurrenceStart,
+          query,
+          text: match.content,
+        })}
+      </div>
       <div className="text-lg">{highlightText(match.source, query)}</div>
     </div>
   );
@@ -138,7 +146,11 @@ export const SearchResultCard = ({
         );
       case 'alignment':
         return (
-          <AlignmentResult match={match as AlignmentMatch} query={query} />
+          <AlignmentResult
+            activeOccurrenceStart={isActive ? activeOccurrenceStart : undefined}
+            match={match as AlignmentMatch}
+            query={query}
+          />
         );
       case 'bibliography':
         return (

--- a/libs/lib-search/src/lib/ui/SearchResultTab.tsx
+++ b/libs/lib-search/src/lib/ui/SearchResultTab.tsx
@@ -1,9 +1,9 @@
 import { TabsList, TabsTrigger } from '@eightyfourthousand/design-system';
-import { RESULTS_ENTITIES, SearchResults } from '../types';
+import { RESULTS_ENTITIES, RESULTS_ENTITY_LABELS, SearchResults } from '../types';
 
 export const SearchResultTabs = ({ results }: { results: SearchResults }) => {
   return (
-    <TabsList className="h-24 gap-4 flex-shrink-0 rounded-lg p-0 w-full bg-transparent">
+    <TabsList className="h-24 gap-4 flex-shrink-0 rounded-lg p-0 w-full bg-transparent sm:p-0">
       {RESULTS_ENTITIES.map(
         (tab) =>
           results[tab].length > 0 && (
@@ -13,8 +13,8 @@ export const SearchResultTabs = ({ results }: { results: SearchResults }) => {
               className="h-full border border-border rounded-xl flex-grow data-[state=inactive]:bg-muted data-[state=active]:border-secondary data-[state=active]:border-3 border-2"
             >
               <div className="flex flex-col gap-1 items-center">
-                <span className="capitalize text-secondary font-bold">
-                  {tab}
+                <span className="text-secondary font-bold">
+                  {RESULTS_ENTITY_LABELS[tab]}
                 </span>
                 <span className="text-primary font-bold">
                   {results[tab].length} matches

--- a/libs/lib-search/src/lib/ui/SearchResultsList.tsx
+++ b/libs/lib-search/src/lib/ui/SearchResultsList.tsx
@@ -16,18 +16,20 @@ export const SearchResultsList = ({
 }) => {
   return (
     <div className="h-full flex flex-col gap-3 pb-4 overflow-y-auto min-h-0">
-      {results.map((result, index) => (
-        <SearchResultCard
-          key={index}
-          activeOccurrenceStart={
-            result.uuid === activePassageUuid ? activeOccurrenceStart : undefined
-          }
-          isActive={result.uuid === activePassageUuid}
-          match={result}
-          query={query}
-          onClick={() => onCardClick(result)}
-        />
-      ))}
+      {results.map((result, index) => {
+        const start = result.uuid === activePassageUuid ? activeOccurrenceStart : undefined;
+        const isActive = !!start;
+        return (
+          <SearchResultCard
+            key={index}
+            activeOccurrenceStart={start}
+            isActive={isActive}
+            match={result}
+            query={query}
+            onClick={() => onCardClick(result)}
+          />
+        )
+      })}
     </div>
   );
 };


### PR DESCRIPTION
### Summary

Previously, our search widget displayed passage results by default, with alignments as the second tab. The issue with this approach is that, because translation passages are excluded from the "Passages" tab and only appear in the "Alignments" tab, it is harder to find the content a user is most likely searching for. But alignments _are_ passages.

This makes alignments the priority, renaming the tab "Translation Passages." The reordering of results exposed related issues with search and replace:

- Translations passages (via alignments) were excluded from the replace UI because they were not considered to be passages
- It was not possible to step through individual translation passages and apply the replace action
- Once the first two were resolved, it became necessary to automatically switch tabs when crossing the boundary between alignment and passage search results

### Linear

- [DEV-553](https://linear.app/84000/issue/DEV-553)
