### PR TITLE
avoid instantiating hover card provider more than once

### DIFF
--- a/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
@@ -73,11 +73,13 @@ export const HoverCardProvider = ({
   openDelay = DEFAULT_HOVER_CARD_OPEN_DELAY,
   closeDelay = DEFAULT_HOVER_CARD_CLOSE_DELAY,
   typeMap = TYPE_ATTRIBUTE_MAP,
+  enabled = true,
   children,
 }: {
   closeDelay?: number;
   openDelay?: number;
   typeMap?: Record<string, string>;
+  enabled?: boolean;
   children: ReactNode;
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -127,6 +129,9 @@ export const HoverCardProvider = ({
   }, []);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     const editorEl = containerRef.current;
     if (!editorEl) {
       return;
@@ -206,6 +211,7 @@ export const HoverCardProvider = ({
       }
     };
   }, [
+    enabled,
     containerRef,
     typeMap,
     openDelay,
@@ -216,6 +222,9 @@ export const HoverCardProvider = ({
   ]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     const handleMouseMove = (evt: MouseEvent) => {
       if (!card) {
         return;
@@ -236,10 +245,10 @@ export const HoverCardProvider = ({
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
     };
-  }, [card, anchor, closeDelay]);
+  }, [enabled, card, anchor, closeDelay]);
 
   useEffect(() => {
-    if (!card) {
+    if (!enabled || !card) {
       return;
     }
 
@@ -259,9 +268,12 @@ export const HoverCardProvider = ({
         card.removeEventListener(eventType, stopPropagation, true);
       });
     };
-  }, [card]);
+  }, [enabled, card]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
@@ -272,10 +284,20 @@ export const HoverCardProvider = ({
     }
 
     closeWithDelay();
-  }, [isEditing, isHoveringAnchor, isHoveringCard, closeDelay, closeWithDelay]);
+  }, [
+    enabled,
+    isEditing,
+    isHoveringAnchor,
+    isHoveringCard,
+    closeDelay,
+    closeWithDelay,
+  ]);
 
   // Handle click outside to dismiss the hover card
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     if (!card && !anchor) {
       return;
     }
@@ -297,7 +319,7 @@ export const HoverCardProvider = ({
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [card, anchor, closeImmediately]);
+  }, [enabled, card, anchor, closeImmediately]);
 
   const renderCard = (uuid: string, type: string, anchorEl: HTMLElement) => {
     if (!editor) return null;
@@ -365,7 +387,7 @@ export const HoverCardProvider = ({
   };
 
   // Only show hover card when editor is available (editing mode only)
-  const shouldShowCard = anchor && uuid && cardType && editor;
+  const shouldShowCard = enabled && anchor && uuid && cardType && editor;
 
   return (
     <HoverCardContext.Provider

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -386,11 +386,7 @@ export const NavigationProvider = ({
 
   return (
     <NavigationContext.Provider value={contextValue}>
-      {hasHoverCards ? (
-        <HoverCardProvider>{children}</HoverCardProvider>
-      ) : (
-        children
-      )}
+      <HoverCardProvider enabled={hasHoverCards}>{children}</HoverCardProvider>
       <GatedFeature flag="show-restriction-warning">
         <RestrictionWarning imprint={imprint} />
       </GatedFeature>

--- a/libs/lib-instr/src/lib/feature-flags.tsx
+++ b/libs/lib-instr/src/lib/feature-flags.tsx
@@ -30,12 +30,17 @@ export type FeatureFlagPayload = {
  * @returns True if the feature flag is enabled for the current application, false otherwise.
  */
 export const useFeatureFlagEnabled = (flagKey: FeatureFlag): boolean => {
-  if (!phUseFeatureFlagEnabled(flagKey)) {
+  const isEnabled = phUseFeatureFlagEnabled(flagKey);
+  const payload = phUseFeatureFlagPayload(flagKey) as
+    | FeatureFlagPayload
+    | undefined;
+
+  if (!isEnabled) {
     return false;
   }
 
   const APPLICATION_NAME = process.env.NEXT_PUBLIC_APPLICATION_NAME || '';
-  const { apps } = phUseFeatureFlagPayload(flagKey) as FeatureFlagPayload;
+  const apps = payload?.apps;
 
   if (!apps?.length) {
     return true;


### PR DESCRIPTION
### Summary

Fixes an issue where there can be multiple `HoverCardProvider` instances, which also instantiates the sub-tree multiple times.