### PR TITLE
Search Glossary Entries

### DIFF
--- a/libs/lib-search/src/lib/types/search.ts
+++ b/libs/lib-search/src/lib/types/search.ts
@@ -1,3 +1,5 @@
+import { GlossaryTermInstance, GlossaryTermInstanceDTO, glossaryTermInstanceFromDTO } from "@eightyfourthousand/data-access";
+
 export const RESULTS_ENTITIES = [
   'alignments',
   'passages',
@@ -20,8 +22,10 @@ export type BibliographySearchMatchDTO = {
 };
 
 export type GlossarySearchMatchDTO = {
+  authority_uuid: string;
   glossary_uuid: string;
   content: string;
+  entry: GlossaryTermInstanceDTO;
 };
 
 export type PassageSearchMatchDTO = {
@@ -67,6 +71,7 @@ export type BibliographyMatch = SearchMatch & {
 
 export type GlossaryMatch = SearchMatch & {
   type: 'glossary';
+  entry: GlossaryTermInstance;
 };
 
 export type SearchResultsDTO = {
@@ -105,8 +110,9 @@ export const glossaryMatchFromDTO = (
 ): GlossaryMatch => {
   return {
     type: 'glossary',
-    uuid: dto.glossary_uuid,
+    uuid: dto.authority_uuid,
     content: dto.content,
+    entry: glossaryTermInstanceFromDTO(dto.entry),
   };
 };
 

--- a/libs/lib-search/src/lib/ui/SearchResultCard.tsx
+++ b/libs/lib-search/src/lib/ui/SearchResultCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { highlightText, removeHtmlTags, useIsMobile } from '@eightyfourthousand/lib-utils';
+import { highlightText, removeDiacritics, removeHtmlTags, useIsMobile } from '@eightyfourthousand/lib-utils';
 import {
   AlignmentMatch,
   BibliographyMatch,
@@ -113,7 +113,20 @@ export const GlossaryResult = ({
   match: GlossaryMatch;
   query: string;
 }) => {
-  return <div>{highlightText(removeHtmlTags(match.content), query)}</div>;
+  return (
+    <div className="flex flex-col gap-2">
+      <div className='text-primary font-bold'>{
+        highlightText(
+          removeDiacritics(match.content),
+          removeDiacritics(query)
+        )
+      }</div>
+      {match.entry.definition && <div
+        className="glossary-instance-definition"
+        dangerouslySetInnerHTML={{ __html: match.entry.definition }}
+      />}
+    </div>
+  );
 };
 
 export const SearchResultCard = ({


### PR DESCRIPTION
### Summary

The `translation_search` function has been updated to return glossary entries based on names. Previously, it simply returned an empty array. The frontend will now display the results and link to them in the glossaries tab.
