### PR TITLE
Streamline Editor Instance Management

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -13,7 +13,7 @@ import {
 import { passagesFromNodes, ensureUuids } from '../../passage';
 import { NavigationProvider } from '../shared';
 import { useDirtyStore, type DirtyStore } from './hooks/useDirtyStore';
-import { computeSavePayload } from './save-filter';
+import { computeSavePayload, type PassageUuidRecord } from './save-filter';
 
 interface EditorContextState {
   doc?: Doc;
@@ -25,12 +25,13 @@ interface EditorContextState {
   setDoc: (doc: Doc) => void;
   getEditor: (key: string) => Editor | undefined;
   setEditor: (key: string, editor?: Editor) => void;
+  refreshEditorBaseline: (key: string) => void;
   save: () => Promise<void>;
   startObserving: (builder: string) => void;
   stopObserving: (builder: string) => void;
   setNavigating: (
     navigating: boolean,
-    resetKnownUuids?: boolean,
+    resetLastObservedUuids?: boolean,
     fragment?: XmlFragment,
   ) => void;
   isNavigating: () => boolean;
@@ -72,6 +73,9 @@ export const EditorContext = createContext<EditorContextState>({
   setEditor: () => {
     throw Error('Not implemented');
   },
+  refreshEditorBaseline: () => {
+    // No-op when outside provider
+  },
   save: async () => {
     // No-op when outside provider
   },
@@ -103,10 +107,12 @@ export const EditorContextProvider = ({
   const [doc, setDoc] = React.useState<Doc>(initialDoc || new Doc());
   // Use ref for immediate tracking to avoid state updates on every keystroke
   const dirtyUuidsRef = useRef<Set<string>>(new Set());
-  const deletedUuidsRef = useRef<Set<string>>(new Set());
   const isNavigatingRef = useRef(false);
   const clearedFragmentRef = useRef<XmlFragment | null>(null);
-  const knownUuidsRef = useRef<Map<XmlFragment, Set<string>>>(new Map());
+  const lastObservedUuidsByFragmentRef = useRef<Map<XmlFragment, Set<string>>>(
+    new Map(),
+  );
+  const savedBaselineUuidsByEditorRef = useRef<PassageUuidRecord>({});
 
   // Store for dirty state with subscription support
   const dirtyStore = useDirtyStore();
@@ -120,6 +126,7 @@ export const EditorContextProvider = ({
   const setEditor = useCallback((key: string, editor?: Editor) => {
     if (!editor && editorCache.current[key]) {
       delete editorCache.current[key];
+      delete savedBaselineUuidsByEditorRef.current[key];
     } else if (editor) {
       editorCache.current[key] = editor;
     }
@@ -132,13 +139,61 @@ export const EditorContextProvider = ({
     [doc],
   );
 
+  const getFragmentUuids = useCallback((fragment: XmlFragment) => {
+    const uuids = new Set<string>();
+    for (let i = 0; i < fragment.length; i++) {
+      const child = fragment.get(i);
+      if (child instanceof XmlElement && child.nodeName === 'passage') {
+        const uuid = child.getAttribute('uuid');
+        if (uuid) {
+          uuids.add(uuid);
+        }
+      }
+    }
+    return uuids;
+  }, []);
+
+  const getEditorUuids = useCallback((editor: Editor) => {
+    const uuids = new Set<string>();
+    editor.state.doc.descendants((node) => {
+      if (node.type.name !== 'passage' || !node.attrs.uuid) {
+        return true;
+      }
+
+      uuids.add(node.attrs.uuid);
+      return false;
+    });
+    return uuids;
+  }, []);
+
+  const refreshEditorBaseline = useCallback(
+    (key: string) => {
+      const editor = editorCache.current[key];
+      if (!editor || editor.isDestroyed) {
+        return;
+      }
+
+      savedBaselineUuidsByEditorRef.current[key] = getEditorUuids(editor);
+
+      const fragment = getFragment(key);
+      if (fragment) {
+        lastObservedUuidsByFragmentRef.current.set(
+          fragment,
+          getFragmentUuids(fragment),
+        );
+      }
+    },
+    [getEditorUuids, getFragment, getFragmentUuids],
+  );
+
   const observerFunction = useCallback(
     (evts: YEvent<XmlFragment | XmlElement>[], txn: Transaction) => {
       if (!txn.local) {
         return;
       }
 
-      // Detect passage deletions by diffing known UUIDs against current fragment state.
+      // Detect passage deletions by diffing the last observed UUIDs against
+      // the current fragment state.
       // We walk up from any event target to find the observed XmlFragment rather than
       // checking each event's target, because merge operations may only produce events
       // targeting passage-level XmlElements (not the fragment itself).
@@ -160,38 +215,44 @@ export const EditorContextProvider = ({
         }
 
         if (fragment) {
-          const currentUuids = new Set<string>();
+          const liveUuids = new Set<string>();
           for (let i = 0; i < fragment.length; i++) {
             const child = fragment.get(i);
             if (child instanceof XmlElement && child.nodeName === 'passage') {
               const uuid = child.getAttribute('uuid');
               if (uuid) {
-                currentUuids.add(uuid);
+                liveUuids.add(uuid);
               }
             }
           }
 
-          const knownForFragment = knownUuidsRef.current.get(fragment);
-          if (knownForFragment && knownForFragment.size > 0) {
-            // Detect deletions: UUIDs in known set but not in current
-            knownForFragment.forEach((uuid) => {
-              if (!currentUuids.has(uuid)) {
-                deletedUuidsRef.current.add(uuid);
-              }
-            });
+          const lastObservedUuidsForFragment =
+            lastObservedUuidsByFragmentRef.current.get(fragment);
+          if (
+            lastObservedUuidsForFragment &&
+            lastObservedUuidsForFragment.size > 0
+          ) {
+            const hasDeleted = Array.from(lastObservedUuidsForFragment).some(
+              (uuid) => !liveUuids.has(uuid),
+            );
 
-            // Detect new passages: UUIDs in current but not in known.
+            // Detect new passages: UUIDs in the current fragment but not in
+            // the last observed fragment state.
             // This catches passages created by splitPassage, where the Yjs
             // binding creates XmlElements with attributes set during construction
             // (pre-integration), so txn.changed never includes them.
-            currentUuids.forEach((uuid) => {
-              if (!knownForFragment.has(uuid)) {
+            liveUuids.forEach((uuid) => {
+              if (!lastObservedUuidsForFragment.has(uuid)) {
                 dirtyUuidsRef.current.add(uuid);
               }
             });
+
+            if (hasDeleted && !dirtyStore.isDirty) {
+              dirtyStore.setDirty(true);
+            }
           }
 
-          knownUuidsRef.current.set(fragment, currentUuids);
+          lastObservedUuidsByFragmentRef.current.set(fragment, liveUuids);
         }
       }
 
@@ -218,39 +279,28 @@ export const EditorContextProvider = ({
           }
         });
       }
-
-      // Mark dirty if there are deletions
-      if (deletedUuidsRef.current.size > 0 && !dirtyStore.isDirty) {
-        dirtyStore.setDirty(true);
-      }
     },
-    [],
+    [dirtyStore, getFragmentUuids],
   );
 
   const startObserving = useCallback(
     (builder: string) => {
       const fragment = getFragment(builder);
       if (fragment) {
-        // Pre-populate knownUuidsRef so the diff-based deletion detection
-        // has a baseline from the very first observer event. Without this,
-        // a merge that happens before any other edit would not be detected
-        // because knownUuidsRef would be empty and the diff would be skipped.
-        const uuids = new Set<string>();
-        for (let i = 0; i < fragment.length; i++) {
-          const child = fragment.get(i);
-          if (child instanceof XmlElement && child.nodeName === 'passage') {
-            const uuid = child.getAttribute('uuid');
-            if (uuid) {
-              uuids.add(uuid);
-            }
-          }
-        }
-        knownUuidsRef.current.set(fragment, uuids);
+        // Pre-populate lastObservedUuidsByFragmentRef so the diff-based
+        // deletion detection has a baseline from the very first observer event.
+        // Without this, a merge that happens before any other edit would not be
+        // detected because the ref would be empty and the diff would be skipped.
+        lastObservedUuidsByFragmentRef.current.set(
+          fragment,
+          getFragmentUuids(fragment),
+        );
 
         fragment.observeDeep(observerFunction);
+        refreshEditorBaseline(builder);
       }
     },
-    [getFragment, observerFunction],
+    [getFragment, getFragmentUuids, observerFunction, refreshEditorBaseline],
   );
 
   const stopObserving = useCallback(
@@ -258,7 +308,9 @@ export const EditorContextProvider = ({
       const fragment = getFragment(builder);
       if (fragment && observerFunction) {
         fragment.unobserveDeep(observerFunction);
+        lastObservedUuidsByFragmentRef.current.delete(fragment);
       }
+      delete savedBaselineUuidsByEditorRef.current[builder];
     },
     [getFragment, observerFunction],
   );
@@ -266,12 +318,12 @@ export const EditorContextProvider = ({
   const setNavigating = useCallback(
     (
       navigating: boolean,
-      resetKnownUuids = false,
+      resetLastObservedUuids = false,
       fragment?: XmlFragment,
     ) => {
       isNavigatingRef.current = navigating;
-      if (navigating && resetKnownUuids) {
-        // Clear known UUIDs so the first observer call after navigation
+      if (navigating && resetLastObservedUuids) {
+        // Clear last observed UUIDs so the first observer call after navigation
         // repopulates without diffing against the stale pre-navigation set.
         // Only done for full navigation (clearContent + setContent), not for
         // load-more which only adds passages and needs to keep its baseline.
@@ -279,10 +331,10 @@ export const EditorContextProvider = ({
         // entry so other editors (e.g. endnotes) retain their baseline and
         // can still detect deletions.
         if (fragment) {
-          knownUuidsRef.current.delete(fragment);
+          lastObservedUuidsByFragmentRef.current.delete(fragment);
           clearedFragmentRef.current = fragment;
         } else {
-          knownUuidsRef.current.clear();
+          lastObservedUuidsByFragmentRef.current.clear();
         }
       }
 
@@ -292,18 +344,10 @@ export const EditorContextProvider = ({
       if (!navigating && clearedFragmentRef.current) {
         const f = clearedFragmentRef.current;
         clearedFragmentRef.current = null;
-        const uuids = new Set<string>();
-        for (let i = 0; i < f.length; i++) {
-          const child = f.get(i);
-          if (child instanceof XmlElement && child.nodeName === 'passage') {
-            const uuid = child.getAttribute('uuid');
-            if (uuid) uuids.add(uuid);
-          }
-        }
-        knownUuidsRef.current.set(f, uuids);
+        lastObservedUuidsByFragmentRef.current.set(f, getFragmentUuids(f));
       }
     },
-    [],
+    [getFragmentUuids],
   );
 
   const isNavigating = useCallback(() => isNavigatingRef.current, []);
@@ -324,8 +368,11 @@ export const EditorContextProvider = ({
         const passagesByUuid = new Map(
           passages
             .filter(
-              (passage): passage is ReplacedPassage & { json: NonNullable<ReplacedPassage['json']> } =>
-                Boolean(passage.json),
+              (
+                passage,
+              ): passage is ReplacedPassage & {
+                json: NonNullable<ReplacedPassage['json']>;
+              } => Boolean(passage.json),
             )
             .map((passage) => [passage.uuid, passage]),
         );
@@ -383,20 +430,37 @@ export const EditorContextProvider = ({
   );
 
   const save = useCallback(async () => {
-    const editors = Object.values(editorCache.current);
-    if (!editors.length) {
+    const editorEntries = Object.entries(editorCache.current).filter(
+      ([, editor]) => !editor.isDestroyed,
+    );
+    if (!editorEntries.length) {
       console.warn('No editor instance found, cannot save.');
       return;
     }
 
-    // Use the ref directly for the most up-to-date dirty/deleted UUIDs
+    const liveUuidsByEditor: PassageUuidRecord = {};
+    editorEntries.forEach(([key, editor]) => {
+      ensureUuids(editor);
+      liveUuidsByEditor[key] = getEditorUuids(editor);
+    });
+    const savedBaselineUuidsByEditor = Object.fromEntries(
+      Object.keys(liveUuidsByEditor)
+        .map(
+          (key) => [key, savedBaselineUuidsByEditorRef.current[key]] as const,
+        )
+        .filter((entry): entry is readonly [string, Set<string>] =>
+          Boolean(entry[1]),
+        ),
+    ) as PassageUuidRecord;
+
     const {
       uuidsToSave,
       uuidsToDelete: deletedUuids,
       hasChanges,
     } = computeSavePayload({
       dirtyUuids: dirtyUuidsRef.current,
-      deletedUuids: deletedUuidsRef.current,
+      baseline: savedBaselineUuidsByEditor,
+      current: liveUuidsByEditor,
     });
 
     if (!hasChanges) {
@@ -406,22 +470,19 @@ export const EditorContextProvider = ({
 
     const passages: Passage[] = [];
     if (uuidsToSave.length) {
-      editors.forEach((editor) => {
-        // Skip editors whose DOM view has been unmounted (e.g. inactive tabs).
-        // Calling blur()/focus() on a destroyed editor throws a TipTap error
-        // about view['hasFocus'] not being accessible.
-        if (editor.isDestroyed) return;
-        // Ensure all nodes have unique, non-null UUIDs before reading them.
-        // New paragraph nodes created by splitting (e.g. pressing Enter) have
-        // uuid: null until the NodeView mount cycle runs validateAttrs. If we
-        // read the document before that cycle completes, annotationExportsFromNode
-        // silently drops any annotation whose node.attrs.uuid is falsy, producing
-        // missing paragraph annotations. ensureUuids fixes this synchronously.
-        ensureUuids(editor);
+      const uuidsToSaveSet = new Set(uuidsToSave);
+      editorEntries.forEach(([, editor]) => {
+        const editorUuids = Array.from(getEditorUuids(editor)).filter((uuid) =>
+          uuidsToSaveSet.has(uuid),
+        );
+        if (editorUuids.length === 0) {
+          return;
+        }
+
         editor.commands.blur();
         passages.push(
           ...passagesFromNodes({
-            uuids: uuidsToSave,
+            uuids: editorUuids,
             workUuid: work.uuid,
             editor,
           }),
@@ -448,9 +509,16 @@ export const EditorContextProvider = ({
 
     // Clear both ref and state
     dirtyUuidsRef.current.clear();
-    deletedUuidsRef.current.clear();
+    editorEntries.forEach(([key]) => refreshEditorBaseline(key));
     dirtyStore.setDirty(false);
-  }, [editorCache, client, work.uuid, applyReplacedPassages, dirtyStore]);
+  }, [
+    client,
+    work.uuid,
+    getEditorUuids,
+    applyReplacedPassages,
+    refreshEditorBaseline,
+    dirtyStore,
+  ]);
 
   return (
     <EditorContext.Provider
@@ -464,6 +532,7 @@ export const EditorContextProvider = ({
         setDoc,
         getEditor,
         setEditor,
+        refreshEditorBaseline,
         save,
         startObserving,
         stopObserving,

--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -113,6 +113,7 @@ export const EditorContextProvider = ({
     new Map(),
   );
   const savedBaselineUuidsByEditorRef = useRef<PassageUuidRecord>({});
+  const observedFragmentsByBuilderRef = useRef<Record<string, XmlFragment>>({});
 
   // Store for dirty state with subscription support
   const dirtyStore = useDirtyStore();
@@ -287,6 +288,17 @@ export const EditorContextProvider = ({
     (builder: string) => {
       const fragment = getFragment(builder);
       if (fragment) {
+        const observedFragment = observedFragmentsByBuilderRef.current[builder];
+        if (observedFragment === fragment) {
+          refreshEditorBaseline(builder);
+          return;
+        }
+
+        if (observedFragment) {
+          observedFragment.unobserveDeep(observerFunction);
+          lastObservedUuidsByFragmentRef.current.delete(observedFragment);
+        }
+
         // Pre-populate lastObservedUuidsByFragmentRef so the diff-based
         // deletion detection has a baseline from the very first observer event.
         // Without this, a merge that happens before any other edit would not be
@@ -297,6 +309,7 @@ export const EditorContextProvider = ({
         );
 
         fragment.observeDeep(observerFunction);
+        observedFragmentsByBuilderRef.current[builder] = fragment;
         refreshEditorBaseline(builder);
       }
     },
@@ -305,14 +318,15 @@ export const EditorContextProvider = ({
 
   const stopObserving = useCallback(
     (builder: string) => {
-      const fragment = getFragment(builder);
-      if (fragment && observerFunction) {
-        fragment.unobserveDeep(observerFunction);
-        lastObservedUuidsByFragmentRef.current.delete(fragment);
+      const observedFragment = observedFragmentsByBuilderRef.current[builder];
+      if (observedFragment) {
+        observedFragment.unobserveDeep(observerFunction);
+        lastObservedUuidsByFragmentRef.current.delete(observedFragment);
+        delete observedFragmentsByBuilderRef.current[builder];
       }
       delete savedBaselineUuidsByEditorRef.current[builder];
     },
-    [getFragment, observerFunction],
+    [observerFunction],
   );
 
   const setNavigating = useCallback(

--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -20,9 +20,16 @@ import {
 } from '@eightyfourthousand/client-graphql';
 import type { PanelFilter } from '@eightyfourthousand/data-access';
 import { PassageSkeleton } from '../shared/PassageSkeleton';
-import { isUuid, scrollToElement, useIsMobile } from '@eightyfourthousand/lib-utils';
+import {
+  isUuid,
+  scrollToElement,
+  useIsMobile,
+} from '@eightyfourthousand/lib-utils';
 import { PanelName, TabName, useNavigation } from '../shared';
-import { LotusPond, SHEET_ANIMATION_DURATION } from '@eightyfourthousand/design-system';
+import {
+  LotusPond,
+  SHEET_ANIMATION_DURATION,
+} from '@eightyfourthousand/design-system';
 import { useEditorState } from './EditorProvider';
 import { usePaginationLoadTriggers } from '../shared/hooks/usePaginationLoadTriggers';
 
@@ -89,7 +96,7 @@ export const PaginationProvider = ({
     ? content.at(-1)?.attrs?.uuid
     : content?.attrs?.uuid;
 
-  const { setNavigating } = useEditorState();
+  const { refreshEditorBaseline, setNavigating } = useEditorState();
 
   const [startCursor, setStartCursor] = useState<string | undefined>();
   const [endCursor, setEndCursor] = useState<string | undefined>(
@@ -116,7 +123,9 @@ export const PaginationProvider = ({
   // matches — this prevents a PaginationProvider for one tab (e.g. endnotes)
   // from reacting to hashes set by a different tab (e.g. glossary).
   const panelHash =
-    !tab || panels[panel]?.tab === tab || (tab === 'translation' && panels[panel]?.tab === 'compare')
+    !tab ||
+    panels[panel]?.tab === tab ||
+    (tab === 'translation' && panels[panel]?.tab === 'compare')
       ? panels[panel]?.hash
       : undefined;
 
@@ -224,6 +233,9 @@ export const PaginationProvider = ({
           });
           setStartCursor(hasMoreBefore && prevCursor ? prevCursor : undefined);
           setEndCursor(hasMoreAfter && nextCursor ? nextCursor : undefined);
+          if (tab) {
+            refreshEditorBaseline(tab);
+          }
 
           // Wait for React to re-render and update the DOM (remove/add skeletons)
           // by waiting until the element's position stabilizes
@@ -293,6 +305,10 @@ export const PaginationProvider = ({
     dataClient,
     updatePanel,
     isMobile,
+    refreshEditorBaseline,
+    setNavigating,
+    tab,
+    fragment,
   ]);
 
   useEffect(() => {
@@ -333,6 +349,9 @@ export const PaginationProvider = ({
         setNavigating(true);
         await insertContentChunked(editor, pos, blocks);
         setNavigating(false);
+        if (tab) {
+          refreshEditorBaseline(tab);
+        }
       }
 
       setEndCursor(hasMore && nextCursor ? nextCursor : undefined);
@@ -346,6 +365,9 @@ export const PaginationProvider = ({
     endCursor,
     dataClient,
     endLoadRequest,
+    refreshEditorBaseline,
+    setNavigating,
+    tab,
   ]);
 
   useEffect(() => {
@@ -385,6 +407,9 @@ export const PaginationProvider = ({
         setNavigating(true);
         editor.commands.insertContentAt(pos, blocks);
         setNavigating(false);
+        if (tab) {
+          refreshEditorBaseline(tab);
+        }
 
         requestAnimationFrame(() => {
           const newScrollHeight = scrollContainer?.scrollHeight || 0;
@@ -398,6 +423,9 @@ export const PaginationProvider = ({
         setNavigating(true);
         editor.commands.insertContentAt(pos, blocks);
         setNavigating(false);
+        if (tab) {
+          refreshEditorBaseline(tab);
+        }
       }
 
       setStartCursor(hasMoreBefore && prevCursor ? prevCursor : undefined);
@@ -411,6 +439,9 @@ export const PaginationProvider = ({
     startCursor,
     dataClient,
     startLoadRequest,
+    refreshEditorBaseline,
+    setNavigating,
+    tab,
   ]);
 
   return (

--- a/libs/lib-editing/src/lib/components/editor/TranslationBuilder.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationBuilder.tsx
@@ -28,6 +28,7 @@ export const TranslationBuilder = ({
     setEditor,
     getEditor,
     startObserving,
+    stopObserving,
     getFragment,
     isNavigating,
   } = useEditorState();
@@ -52,6 +53,16 @@ export const TranslationBuilder = ({
       }
     })();
   }, [name, canEdit, getFragment]);
+
+  useEffect(() => {
+    return () => {
+      if (debouncedSyncRef.current) {
+        clearTimeout(debouncedSyncRef.current);
+      }
+      setEditor(name, undefined);
+      stopObserving(name);
+    };
+  }, [name, setEditor, stopObserving]);
 
   return content && fragment ? (
     <PaginationProvider
@@ -83,7 +94,7 @@ export const TranslationBuilder = ({
           }
           passageUuidsByTypeRef.current = byType;
 
-          editor.on('update', () => {
+          const handleEndnotesUpdate = () => {
             // Collect current passage UUIDs grouped by type (cheap)
             const currentByType: Record<string, Set<string>> = {};
             const doc = editor.state.doc;
@@ -159,6 +170,11 @@ export const TranslationBuilder = ({
                 syncEndnoteLinkLabelsAcrossEditors(editor, getEditor);
               }, 150);
             }
+          };
+
+          editor.on('update', handleEndnotesUpdate);
+          editor.on('destroy', () => {
+            editor.off('update', handleEndnotesUpdate);
           });
         }
       }}

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkHoverContent.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkHoverContent.tsx
@@ -10,7 +10,6 @@ import {
   Trash2Icon,
 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
-import { useHoverCard } from '../../../shared/HoverCardProvider';
 import { useNavigation } from '../../../shared/NavigationContext';
 import { findEndnoteMarkByUuid, findPassageNode } from '../../util';
 import { useEditorState } from '../../EditorProvider';
@@ -22,17 +21,20 @@ export const EndNoteLinkHoverContent = ({
   uuid,
   endNote,
   editor,
+  close,
+  setHoverCardEditing,
 }: {
   uuid: string;
   endNote: string;
   editor: Editor;
   anchor: HTMLElement;
+  close: () => void;
+  setHoverCardEditing: (isEditing: boolean) => void;
 }) => {
   const [label, setLabel] = useState<string | undefined>();
-  const [labelState, setLabelState] = useState<
-    'loading' | 'loaded' | 'error'
-  >('loading');
-  const { close, setIsEditing } = useHoverCard();
+  const [labelState, setLabelState] = useState<'loading' | 'loaded' | 'error'>(
+    'loading',
+  );
   const { getEditor } = useEditorState();
   const { fetchEndNote } = useNavigation();
 
@@ -66,7 +68,7 @@ export const EndNoteLinkHoverContent = ({
   }, [endNote, fetchEndNote, getEditor]);
 
   const removeLink = useCallback(() => {
-    setIsEditing(false);
+    setHoverCardEditing(false);
     close();
 
     setTimeout(() => {
@@ -87,10 +89,10 @@ export const EndNoteLinkHoverContent = ({
       }
       editor.view.dispatch(tr);
     }, EDITOR_UPDATE_DELAY_MS);
-  }, [editor, uuid, close, setIsEditing]);
+  }, [editor, uuid, close, setHoverCardEditing]);
 
   const deleteEndnoteAndLink = useCallback(() => {
-    setIsEditing(false);
+    setHoverCardEditing(false);
     close();
 
     setTimeout(() => {
@@ -99,7 +101,7 @@ export const EndNoteLinkHoverContent = ({
         deleteEndnotePassageNode(endnotesEditor, endNote);
       }
     }, EDITOR_UPDATE_DELAY_MS);
-  }, [endNote, getEditor, close, setIsEditing]);
+  }, [endNote, getEditor, close, setHoverCardEditing]);
 
   return (
     <div className="flex justify-between gap-2 p-2 w-fit max-w-80">

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstance.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstance.tsx
@@ -9,7 +9,6 @@ import { BookOpenIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { GlossarySearch } from './GlossarySearch';
 import { findMarkByUuid } from '../../util';
-import { useHoverCard } from '../../../shared/HoverCardProvider';
 import { useNavigation } from '../../../shared';
 
 const EDITOR_UPDATE_DELAY_MS = 100;
@@ -19,17 +18,20 @@ export const GlossaryInstance = ({
   glossary,
   editor,
   anchor,
+  close,
+  setHoverCardEditing,
 }: {
   uuid: string;
   glossary: string;
   editor: Editor;
   anchor: HTMLElement;
+  close: () => void;
+  setHoverCardEditing: (isEditing: boolean) => void;
 }) => {
   const [isEditing, setIsEditingLocal] = useState(false);
   const [english, setEnglish] = useState<string | null>(null);
   const [termNumber, setTermNumber] = useState<number | null>(null);
   const markText = anchor.textContent ?? '';
-  const { close, setIsEditing: setIsEditingContext } = useHoverCard();
   const { fetchGlossaryTerm } = useNavigation();
 
   useEffect(() => {
@@ -53,9 +55,9 @@ export const GlossaryInstance = ({
   const setIsEditing = useCallback(
     (editing: boolean) => {
       setIsEditingLocal(editing);
-      setIsEditingContext(editing);
+      setHoverCardEditing(editing);
     },
-    [setIsEditingContext],
+    [setHoverCardEditing],
   );
 
   const deleteLink = useCallback(() => {

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLinkHoverContent.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLinkHoverContent.tsx
@@ -4,7 +4,6 @@ import { ChevronRightIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { InternalLinkInput } from './InternalLinkInput';
 import { findMarkByUuid } from '../../util';
-import { useHoverCard } from '../../../shared/HoverCardProvider';
 
 const EDITOR_UPDATE_DELAY_MS = 100;
 
@@ -14,22 +13,25 @@ export const InternalLinkHoverContent = ({
   entity,
   editor,
   anchor,
+  close,
+  setHoverCardEditing,
 }: {
   uuid: string;
   entityType: string;
   entity: string;
   editor: Editor;
   anchor: HTMLElement;
+  close: () => void;
+  setHoverCardEditing: (isEditing: boolean) => void;
 }) => {
   const [isEditing, setIsEditingLocal] = useState(false);
-  const { close, setIsEditing: setIsEditingContext } = useHoverCard();
 
   const setIsEditing = useCallback(
     (editing: boolean) => {
       setIsEditingLocal(editing);
-      setIsEditingContext(editing);
+      setHoverCardEditing(editing);
     },
-    [setIsEditingContext],
+    [setHoverCardEditing],
   );
 
   const deleteLink = useCallback(() => {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkHoverContent.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/LinkHoverContent.tsx
@@ -4,7 +4,6 @@ import { GlobeIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { HoverInputField } from '../HoverInputField';
 import { findMarkByUuid } from '../../util';
-import { useHoverCard } from '../../../shared/HoverCardProvider';
 
 const EDITOR_UPDATE_DELAY_MS = 100;
 
@@ -13,21 +12,24 @@ export const LinkHoverContent = ({
   href,
   editor,
   anchor,
+  close,
+  setHoverCardEditing,
 }: {
   uuid: string;
   href: string;
   editor: Editor;
   anchor: HTMLElement;
+  close: () => void;
+  setHoverCardEditing: (isEditing: boolean) => void;
 }) => {
   const [isEditing, setIsEditingLocal] = useState(false);
-  const { close, setIsEditing: setIsEditingContext } = useHoverCard();
 
   const setIsEditing = useCallback(
     (editing: boolean) => {
       setIsEditingLocal(editing);
-      setIsEditingContext(editing);
+      setHoverCardEditing(editing);
     },
-    [setIsEditingContext],
+    [setHoverCardEditing],
   );
 
   const deleteLink = useCallback(() => {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionHoverContent.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionHoverContent.tsx
@@ -3,7 +3,6 @@ import { Editor } from '@tiptap/core';
 import { ChevronRightIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { InternalLinkInput } from '../InternalLink/InternalLinkInput';
-import { useHoverCard } from '../../../shared/HoverCardProvider';
 import type { MentionItem } from './Mention';
 
 const EDITOR_UPDATE_DELAY_MS = 100;
@@ -14,7 +13,9 @@ const EDITOR_UPDATE_DELAY_MS = 100;
 function findMentionNodeByItemUuid(
   editor: Editor,
   itemUuid: string,
-): { pos: number; node: ReturnType<Editor['state']['doc']['nodeAt']> } | undefined {
+):
+  | { pos: number; node: ReturnType<Editor['state']['doc']['nodeAt']> }
+  | undefined {
   const { doc } = editor.state;
   let result: { pos: number; node: ReturnType<typeof doc.nodeAt> } | undefined;
 
@@ -38,22 +39,25 @@ export const MentionHoverContent = ({
   entityType,
   entity,
   editor,
+  close,
+  setHoverCardEditing,
 }: {
   uuid: string;
   entityType: string;
   entity: string;
   editor: Editor;
   anchor: HTMLElement;
+  close: () => void;
+  setHoverCardEditing: (isEditing: boolean) => void;
 }) => {
   const [isEditing, setIsEditingLocal] = useState(false);
-  const { close, setIsEditing: setIsEditingContext } = useHoverCard();
 
   const setIsEditing = useCallback(
     (editing: boolean) => {
       setIsEditingLocal(editing);
-      setIsEditingContext(editing);
+      setHoverCardEditing(editing);
     },
-    [setIsEditingContext],
+    [setHoverCardEditing],
   );
 
   const deleteMention = useCallback(() => {

--- a/libs/lib-editing/src/lib/components/editor/save-filter.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/save-filter.spec.ts
@@ -1,54 +1,47 @@
 import { computeSavePayload } from './save-filter';
 
 describe('computeSavePayload', () => {
-  it('should return dirty UUIDs as uuidsToSave when no deletions', () => {
+  it('saves dirty UUIDs that still exist in the current editor state', () => {
     const result = computeSavePayload({
-      dirtyUuids: new Set(['a', 'b']),
-      deletedUuids: new Set(),
+      dirtyUuids: new Set(['a']),
+      baseline: {
+        translation: new Set(['a', 'b']),
+      },
+      current: {
+        translation: new Set(['a', 'b']),
+      },
     });
 
-    expect(result.uuidsToSave).toEqual(['a', 'b']);
+    expect(result.uuidsToSave).toEqual(['a']);
     expect(result.uuidsToDelete).toEqual([]);
     expect(result.hasChanges).toBe(true);
   });
 
-  it('should return deleted UUIDs as uuidsToDelete when no dirty', () => {
+  it('deletes baseline UUIDs missing from the current editor state', () => {
     const result = computeSavePayload({
       dirtyUuids: new Set(),
-      deletedUuids: new Set(['x']),
+      baseline: {
+        translation: new Set(['a', 'b']),
+      },
+      current: {
+        translation: new Set(['a']),
+      },
     });
 
     expect(result.uuidsToSave).toEqual([]);
-    expect(result.uuidsToDelete).toEqual(['x']);
-    expect(result.hasChanges).toBe(true);
-  });
-
-  it('should exclude deleted UUIDs from the save list', () => {
-    const result = computeSavePayload({
-      dirtyUuids: new Set(['a', 'b', 'c']),
-      deletedUuids: new Set(['b']),
-    });
-
-    expect(result.uuidsToSave).toEqual(['a', 'c']);
     expect(result.uuidsToDelete).toEqual(['b']);
     expect(result.hasChanges).toBe(true);
   });
 
-  it('should handle a UUID that is both dirty and deleted', () => {
-    const result = computeSavePayload({
-      dirtyUuids: new Set(['a']),
-      deletedUuids: new Set(['a']),
-    });
-
-    expect(result.uuidsToSave).toEqual([]);
-    expect(result.uuidsToDelete).toEqual(['a']);
-    expect(result.hasChanges).toBe(true);
-  });
-
-  it('should report no changes when both sets are empty', () => {
+  it('does not delete a restored baseline UUID', () => {
     const result = computeSavePayload({
       dirtyUuids: new Set(),
-      deletedUuids: new Set(),
+      baseline: {
+        translation: new Set(['a']),
+      },
+      current: {
+        translation: new Set(['a']),
+      },
     });
 
     expect(result.uuidsToSave).toEqual([]);
@@ -56,39 +49,69 @@ describe('computeSavePayload', () => {
     expect(result.hasChanges).toBe(false);
   });
 
-  it('should handle split scenario: original dirty + new dirty, none deleted', () => {
+  it('saves new UUIDs that are not in the baseline', () => {
     const result = computeSavePayload({
-      dirtyUuids: new Set(['original', 'new-split']),
-      deletedUuids: new Set(),
+      dirtyUuids: new Set(),
+      baseline: {
+        translation: new Set(['a']),
+      },
+      current: {
+        translation: new Set(['a', 'b']),
+      },
     });
 
-    expect(result.uuidsToSave).toEqual(
-      expect.arrayContaining(['original', 'new-split']),
-    );
-    expect(result.uuidsToSave).toHaveLength(2);
+    expect(result.uuidsToSave).toEqual(['b']);
     expect(result.uuidsToDelete).toEqual([]);
     expect(result.hasChanges).toBe(true);
   });
 
-  it('should handle merge scenario: merged passage dirty + old passage deleted', () => {
-    const result = computeSavePayload({
-      dirtyUuids: new Set(['passage-a', 'passage-b']),
-      deletedUuids: new Set(['passage-b']),
-    });
-
-    expect(result.uuidsToSave).toEqual(['passage-a']);
-    expect(result.uuidsToDelete).toEqual(['passage-b']);
-    expect(result.hasChanges).toBe(true);
-  });
-
-  it('should handle delete-only scenario: passage deleted without edits', () => {
+  it('does not save unchanged baseline UUIDs without dirty hints', () => {
     const result = computeSavePayload({
       dirtyUuids: new Set(),
-      deletedUuids: new Set(['deleted-passage']),
+      baseline: {
+        translation: new Set(['a']),
+      },
+      current: {
+        translation: new Set(['a']),
+      },
     });
 
     expect(result.uuidsToSave).toEqual([]);
-    expect(result.uuidsToDelete).toEqual(['deleted-passage']);
+    expect(result.uuidsToDelete).toEqual([]);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it('does not save UUIDs that are also deleted', () => {
+    const result = computeSavePayload({
+      dirtyUuids: new Set(['a']),
+      baseline: {
+        translation: new Set(['a']),
+      },
+      current: {
+        translation: new Set(),
+      },
+    });
+
+    expect(result.uuidsToSave).toEqual([]);
+    expect(result.uuidsToDelete).toEqual(['a']);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it('tracks independent editor baselines separately', () => {
+    const result = computeSavePayload({
+      dirtyUuids: new Set(['n1']),
+      baseline: {
+        translation: new Set(['a']),
+        endnotes: new Set(['n1', 'n2']),
+      },
+      current: {
+        translation: new Set(['a']),
+        endnotes: new Set(['n1', 'n3']),
+      },
+    });
+
+    expect(result.uuidsToSave).toEqual(['n1', 'n3']);
+    expect(result.uuidsToDelete).toEqual(['n2']);
     expect(result.hasChanges).toBe(true);
   });
 });

--- a/libs/lib-editing/src/lib/components/editor/save-filter.ts
+++ b/libs/lib-editing/src/lib/components/editor/save-filter.ts
@@ -1,27 +1,49 @@
-/**
- * Compute which passage UUIDs should be saved and which should be deleted.
- * Passages that are both dirty and deleted are excluded from the save list
- * (they no longer exist in the editor).
- */
+export type PassageUuidRecord = Record<string, Set<string>>;
+
 export const computeSavePayload = ({
   dirtyUuids,
-  deletedUuids,
+  baseline,
+  current,
 }: {
   dirtyUuids: Set<string>;
-  deletedUuids: Set<string>;
+  baseline: PassageUuidRecord;
+  current: PassageUuidRecord;
 }): {
   uuidsToSave: string[];
   uuidsToDelete: string[];
   hasChanges: boolean;
 } => {
-  const uuidsToDelete = Array.from(deletedUuids);
-  const uuidsToSave = Array.from(dirtyUuids).filter(
-    (uuid) => !deletedUuids.has(uuid),
-  );
+  const uuidsToDelete = new Set<string>();
+  const uuidsToSave = new Set<string>();
+
+  Object.entries(baseline).forEach(([key, baselineForKey]) => {
+    const currentForKey = current[key] ?? new Set<string>();
+    baselineForKey.forEach((uuid) => {
+      if (!currentForKey.has(uuid)) {
+        uuidsToDelete.add(uuid);
+      }
+    });
+  });
+
+  Object.entries(current).forEach(([key, currentForKey]) => {
+    const baselineForKey = baseline[key] ?? new Set<string>();
+    currentForKey.forEach((uuid) => {
+      if (!baselineForKey.has(uuid)) {
+        uuidsToSave.add(uuid);
+        return;
+      }
+
+      if (dirtyUuids.has(uuid)) {
+        uuidsToSave.add(uuid);
+      }
+    });
+  });
+
+  uuidsToDelete.forEach((uuid) => uuidsToSave.delete(uuid));
 
   return {
-    uuidsToSave,
-    uuidsToDelete,
-    hasChanges: uuidsToSave.length > 0 || uuidsToDelete.length > 0,
+    uuidsToSave: Array.from(uuidsToSave),
+    uuidsToDelete: Array.from(uuidsToDelete),
+    hasChanges: uuidsToSave.size > 0 || uuidsToDelete.size > 0,
   };
 };

--- a/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
@@ -6,10 +6,8 @@ import {
 } from '@eightyfourthousand/design-system';
 import { isInBounds } from '@eightyfourthousand/lib-utils';
 import {
-  createContext,
   ReactNode,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -38,36 +36,6 @@ const TYPE_ATTRIBUTE_MAP: Record<HoverCardType, string> = {
   internalLink: 'uuid',
   mention: 'uuid',
 };
-
-export interface HoverCardState {
-  anchor: HTMLElement | null;
-  uuid?: string;
-  cardType?: HoverCardType;
-  editor?: Editor;
-  isEditing: boolean;
-  setAnchor: (anchor: HTMLElement | null) => void;
-  setUuid: (uuid?: string) => void;
-  setCard: (card: HTMLElement | null) => void;
-  setIsEditing: (isEditing: boolean) => void;
-  close: () => void;
-}
-
-// Defensive defaults: consumers keep their own local state and already call
-// close() via the mounted provider's own callback, so a no-op here avoids
-// crashing when the context isn't in scope (e.g. feature-flag hydration race).
-const warnNoProvider = (name: string) => () => {
-  console.warn(`HoverCardContext.${name} called outside a HoverCardProvider`);
-};
-
-export const HoverCardContext = createContext<HoverCardState>({
-  anchor: null,
-  isEditing: false,
-  setAnchor: warnNoProvider('setAnchor'),
-  setCard: warnNoProvider('setCard'),
-  setUuid: warnNoProvider('setUuid'),
-  setIsEditing: warnNoProvider('setIsEditing'),
-  close: warnNoProvider('close'),
-});
 
 export const HoverCardProvider = ({
   openDelay = DEFAULT_HOVER_CARD_OPEN_DELAY,
@@ -332,6 +300,8 @@ export const HoverCardProvider = ({
           glossary={glossary}
           editor={editor}
           anchor={anchorEl}
+          close={closeImmediately}
+          setHoverCardEditing={setIsEditing}
         />
       );
     }
@@ -343,6 +313,8 @@ export const HoverCardProvider = ({
           endNote={endNote}
           editor={editor}
           anchor={anchorEl}
+          close={closeImmediately}
+          setHoverCardEditing={setIsEditing}
         />
       );
     }
@@ -354,6 +326,8 @@ export const HoverCardProvider = ({
           href={href}
           editor={editor}
           anchor={anchorEl}
+          close={closeImmediately}
+          setHoverCardEditing={setIsEditing}
         />
       );
     }
@@ -367,6 +341,8 @@ export const HoverCardProvider = ({
           entity={entity}
           editor={editor}
           anchor={anchorEl}
+          close={closeImmediately}
+          setHoverCardEditing={setIsEditing}
         />
       );
     }
@@ -380,6 +356,8 @@ export const HoverCardProvider = ({
           entity={entity}
           editor={editor}
           anchor={anchorEl}
+          close={closeImmediately}
+          setHoverCardEditing={setIsEditing}
         />
       );
     }
@@ -390,20 +368,7 @@ export const HoverCardProvider = ({
   const shouldShowCard = enabled && anchor && uuid && cardType && editor;
 
   return (
-    <HoverCardContext.Provider
-      value={{
-        anchor,
-        uuid,
-        cardType,
-        editor,
-        isEditing,
-        setAnchor,
-        setCard,
-        setUuid,
-        setIsEditing,
-        close: closeImmediately,
-      }}
-    >
+    <>
       <div className="size-full" ref={containerRef}>
         {children}
       </div>
@@ -412,15 +377,6 @@ export const HoverCardProvider = ({
           {renderCard(uuid, cardType, anchor)}
         </TranslationHoverCard>
       )}
-    </HoverCardContext.Provider>
+    </>
   );
-};
-
-export const useHoverCard = () => {
-  const context = useContext(HoverCardContext);
-  if (!context) {
-    throw new Error('useHoverCard must be used within a HoverCardProvider');
-  }
-
-  return context;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
         "@types/react-is": "19.0.0",
         "autoprefixer": "10.4.20",
         "babel-jest": "30.0.5",
+        "baseline-browser-mapping": "^2.10.24",
         "css-loader": "^7.1.2",
         "cypress": "15.7.1",
         "esbuild": "^0.19.2",
@@ -19195,13 +19196,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.6.tgz",
-      "integrity": "sha512-v9BVVpOTLB59C9E7aSnmIF8h7qRsFpx+A2nugVMTszEOMcfjlZMsXRm4LF23I3Z9AJxc8ANpIvzbzONoX9VJlg==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-auth": {

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "@types/react-is": "19.0.0",
     "autoprefixer": "10.4.20",
     "babel-jest": "30.0.5",
+    "baseline-browser-mapping": "^2.10.24",
     "css-loader": "^7.1.2",
     "cypress": "15.7.1",
     "esbuild": "^0.19.2",


### PR DESCRIPTION
### Summary

Refines some aspects of Editor state:

- Passage uuids for caching, updating and deleting
- Editor instance lifecycle

The goal is avoid zombie instances of the editor and observers intercepting calls to save passage data and quietly failing. The next step will be to provide direct feedback in the UI that data has been saved or failed. This builds on #334, which ensures the editor matches the database after saving.

### Linear

- part of [DEV-593](https://linear.app/84000/issue/DEV-593)
- part of [DEV-594](https://linear.app/84000/issue/DEV-594)