### PR TITLE
Nest blockquote Style

### DIFF
--- a/libs/design-system/src/lib/Typography/Typography.tsx
+++ b/libs/design-system/src/lib/Typography/Typography.tsx
@@ -249,7 +249,7 @@ export function A({
   );
 }
 
-export const BLOCKQUOTE_STYLE = 'mt-6 border-l-2 border-l-border pl-6';
+export const BLOCKQUOTE_STYLE = 'mt-6 border-l-2 border-l-border pl-6 [&_blockquote]:border-l-0';
 export function Blockquote({
   children,
   className,


### PR DESCRIPTION
### Summary

Adds a tailwind selector to avoid displaying a left border for nested `blockquote` html elements.

### Linear

- [DEV-331](https://linear.app/84000/issue/DEV-331)
