### PR TITLE
Minimize Saves

### DIFF
--- a/libs/data-access/src/lib/passage/save.spec.ts
+++ b/libs/data-access/src/lib/passage/save.spec.ts
@@ -1,0 +1,252 @@
+import { savePassagesWithDeletions } from './save';
+import type { AnnotationDTO, Passage, PassageRowDTO } from '../types';
+
+type TableName = 'passages' | 'passage_annotations';
+
+type FakeState = {
+  annotations: AnnotationDTO[];
+  deletedAnnotationUuids: string[];
+  deletedPassageUuids: string[];
+  passageUpserts: PassageRowDTO[][];
+  passages: PassageRowDTO[];
+  annotationUpserts: AnnotationDTO[][];
+};
+
+class FakeQueryBuilder {
+  private action?: 'select' | 'delete';
+  private inColumn?: string;
+  private inValues: string[] = [];
+
+  constructor(
+    private readonly state: FakeState,
+    private readonly table: TableName,
+  ) {}
+
+  select() {
+    this.action = 'select';
+    return this;
+  }
+
+  delete() {
+    this.action = 'delete';
+    return this;
+  }
+
+  upsert(rows: PassageRowDTO[] | AnnotationDTO[]) {
+    if (this.table === 'passages') {
+      this.state.passageUpserts.push(rows as PassageRowDTO[]);
+    } else {
+      this.state.annotationUpserts.push(rows as AnnotationDTO[]);
+    }
+    return Promise.resolve({ error: null });
+  }
+
+  in(column: string, values: string[]) {
+    this.inColumn = column;
+    this.inValues = values;
+    return this;
+  }
+
+  not() {
+    return this;
+  }
+
+  eq() {
+    return this;
+  }
+
+  gt() {
+    return this;
+  }
+
+  order() {
+    return this;
+  }
+
+  limit() {
+    return this;
+  }
+
+  then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?:
+      | ((value: {
+          data: unknown[];
+          error?: null;
+        }) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ) {
+    return Promise.resolve(this.execute()).then(onfulfilled, onrejected);
+  }
+
+  private execute() {
+    if (this.action === 'delete') {
+      if (this.table === 'passage_annotations') {
+        if (this.inColumn === 'passage_uuid') {
+          this.state.deletedAnnotationUuids.push(
+            ...this.state.annotations
+              .filter((annotation) =>
+                this.inValues.includes(annotation.passage_uuid ?? ''),
+              )
+              .map((annotation) => annotation.uuid),
+          );
+        } else {
+          this.state.deletedAnnotationUuids.push(...this.inValues);
+        }
+      } else {
+        this.state.deletedPassageUuids.push(...this.inValues);
+      }
+      return { data: [], error: null };
+    }
+
+    if (this.table === 'passage_annotations') {
+      return {
+        data: this.state.annotations.filter((annotation) =>
+          this.inValues.includes(annotation.passage_uuid ?? ''),
+        ),
+        error: null,
+      };
+    }
+
+    return {
+      data: this.inColumn
+        ? this.state.passages.filter((passage) =>
+            this.inValues.includes(passage.uuid),
+          )
+        : [],
+      error: null,
+    };
+  }
+}
+
+const createFakeClient = (state: FakeState) =>
+  ({
+    from: (table: TableName) => new FakeQueryBuilder(state, table),
+    rpc: jest.fn().mockResolvedValue({ error: null }),
+  }) as never;
+
+const createState = ({
+  annotations = [],
+  passages = [],
+}: {
+  annotations?: AnnotationDTO[];
+  passages?: PassageRowDTO[];
+}): FakeState => ({
+  annotations,
+  deletedAnnotationUuids: [],
+  deletedPassageUuids: [],
+  passageUpserts: [],
+  passages,
+  annotationUpserts: [],
+});
+
+const passage: Passage = {
+  uuid: 'passage-1',
+  workUuid: 'work-1',
+  content: 'Body text',
+  label: '1',
+  sort: 1,
+  type: 'translation',
+  annotations: [
+    {
+      uuid: 'annotation-1',
+      passageUuid: 'passage-1',
+      start: 0,
+      end: 9,
+      type: 'paragraph',
+    },
+  ],
+};
+
+const passageRow: PassageRowDTO = {
+  uuid: 'passage-1',
+  work_uuid: 'work-1',
+  content: 'Body text',
+  label: '1',
+  sort: 1,
+  type: 'translation',
+};
+
+const annotationRow: AnnotationDTO = {
+  uuid: 'annotation-1',
+  passage_uuid: 'passage-1',
+  start: 0,
+  end: 9,
+  type: 'paragraph',
+  content: [],
+};
+
+describe('savePassagesWithDeletions', () => {
+  it('does not upsert unchanged passage or annotation rows', async () => {
+    const state = createState({
+      annotations: [annotationRow],
+      passages: [passageRow],
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [passage],
+    });
+
+    expect(result.success).toBe(true);
+    expect(state.passageUpserts).toEqual([]);
+    expect(state.annotationUpserts).toEqual([]);
+    expect(state.deletedAnnotationUuids).toEqual([]);
+  });
+
+  it('upserts only changed annotations for dirty passages', async () => {
+    const state = createState({
+      annotations: [{ ...annotationRow, end: 4 }],
+      passages: [passageRow],
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [passage],
+    });
+
+    expect(result.success).toBe(true);
+    expect(state.passageUpserts).toEqual([]);
+    expect(state.annotationUpserts).toEqual([[annotationRow]]);
+    expect(state.deletedAnnotationUuids).toEqual([]);
+  });
+
+  it('deletes annotations omitted from a saved dirty passage', async () => {
+    const state = createState({
+      annotations: [
+        annotationRow,
+        { ...annotationRow, uuid: 'annotation-2', start: 5, end: 9 },
+      ],
+      passages: [passageRow],
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [passage],
+    });
+
+    expect(result.success).toBe(true);
+    expect(state.annotationUpserts).toEqual([]);
+    expect(state.deletedAnnotationUuids).toEqual(['annotation-2']);
+  });
+
+  it('supports delete-only saves without passage or annotation upserts', async () => {
+    const state = createState({
+      annotations: [annotationRow],
+      passages: [passageRow],
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [],
+      deletedUuids: ['passage-1'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.deletedCount).toBe(1);
+    expect(state.passageUpserts).toEqual([]);
+    expect(state.annotationUpserts).toEqual([]);
+    expect(state.deletedAnnotationUuids).toEqual(['annotation-1']);
+    expect(state.deletedPassageUuids).toEqual(['passage-1']);
+  });
+});

--- a/libs/data-access/src/lib/passage/save.ts
+++ b/libs/data-access/src/lib/passage/save.ts
@@ -2,7 +2,9 @@ import {
   ANNOTATIONS_TO_IGNORE,
   BodyItemType,
   DataClient,
+  AnnotationDTO,
   Passage,
+  PassageRowDTO,
   TohokuCatalogEntry,
   passagesToDTO,
   passagesToRowDTO,
@@ -181,6 +183,74 @@ export type SavePassagesWithDeletionsResult = {
   error?: string;
 };
 
+type ExistingPassageRow = PassageRowDTO;
+
+type ExistingAnnotationRow = AnnotationDTO & {
+  passage_uuid: string;
+};
+
+const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(
+        ([key, entryValue]) =>
+          `${JSON.stringify(key)}:${stableStringify(entryValue)}`,
+      )
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+};
+
+const nullableEqual = (a: unknown, b: unknown) => (a ?? null) === (b ?? null);
+
+const passageRowHasChanged = (
+  incoming: PassageRowDTO,
+  existing?: ExistingPassageRow,
+) => {
+  if (!existing) {
+    return true;
+  }
+
+  return (
+    incoming.content !== existing.content ||
+    incoming.label !== existing.label ||
+    incoming.sort !== existing.sort ||
+    incoming.type !== existing.type ||
+    incoming.work_uuid !== existing.work_uuid ||
+    !nullableEqual(incoming.xmlId, existing.xmlId) ||
+    !nullableEqual(incoming.parent, existing.parent) ||
+    stableStringify(incoming.toh ?? null) !==
+      stableStringify(existing.toh ?? null)
+  );
+};
+
+const annotationHasChanged = (
+  incoming: AnnotationDTO,
+  existing?: ExistingAnnotationRow,
+) => {
+  if (!existing) {
+    return true;
+  }
+
+  return (
+    incoming.start !== existing.start ||
+    incoming.end !== existing.end ||
+    incoming.type !== existing.type ||
+    (incoming.passage_uuid ?? incoming.passageUuid ?? '') !==
+      existing.passage_uuid ||
+    stableStringify(incoming.content ?? []) !==
+      stableStringify(existing.content ?? []) ||
+    stableStringify(incoming.toh ?? null) !==
+      stableStringify(existing.toh ?? null)
+  );
+};
+
 export const savePassagesWithDeletions = async ({
   client,
   passages,
@@ -191,10 +261,15 @@ export const savePassagesWithDeletions = async ({
   deletedUuids?: string[];
 }): Promise<SavePassagesWithDeletionsResult> => {
   const inputUuids = passages.map((p) => p.uuid);
-  const { data: existingRows } = await client
-    .from('passages')
-    .select('uuid')
-    .in('uuid', inputUuids);
+  const { data: existingRows } =
+    inputUuids.length > 0
+      ? await client
+          .from('passages')
+          .select(
+            'uuid, content, label, sort, type, work_uuid, xmlId, parent, toh',
+          )
+          .in('uuid', inputUuids)
+      : { data: [] };
   const existingUuidSet = new Set((existingRows ?? []).map((r) => r.uuid));
   const newPassages = passages.filter((p) => !existingUuidSet.has(p.uuid));
   const sortedNewPassages = [...newPassages].sort((a, b) => b.sort - a.sort);
@@ -276,11 +351,35 @@ export const savePassagesWithDeletions = async ({
   const passageRowDtos = passagesToRowDTO(passages);
   const passageUuids = passages.map((p) => p.uuid);
   const annotations = dtos.flatMap((p) => p.annotations || []);
-  const { data: existingAnnotations } = await client
-    .from('passage_annotations')
-    .select('uuid')
-    .in('passage_uuid', passageUuids)
-    .not('type', 'in', `(${ANNOTATIONS_TO_IGNORE.join(',')})`);
+  const { data: existingAnnotations } =
+    passageUuids.length > 0
+      ? await client
+          .from('passage_annotations')
+          .select('uuid, passage_uuid, start, end, type, content, toh')
+          .in('passage_uuid', passageUuids)
+          .not('type', 'in', `(${ANNOTATIONS_TO_IGNORE.join(',')})`)
+      : { data: [] };
+
+  const existingRowsByUuid = new Map(
+    ((existingRows ?? []) as ExistingPassageRow[]).map((row) => [
+      row.uuid,
+      row,
+    ]),
+  );
+  const passageRowsToUpsert = passageRowDtos.filter((row) =>
+    passageRowHasChanged(row, existingRowsByUuid.get(row.uuid)),
+  );
+  const existingAnnotationsByUuid = new Map(
+    ((existingAnnotations ?? []) as ExistingAnnotationRow[]).map(
+      (annotation) => [annotation.uuid, annotation],
+    ),
+  );
+  const annotationsToUpsert = annotations.filter((annotation) =>
+    annotationHasChanged(
+      annotation,
+      existingAnnotationsByUuid.get(annotation.uuid),
+    ),
+  );
 
   const annotationsToDelete = existingAnnotations?.filter(
     (existingAnnotation) =>
@@ -289,24 +388,26 @@ export const savePassagesWithDeletions = async ({
       ),
   );
 
-  const { error: passageError } = await client
-    .from('passages')
-    .upsert(passageRowDtos, { onConflict: 'uuid' });
+  if (passageRowsToUpsert.length > 0) {
+    const { error: passageError } = await client
+      .from('passages')
+      .upsert(passageRowsToUpsert, { onConflict: 'uuid' });
 
-  if (passageError) {
-    console.error('Error saving passages:', passageError);
-    return {
-      success: false,
-      savedCount: 0,
-      passages: [],
-      error: `Failed to save passages: ${passageError.message}`,
-    };
+    if (passageError) {
+      console.error('Error saving passages:', passageError);
+      return {
+        success: false,
+        savedCount: 0,
+        passages: [],
+        error: `Failed to save passages: ${passageError.message}`,
+      };
+    }
   }
 
-  if (annotations.length > 0) {
+  if (annotationsToUpsert.length > 0) {
     const { error: annotationError } = await client
       .from('passage_annotations')
-      .upsert(annotations, { onConflict: 'uuid' });
+      .upsert(annotationsToUpsert, { onConflict: 'uuid' });
 
     if (annotationError) {
       console.error('Error saving annotations:', annotationError);
@@ -333,10 +434,13 @@ export const savePassagesWithDeletions = async ({
     }
   }
 
-  const { data: savedRows } = await client
-    .from('passages')
-    .select('uuid, work_uuid, content, label, sort, type, xmlId, toh')
-    .in('uuid', inputUuids);
+  const { data: savedRows } =
+    inputUuids.length > 0
+      ? await client
+          .from('passages')
+          .select('uuid, work_uuid, content, label, sort, type, xmlId, toh')
+          .in('uuid', inputUuids)
+      : { data: [] };
 
   const savedPassages: SavedPassageRow[] = (savedRows ?? []).map((row) => ({
     uuid: row.uuid,

--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -116,6 +116,7 @@ export const EditorContextProvider = ({
   // Use ref for immediate tracking to avoid state updates on every keystroke
   const dirtyUuidsRef = useRef<Set<string>>(new Set());
   const isNavigatingRef = useRef(false);
+  const isNormalizingForSaveRef = useRef(false);
   const clearedFragmentRef = useRef<XmlFragment | null>(null);
   const lastObservedUuidsByFragmentRef = useRef<Map<XmlFragment, Set<string>>>(
     new Map(),
@@ -209,7 +210,11 @@ export const EditorContextProvider = ({
       // We intentionally avoid using Yjs `changes.deleted` because operations like
       // splitPassage (replaceWith + insert) cause the binding to delete and re-create
       // XmlElements internally, producing false positives.
-      if (!isNavigatingRef.current && evts.length > 0) {
+      if (
+        !isNavigatingRef.current &&
+        !isNormalizingForSaveRef.current &&
+        evts.length > 0
+      ) {
         let fragment: XmlFragment | null = null;
         let current: XmlFragment | XmlElement | null = evts[0].target;
         while (current) {
@@ -265,7 +270,7 @@ export const EditorContextProvider = ({
         }
       }
 
-      if (!isNavigatingRef.current) {
+      if (!isNavigatingRef.current && !isNormalizingForSaveRef.current) {
         txn.changed.forEach((_change, key) => {
           // Start from key itself (not key.parent) so that structural changes
           // directly on a passage XmlElement (e.g. children moved during merge)
@@ -462,7 +467,6 @@ export const EditorContextProvider = ({
 
     const liveUuidsByEditor: PassageUuidRecord = {};
     editorEntries.forEach(([key, editor]) => {
-      ensureUuids(editor);
       liveUuidsByEditor[key] = getEditorUuids(editor);
     });
     const savedBaselineUuidsByEditor = Object.fromEntries(
@@ -493,6 +497,22 @@ export const EditorContextProvider = ({
     const passages: Passage[] = [];
     if (uuidsToSave.length) {
       const uuidsToSaveSet = new Set(uuidsToSave);
+      isNormalizingForSaveRef.current = true;
+      try {
+        editorEntries.forEach(([, editor]) => {
+          const editorUuids = Array.from(getEditorUuids(editor)).filter(
+            (uuid) => uuidsToSaveSet.has(uuid),
+          );
+          if (editorUuids.length === 0) {
+            return;
+          }
+
+          ensureUuids(editor, { passageUuids: new Set(editorUuids) });
+        });
+      } finally {
+        isNormalizingForSaveRef.current = false;
+      }
+
       editorEntries.forEach(([, editor]) => {
         const editorUuids = Array.from(getEditorUuids(editor)).filter((uuid) =>
           uuidsToSaveSet.has(uuid),

--- a/libs/lib-editing/src/lib/passage.spec.ts
+++ b/libs/lib-editing/src/lib/passage.spec.ts
@@ -1,0 +1,94 @@
+import { ensureUuids } from './passage';
+
+type FakeNode = {
+  attrs: Record<string, unknown>;
+  content?: FakeNode[];
+  marks?: unknown[];
+  type: { name: string };
+};
+
+const createFakeEditor = (nodes: FakeNode[]) => {
+  const setNodeMarkup = jest.fn();
+  const dispatch = jest.fn();
+  let pos = 0;
+  const walk = (
+    node: FakeNode,
+    callback: (node: FakeNode, pos: number) => boolean,
+  ) => {
+    const currentPos = pos;
+    pos += 1;
+    const shouldDescend = callback(node, currentPos);
+    if (shouldDescend) {
+      node.content?.forEach((child) => walk(child, callback));
+    }
+  };
+  const doc = {
+    descendants: (callback: (node: FakeNode, pos: number) => boolean) => {
+      pos = 0;
+      nodes.forEach((node) => walk(node, callback));
+    },
+    resolve: () => ({ depth: 0, node: () => nodes[0] }),
+  };
+
+  return {
+    editor: {
+      state: {
+        doc,
+        tr: {
+          setNodeMarkup,
+          removeMark: jest.fn(),
+          addMark: jest.fn(),
+        },
+      },
+      view: { dispatch },
+    },
+    dispatch,
+    setNodeMarkup,
+  };
+};
+
+describe('ensureUuids', () => {
+  it('normalizes a dirty passage child whose uuid duplicates the passage uuid', () => {
+    const passageNode: FakeNode = {
+      attrs: { uuid: 'passage-1' },
+      content: [
+        {
+          attrs: { uuid: 'passage-1' },
+          marks: [],
+          type: { name: 'paragraph' },
+        },
+      ],
+      marks: [],
+      type: { name: 'passage' },
+    };
+    const otherPassageNode: FakeNode = {
+      attrs: { uuid: 'passage-2' },
+      content: [
+        {
+          attrs: { uuid: 'passage-2' },
+          marks: [],
+          type: { name: 'paragraph' },
+        },
+      ],
+      marks: [],
+      type: { name: 'passage' },
+    };
+
+    const { editor, dispatch, setNodeMarkup } = createFakeEditor([
+      passageNode,
+      otherPassageNode,
+    ]);
+
+    ensureUuids(editor as never, { passageUuids: new Set(['passage-1']) });
+
+    expect(setNodeMarkup).toHaveBeenCalledTimes(1);
+    expect(setNodeMarkup).toHaveBeenCalledWith(
+      1,
+      undefined,
+      expect.objectContaining({
+        uuid: expect.not.stringMatching(/^passage-[12]$/),
+      }),
+    );
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/lib-editing/src/lib/passage.ts
+++ b/libs/lib-editing/src/lib/passage.ts
@@ -39,16 +39,37 @@ import { Passage } from '@eightyfourthousand/data-access';
 // and must be deduplicated alongside the main `uuid` attribute.
 const PARAMETER_UUID_ATTRS = ['leadingSpaceUuid', 'indentUuid'] as const;
 
-export const ensureUuids = (editor: Editor): void => {
+export interface EnsureUuidsOptions {
+  passageUuids?: Set<string>;
+}
+
+export const ensureUuids = (
+  editor: Editor,
+  options: EnsureUuidsOptions = {},
+): void => {
   const { state, view } = editor;
   const { doc, tr } = state;
   const seen = new Set<string>();
   let changed = false;
+  let activePassageUuid: string | undefined;
+  const targetPassageUuids = options.passageUuids;
 
   doc.descendants((node, pos) => {
     // text and doc nodes never carry a uuid
     if (node.type.name === 'text' || node.type.name === 'doc') {
       return true;
+    }
+
+    if (node.type.name === 'passage') {
+      activePassageUuid = node.attrs.uuid;
+      if (node.attrs.uuid) {
+        seen.add(node.attrs.uuid);
+      }
+      return !targetPassageUuids || targetPassageUuids.has(node.attrs.uuid);
+    }
+
+    if (targetPassageUuids && !activePassageUuid) {
+      return false;
     }
 
     let newAttrs: Record<string, unknown> | null = null;
@@ -87,6 +108,24 @@ export const ensureUuids = (editor: Editor): void => {
   // marks directly, so we must walk text nodes to find them.
   doc.descendants((node, pos) => {
     if (node.type.name !== 'text' || node.marks.length === 0) return true;
+
+    if (targetPassageUuids) {
+      let nodeInTargetPassage = false;
+      const $pos = doc.resolve(pos);
+      for (let depth = $pos.depth; depth >= 0; depth--) {
+        const parent = $pos.node(depth);
+        if (
+          parent.type.name === 'passage' &&
+          targetPassageUuids.has(parent.attrs.uuid)
+        ) {
+          nodeInTargetPassage = true;
+          break;
+        }
+      }
+      if (!nodeInTargetPassage) {
+        return true;
+      }
+    }
 
     for (const mark of node.marks) {
       const existing: string | null | undefined = mark.attrs.uuid;


### PR DESCRIPTION
### Summary

The business logic for marking a passage as dirty was over-eager. This limits saves and deletes to only act on passages and annotations that have actually changed.