### PR TITLE
Editor Link Routing

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
+++ b/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
@@ -11,11 +11,14 @@ export async function GET(
     nextUrl: { searchParams },
   } = request;
 
+  const isEditor = searchParams.get('edit') === 'true';
+  const prefix = isEditor ? '/translations/editor' : '/translations/reader';
+
   const path = await lookupEntity({
     type,
     entity,
     searchParams,
-    prefix: '/translations/reader',
+    prefix,
   });
 
   if (!path) {

--- a/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
+++ b/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
@@ -11,7 +11,12 @@ export async function GET(
     nextUrl: { searchParams },
   } = request;
 
-  const path = await lookupEntity({ type, entity, searchParams });
+  const path = await lookupEntity({
+    type,
+    entity,
+    searchParams,
+    prefix: '/translations/reader',
+  });
 
   if (!path) {
     return notFound();

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
@@ -91,7 +91,10 @@ export const InternalLink = Mark.create<InternalLinkOptions>({
         e.preventDefault();
         if (!isSameWork) {
           // Cross-work links open in a new tab
-          const href = props.mark.attrs.href || '#';
+          let href = props.mark.attrs.href || '#';
+          if (isEditable && href) {
+            href = `${href}?edit=true`;
+          }
           window.open(href, '_blank');
           return
         }

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -86,7 +86,10 @@ export const Mention = Node.create<MentionOptions>({
         anchor.textContent = item.text || item.displayText || item.entity;
 
         // Compute href from linkType + entity
-        const href = `/entity/${item.linkType}/${item.entity}`;
+        let href = `/entity/${item.linkType}/${item.entity}`;
+        if (isEditable) {
+          href = `${href}?edit=true`;
+        }
 
         if (item.isSameWork) {
           // Same-work links navigate in-place via panel system


### PR DESCRIPTION
### Summary

The `lookupEntity` function that powers the `/entity` endpoints accepts a prefix parameter. It was previously not being used in Studio, where it was needed. Internal links will now function as expected. They will link to another reader or editor instance depending on the origin.

### Linear

- [DEV-586](https://linear.app/84000/issue/DEV-586)
