### PR TITLE
Blank Folio Pages

### DIFF
--- a/libs/data-access/src/lib/types/folio.ts
+++ b/libs/data-access/src/lib/types/folio.ts
@@ -3,7 +3,7 @@ export type FolioSide = (typeof FOLIO_SIDES)[number];
 
 export type FolioDTO = {
   folio_uuid: string;
-  content: string;
+  content?: string;
   volume_number: number;
   folio_number: number;
   side: FolioSide;
@@ -20,7 +20,7 @@ export type Folio = {
 export const folioFromDTO = (dto: FolioDTO): Folio => {
   return {
     uuid: dto.folio_uuid,
-    content: dto.content,
+    content: dto.content || '',
     volume: dto.volume_number,
     folio: dto.folio_number,
     side: dto.side,

--- a/libs/lib-editing/src/lib/components/shared/SourceReader.tsx
+++ b/libs/lib-editing/src/lib/components/shared/SourceReader.tsx
@@ -3,7 +3,10 @@
 import { useInView } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigation } from './NavigationProvider';
-import { createGraphQLClient, getWorkFolios } from '@eightyfourthousand/client-graphql';
+import {
+  createGraphQLClient,
+  getWorkFolios,
+} from '@eightyfourthousand/client-graphql';
 import type { Folio } from '@eightyfourthousand/data-access';
 import { LabeledElement } from './LabeledElement';
 import { PassageSkeleton } from './PassageSkeleton';
@@ -61,9 +64,15 @@ export const SourceReader = () => {
           className="mt-0.5"
           contentType="source"
         >
-          <div className="leading-7 font-tibetan text-lg 2xl:whitespace-pre-wrap whitespace-normal">
-            {folio.content}
-          </div>
+          {folio.content ? (
+            <div className="leading-7 min-h-8 font-tibetan text-lg 2xl:whitespace-pre-wrap whitespace-normal">
+              {folio.content}
+            </div>
+          ) : (
+            <div className="h-12 text-center text-muted-foreground">
+              [blank]
+            </div>
+          )}
         </LabeledElement>
       ))}
       <div ref={loadMoreRef} className="h-0" />


### PR DESCRIPTION
### Summary

The assumption that `folios` table rows will always have a non-null `content` column was not valid. Folio pages can be blank, signified by null `content`.

In addition to accommodating this in the backend, the source reader has been updated to make clear a blank page is intentional.

### Linear

- Fixes [ED-1183](https://linear.app/84000/issue/ED-1183)
