### PR TITLE
Pass Attestation Flag

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/EditorBackMatterPage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorBackMatterPage.tsx
@@ -18,6 +18,7 @@ import { TranslationBuilder } from '../editor';
 import { isStaticFeatureEnabled } from '@eightyfourthousand/lib-instr/static';
 
 export const EditorBackMatterPage = () => {
+  const withAttestations = isStaticFeatureEnabled('glossary-attestations');
   const { work } = useEditorState();
   const [endnotes, setEndnotes] = useState<TranslationEditorContent>();
   const [abbreviations, setAbbreviations] =
@@ -29,7 +30,6 @@ export const EditorBackMatterPage = () => {
     (async () => {
       const { uuid } = work;
       const graphqlClient = createGraphQLClient();
-      const withAttestations = isStaticFeatureEnabled('glossary-attestations');
 
       const [
         { blocks: endnoteBlocks },
@@ -90,6 +90,7 @@ export const EditorBackMatterPage = () => {
       bibliography={bibliography}
       abbreviations={abbreviations}
       renderTranslation={renderTranslation}
+      withAttestations={withAttestations}
       isEditor={true}
     />
   );

--- a/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPage.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPage.tsx
@@ -57,6 +57,7 @@ export const ReaderBackMatterPage = async ({
       bibliography={bibliography}
       endnotes={endnotes}
       glossary={glossary}
+      withAttestations={withAttestations}
     />
   );
 };

--- a/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPanel.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPanel.tsx
@@ -15,12 +15,14 @@ export const ReaderBackMatterPanel = ({
   glossary,
   bibliography,
   abbreviations,
+  withAttestations = false,
 }: {
   workUuid: string;
   endnotes: TranslationEditorContent;
   glossary: GlossaryTermsPage;
   bibliography: BibliographyEntries;
   abbreviations: TranslationEditorContent;
+  withAttestations?: boolean;
 }) => {
   const { hasTranslationContent } = useNavigation();
   if (!hasTranslationContent) {
@@ -48,6 +50,7 @@ export const ReaderBackMatterPanel = ({
       bibliography={bibliography}
       abbreviations={abbreviations}
       renderTranslation={renderTranslation}
+      withAttestations={withAttestations}
     />
   );
 };

--- a/libs/lib-editing/src/lib/components/shared/BackMatterPanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/BackMatterPanel.tsx
@@ -24,6 +24,7 @@ export const BackMatterPanel = ({
   bibliography,
   abbreviations,
   isEditor = false,
+  withAttestations = false,
   renderTranslation,
 }: {
   workUuid: string;
@@ -32,6 +33,7 @@ export const BackMatterPanel = ({
   bibliography: BibliographyEntries;
   abbreviations: TranslationEditorContent;
   isEditor?: boolean;
+  withAttestations?: boolean;
   renderTranslation: (
     params: TranslationRenderer,
   ) => ReactElement<TranslationRenderer>;
@@ -111,6 +113,7 @@ export const BackMatterPanel = ({
                 <GlossaryPaginationProvider
                   workUuid={workUuid}
                   initialPage={glossary}
+                  withAttestations={withAttestations}
                 >
                   <GlossaryTermList isEditor={isEditor} />
                 </GlossaryPaginationProvider>

--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryPaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryPaginationProvider.tsx
@@ -42,10 +42,12 @@ const GlossaryPaginationContext = createContext<GlossaryPaginationState>({
 export const GlossaryPaginationProvider = ({
   workUuid,
   initialPage,
+  withAttestations = false,
   children,
 }: {
   workUuid: string;
   initialPage: GlossaryTermsPage;
+  withAttestations?: boolean;
   children: ReactNode;
 }) => {
   const [terms, setTerms] = useState(initialPage.terms);
@@ -126,6 +128,7 @@ export const GlossaryPaginationProvider = ({
             client: dataClient,
             uuid: workUuid,
             termUuid: navCursor,
+            withAttestations,
           });
 
           if (page.terms.length === 0) return;
@@ -182,6 +185,7 @@ export const GlossaryPaginationProvider = ({
         uuid: workUuid,
         cursor: endCursor,
         direction: 'forward',
+        withAttestations,
       });
 
       if (page.terms.length > 0) {

--- a/libs/lib-instr/src/lib/static-features.ts
+++ b/libs/lib-instr/src/lib/static-features.ts
@@ -5,7 +5,7 @@
 export type StaticFeature = 'glossary-attestations';
 
 const STATIC_FEATURE_FLAGS: Record<StaticFeature, string[]> = {
-  'glossary-attestations': ['scholars-room'],
+  'glossary-attestations': ['scholars-room', 'studio', 'reader-embed'],
 };
 
 export const isStaticFeatureEnabled = (flagKey: StaticFeature) => {


### PR DESCRIPTION
### Summary

Fixes an issue where the `withAttestation` was only applied to the first page of glossary terms.

### Linear

- [DEV-591](https://linear.app/84000/issue/DEV-591)