### PR TITLE
Gdamron/dev 598 update copy link behavior

### DIFF
--- a/libs/data-access/src/lib/auth.ts
+++ b/libs/data-access/src/lib/auth.ts
@@ -4,7 +4,6 @@ import { DataClient, UserClaims, UserPermission, UserRole } from './types';
 export const getSession = async ({ client }: { client: DataClient }) => {
   const { data, error } = await client.auth.getSession();
   if (error || !data?.session) {
-    console.info(`Failed to get session data: ${error}`);
     return null;
   }
 

--- a/libs/data-access/src/lib/panel-url.ts
+++ b/libs/data-access/src/lib/panel-url.ts
@@ -1,4 +1,5 @@
 import {
+  BODY_ITEM_TYPES,
   PANEL_FOR_CONTENT_SECTION,
   PanelContentType,
   TAB_FOR_CONTENT_SECTION,
@@ -42,6 +43,16 @@ export const urlForPanelContent = ({
   return baseUrl.toString();
 };
 
+export const entityTypeForContentType = (
+  contentType: PanelContentType,
+): string => {
+  if (['compare', 'source', ...BODY_ITEM_TYPES].includes(contentType)) {
+    return 'passage';
+  }
+
+  return contentType;
+};
+
 export const urlForEntity = ({
   location,
   uuid,
@@ -51,6 +62,15 @@ export const urlForEntity = ({
   uuid: string;
   contentType?: PanelContentType;
 }): string => {
+  // TODO: support folios in the entity endpoint
+  if (contentType === 'source') {
+    return urlForPanelContent({
+      location,
+      hash: uuid,
+      contentType,
+    });
+  }
+
   const { href, search, host } = location;
   const searchParams = new URLSearchParams(search);
 
@@ -60,11 +80,16 @@ export const urlForEntity = ({
     return baseUrl.toString();
   }
 
-  const entityType =
-    contentType === 'compare'
-      ? 'translation'
-      : contentType.replace('Header', '');
+  const entityType = entityTypeForContentType(contentType);
   const baseUrl = new URL(`${host}/entity/${entityType}/${uuid}`);
-  baseUrl.search = searchParams.toString();
+  const toh = searchParams.get('toh');
+  const { tab } = panelAndTabForContentType(contentType);
+  const queryParams = new URLSearchParams({
+    tab,
+  });
+  if (toh) {
+    queryParams.set('toh', toh);
+  }
+  baseUrl.search = queryParams.toString();
   return baseUrl.toString();
 };

--- a/libs/data-access/src/lib/panel-url.ts
+++ b/libs/data-access/src/lib/panel-url.ts
@@ -41,3 +41,30 @@ export const urlForPanelContent = ({
   baseUrl.search = searchParams.toString();
   return baseUrl.toString();
 };
+
+export const urlForEntity = ({
+  location,
+  uuid,
+  contentType,
+}: {
+  location: Location;
+  uuid: string;
+  contentType?: PanelContentType;
+}): string => {
+  const { href, search, host } = location;
+  const searchParams = new URLSearchParams(search);
+
+  if (!contentType) {
+    const baseUrl = new URL(href);
+    baseUrl.hash = `#${uuid}`;
+    return baseUrl.toString();
+  }
+
+  const entityType =
+    contentType === 'compare'
+      ? 'translation'
+      : contentType.replace('Header', '');
+  const baseUrl = new URL(`${host}/entity/${entityType}/${uuid}`);
+  baseUrl.search = searchParams.toString();
+  return baseUrl.toString();
+};

--- a/libs/data-access/src/lib/types/layout.ts
+++ b/libs/data-access/src/lib/types/layout.ts
@@ -2,6 +2,7 @@ import { BodyItemType } from './passage';
 
 export type PanelContentType =
   | BodyItemType
+  | 'compare'
   | 'glossary'
   | 'bibliography'
   | 'source';
@@ -13,9 +14,11 @@ export const TAB_FOR_CONTENT_SECTION: Partial<
   abbreviations: 'abbreviations',
   acknowledgment: 'front',
   bibliography: 'bibliography',
+  compare: 'compare',
   glossary: 'glossary',
   endnotes: 'endnotes',
   introduction: 'front',
+  source: 'source',
   summary: 'front',
 } as const;
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/EditorOptions.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/EditorOptions.tsx
@@ -1,15 +1,43 @@
 'use client';
 
-import { DropdownMenuItem, DropdownMenuSeparator } from '@eightyfourthousand/design-system';
-import { BracesIcon, PencilIcon, Trash2Icon } from 'lucide-react';
+import { useCallback } from 'react';
+import { NodeViewProps } from '@tiptap/react';
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@eightyfourthousand/design-system';
+import { BracesIcon, CopyIcon, PencilIcon, Trash2Icon } from 'lucide-react';
+import {
+  PanelContentType,
+  urlForEntity,
+} from '@eightyfourthousand/data-access';
 
 export const EditorOptions = ({
+  node,
+  contentType,
   onSelection,
-}: {
+}: NodeViewProps & {
+  contentType: PanelContentType;
   onSelection: (item: string) => void;
 }) => {
+  const copyLink = useCallback(() => {
+    const uuid = node.attrs.uuid;
+    const location = window.location;
+
+    const link = urlForEntity({
+      location,
+      uuid,
+      contentType,
+    });
+
+    navigator.clipboard.writeText(link);
+  }, [node.attrs.uuid, contentType]);
+
   return (
     <>
+      <DropdownMenuItem onSelect={copyLink}>
+        <CopyIcon className="text-primary" /> Copy Link
+      </DropdownMenuItem>
       <DropdownMenuItem onSelect={() => onSelection('label')}>
         <PencilIcon className="text-Primary" /> Edit Label
       </DropdownMenuItem>

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/EditorOptions.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/EditorOptions.tsx
@@ -9,7 +9,7 @@ import {
 import { BracesIcon, CopyIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import {
   PanelContentType,
-  urlForEntity,
+  urlForPanelContent,
 } from '@eightyfourthousand/data-access';
 
 export const EditorOptions = ({
@@ -21,12 +21,12 @@ export const EditorOptions = ({
   onSelection: (item: string) => void;
 }) => {
   const copyLink = useCallback(() => {
-    const uuid = node.attrs.uuid;
+    const hash = node.attrs.uuid;
     const location = window.location;
 
-    const link = urlForEntity({
+    const link = urlForPanelContent({
       location,
-      uuid,
+      hash,
       contentType,
     });
 
@@ -38,6 +38,7 @@ export const EditorOptions = ({
       <DropdownMenuItem onSelect={copyLink}>
         <CopyIcon className="text-primary" /> Copy Link
       </DropdownMenuItem>
+      <DropdownMenuSeparator />
       <DropdownMenuItem onSelect={() => onSelection('label')}>
         <PencilIcon className="text-Primary" /> Edit Label
       </DropdownMenuItem>

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/Passage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/Passage.tsx
@@ -150,6 +150,8 @@ const PassageComponent = (props: NodeViewProps) => {
                 />
               ) : editor.isEditable ? (
                 <EditorOptions
+                  {...props}
+                  contentType={source ? 'compare' : node.attrs.type}
                   onSelection={(item) => {
                     setDialogType(item);
                     setIsDialogOpen(true);

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/ReaderOptions.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/ReaderOptions.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { PanelContentType, urlForPanelContent } from '@eightyfourthousand/data-access';
-import { DropdownMenuItem, DropdownMenuSeparator } from '@eightyfourthousand/design-system';
+import {
+  PanelContentType,
+  urlForEntity,
+} from '@eightyfourthousand/data-access';
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@eightyfourthousand/design-system';
 import { NodeViewProps } from '@tiptap/react';
 import { BookmarkIcon, CopyIcon, MessageSquareIcon } from 'lucide-react';
 import { useCallback } from 'react';
@@ -15,18 +21,19 @@ export const ReaderOptions = (
   },
 ) => {
   const copyLink = useCallback(() => {
-    const hash = props.node.attrs.uuid;
+    const uuid = props.node.attrs.uuid;
     const contentType = props.contentType;
     const location = window.location;
 
-    const link = urlForPanelContent({
+    const link = urlForEntity({
       location,
-      hash,
+      uuid,
       contentType,
     });
 
     navigator.clipboard.writeText(link);
-  }, [props.node, props.contentType]);
+  }, [props.node.attrs.uuid, props.contentType]);
+
   return (
     <>
       <DropdownMenuItem onSelect={props.toggleBookmark}>

--- a/libs/lib-editing/src/lib/components/shared/LabeledElement.tsx
+++ b/libs/lib-editing/src/lib/components/shared/LabeledElement.tsx
@@ -21,12 +21,14 @@ import { useNavigation } from './NavigationProvider';
 export const LabeledElement = ({
   label,
   id = undefined,
+  uuid = undefined,
   className,
   contentType,
   children,
 }: {
   label?: string;
   id?: string;
+  uuid?: string;
   className?: string;
   contentType?: PanelContentType;
   children: ReactNode;
@@ -47,7 +49,7 @@ export const LabeledElement = ({
 
     const link = urlForEntity({
       location: window.location,
-      uuid: id,
+      uuid: uuid || id,
       contentType,
     });
     navigator.clipboard.writeText(link);

--- a/libs/lib-editing/src/lib/components/shared/LabeledElement.tsx
+++ b/libs/lib-editing/src/lib/components/shared/LabeledElement.tsx
@@ -2,7 +2,7 @@
 
 import {
   PanelContentType,
-  urlForPanelContent,
+  urlForEntity,
   useBookmark,
 } from '@eightyfourthousand/data-access';
 import {
@@ -45,9 +45,9 @@ export const LabeledElement = ({
       return;
     }
 
-    const link = urlForPanelContent({
+    const link = urlForEntity({
       location: window.location,
-      hash: id,
+      uuid: id,
       contentType,
     });
     navigator.clipboard.writeText(link);
@@ -111,7 +111,8 @@ export const LabeledElement = ({
                     setShowRevisionForm(true);
                   }}
                 >
-                  <MessageSquareIcon className="text-primary" /> Suggest Revision
+                  <MessageSquareIcon className="text-primary" /> Suggest
+                  Revision
                 </DropdownMenuItem>
               </>
             )}

--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryTermList.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryTermList.tsx
@@ -40,6 +40,7 @@ export const GlossaryTermList = ({
         {terms.map((instance, index) => (
           <LabeledElement
             id={instance.authority || instance.uuid || `glossary-${index}`}
+            uuid={instance.uuid}
             key={instance.authority || instance.uuid || `glossary-${index}`}
             label={`g.${instance.termNumber}`}
             contentType="glossary"


### PR DESCRIPTION
### Summary

- Add "Copy Link" to editor passage dropdown, using panel-based url with full state
- Use `/entity` endpoint for "Copy Link" in reader

### Linear

- [DEV-598](https://linear.app/84000/issue/DEV-598)
