### PR TITLE
Regex Search (and Replace) 

### DIFF
--- a/apps/api-graphql/src/graphql/schema/passage/passage.graphql
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.graphql
@@ -313,5 +313,6 @@ extend type Mutation {
     occurrenceIndex: Int
     cursorPassageUuid: ID
     cursorStart: Int
+    useRegex: Boolean
   ): ReplaceResult!
 }

--- a/apps/api-graphql/src/graphql/schema/passage/passage.mutation.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.mutation.ts
@@ -3,6 +3,7 @@ import {
   Passage,
   Annotation,
   findLiteralOccurrences,
+  findRegexOccurrences,
   fetchReplaceAnnotations,
   fetchReplaceRows,
   hasPermission,
@@ -124,6 +125,7 @@ export const replaceMutation = async (
     searchText: string;
     targetUuids: string[];
     type?: 'PASSAGE';
+    useRegex?: boolean;
   },
   ctx: GraphQLContext,
 ): Promise<ReplaceResult> => {
@@ -195,7 +197,8 @@ export const replaceMutation = async (
           }
         }
 
-        const occurrences = findLiteralOccurrences(row.content, args.searchText);
+        const findOccurrences = args.useRegex ? findRegexOccurrences : findLiteralOccurrences;
+        const occurrences = findOccurrences(row.content, args.searchText);
         occurrenceIndex =
           row.uuid === cursorPassageUuid
             ? occurrences.findIndex((occurrence) => occurrence.start >= cursorStart)
@@ -207,7 +210,8 @@ export const replaceMutation = async (
           continue;
         }
       } else if (remainingOccurrenceIndex !== undefined) {
-        const occurrences = findLiteralOccurrences(row.content, args.searchText);
+        const findOccurrences = args.useRegex ? findRegexOccurrences : findLiteralOccurrences;
+        const occurrences = findOccurrences(row.content, args.searchText);
         if (remainingOccurrenceIndex >= occurrences.length) {
           remainingOccurrenceIndex -= occurrences.length;
           continue;
@@ -221,6 +225,7 @@ export const replaceMutation = async (
         searchText: args.searchText,
         replaceText: args.replaceText,
         occurrenceIndex,
+        useRegex: args.useRegex,
       });
 
       if (replacement.replacementsApplied === 0) {
@@ -248,6 +253,7 @@ export const replaceMutation = async (
           })),
           searchText: args.searchText,
           updatedContentByUuid,
+          useRegex: args.useRegex,
         });
 
         nextPassageUuid = nextCursor?.passageUuid ?? null;

--- a/apps/api-graphql/src/graphql/schema/passage/passage.replace.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.replace.ts
@@ -4,6 +4,7 @@ import {
   Passage,
   annotationsFromDTO,
   findLiteralOccurrences,
+  findRegexOccurrences,
   type ReplacePassageRow,
 } from '@eightyfourthousand/data-access';
 
@@ -61,6 +62,7 @@ export const validateReplaceArgs = (args: {
   searchText: string;
   targetUuids: string[];
   type?: 'PASSAGE';
+  useRegex?: boolean;
 }) => {
   const replaceType = args.type ?? 'PASSAGE';
   if (replaceType !== 'PASSAGE') {
@@ -117,12 +119,14 @@ export const findNextReplaceCursor = ({
   passages,
   searchText,
   updatedContentByUuid,
+  useRegex = false,
 }: {
   fromPassageUuid: string;
   fromStart: number;
   passages: Array<{ content: string; uuid: string }>;
   searchText: string;
   updatedContentByUuid: Map<string, string>;
+  useRegex?: boolean;
 }): { passageUuid: string; start: number } | null => {
   const startIndex = passages.findIndex(
     (passage) => passage.uuid === fromPassageUuid,
@@ -135,6 +139,8 @@ export const findNextReplaceCursor = ({
   const getContent = (uuid: string, fallback: string) =>
     updatedContentByUuid.get(uuid) ?? fallback;
 
+  const findOccurrences = useRegex ? findRegexOccurrences : findLiteralOccurrences;
+
   const findMatchInPassage = ({
     minStart,
     passage,
@@ -143,7 +149,7 @@ export const findNextReplaceCursor = ({
     passage: { content: string; uuid: string };
   }) => {
     const content = getContent(passage.uuid, passage.content);
-    const match = findLiteralOccurrences(content, searchText).find(
+    const match = findOccurrences(content, searchText).find(
       (occurrence) => occurrence.start >= minStart,
     );
 

--- a/libs/client-graphql/src/lib/functions/replace.ts
+++ b/libs/client-graphql/src/lib/functions/replace.ts
@@ -32,6 +32,7 @@ const REPLACE_MUTATION = gql`
     $occurrenceIndex: Int
     $cursorPassageUuid: ID
     $cursorStart: Int
+    $useRegex: Boolean
   ) {
     replace(
       searchText: $searchText
@@ -41,6 +42,7 @@ const REPLACE_MUTATION = gql`
       occurrenceIndex: $occurrenceIndex
       cursorPassageUuid: $cursorPassageUuid
       cursorStart: $cursorStart
+      useRegex: $useRegex
     ) {
       success
       updatedCount
@@ -67,6 +69,7 @@ export const replace = async ({
   searchText,
   targetUuids,
   type = 'PASSAGE',
+  useRegex,
 }: {
   client: GraphQLClient;
   occurrenceIndex?: number;
@@ -76,6 +79,7 @@ export const replace = async ({
   cursorStart?: number;
   targetUuids: string[];
   type?: ReplaceType;
+  useRegex?: boolean;
 }) => {
   const response = await client.request<ReplaceResponse>(REPLACE_MUTATION, {
     searchText,
@@ -85,6 +89,7 @@ export const replace = async ({
     occurrenceIndex,
     cursorPassageUuid,
     cursorStart,
+    useRegex,
   });
 
   return response.replace;

--- a/libs/data-access/src/lib/replace.ts
+++ b/libs/data-access/src/lib/replace.ts
@@ -50,14 +50,45 @@ export const findLiteralOccurrences = (
   return matches;
 };
 
+export const findRegexOccurrences = (
+  content: string,
+  pattern: string,
+): Array<{ end: number; start: number }> => {
+  if (!pattern) {
+    return [];
+  }
+
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern, 'gi');
+  } catch {
+    return [];
+  }
+
+  const matches: Array<{ end: number; start: number }> = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(content)) !== null) {
+    if (match[0].length === 0) {
+      regex.lastIndex++;
+      continue;
+    }
+    matches.push({ start: match.index, end: match.index + match[0].length });
+  }
+
+  return matches;
+};
+
 export const getPassageOccurrences = (
   passages: { content: string; uuid: string; type: 'passage' | 'alignment' }[],
   searchText: string,
+  useRegex = false,
 ): PassageOccurrence[] => {
   let index = 0;
+  const findOccurrences = useRegex ? findRegexOccurrences : findLiteralOccurrences;
 
   return passages.flatMap((passage) =>
-    findLiteralOccurrences(passage.content, searchText).map((match, passageIndex) => ({
+    findOccurrences(passage.content, searchText).map((match, passageIndex) => ({
       ...match,
       index: index++,
       passageOccurrenceIndex: passageIndex,
@@ -172,11 +203,13 @@ export const replacePassageText = ({
   passage,
   replaceText,
   searchText,
+  useRegex = false,
 }: {
   occurrenceIndex?: number;
   passage: Passage;
   replaceText: string;
   searchText: string;
+  useRegex?: boolean;
 }): PassageReplacementResult => {
   if (!searchText || occurrenceIndex === null) {
     return {
@@ -187,7 +220,8 @@ export const replacePassageText = ({
     };
   }
 
-  const matches = findLiteralOccurrences(passage.content, searchText);
+  const findOccurrences = useRegex ? findRegexOccurrences : findLiteralOccurrences;
+  const matches = findOccurrences(passage.content, searchText);
   const matchesToApply =
     occurrenceIndex === undefined
       ? matches

--- a/libs/lib-editing/src/lib/components/shared/SearchReplacePanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/SearchReplacePanel.tsx
@@ -40,7 +40,6 @@ export const SearchReplacePanel = ({
     canReplace &&
     !replaceDisabledReason &&
     !!searchContext.searchQuery &&
-    !!replaceQuery &&
     searchContext.passageOccurrences.length > 0 &&
     !replacing;
   const canStepBackward =
@@ -105,6 +104,7 @@ export const SearchReplacePanel = ({
             searchText: searchContext.searchQuery,
             replaceText: replaceQuery,
             targetUuids: chunk,
+            useRegex: searchContext.useRegex,
           });
 
           if (!response.success) {
@@ -133,6 +133,7 @@ export const SearchReplacePanel = ({
         targetUuids: [activeOccurrence.passageUuid],
         cursorPassageUuid: activeOccurrence.passageUuid,
         cursorStart: activeOccurrence.start,
+        useRegex: searchContext.useRegex,
       });
 
       if (!response.success) {
@@ -207,7 +208,9 @@ export const SearchReplacePanel = ({
             {replaceDisabledReason && <span>{replaceDisabledReason}</span>}
           </div>
           <div className="text-sm text-muted-foreground pb-4">
-            Replace is case sensitive and is only applied to passages.
+            {searchContext.useRegex
+              ? 'Regex replace is applied to passages only.'
+              : 'Replace is case sensitive and is only applied to passages.'}
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Button

--- a/libs/lib-search/src/lib/data/search.ts
+++ b/libs/lib-search/src/lib/data/search.ts
@@ -7,16 +7,19 @@ export const search = async ({
   text,
   uuid,
   toh,
+  useRegex = false,
 }: {
   text: string;
   uuid: string;
   toh: string;
+  useRegex?: boolean;
 }) => {
   const client = await createServerClient();
   const { data, error } = await client.rpc('translation_search', {
     search_term: text,
     work_uuid: uuid,
     toh: toh,
+    use_regex: useRegex,
   });
 
   if (error) {

--- a/libs/lib-search/src/lib/ui/SearchButton.tsx
+++ b/libs/lib-search/src/lib/ui/SearchButton.tsx
@@ -47,6 +47,7 @@ export interface SearchActionContext {
   scrollActiveOccurrenceIntoView: () => void;
   setActiveOccurrenceIndex: (index: number) => void;
   setShouldScrollActiveOccurrence: (shouldScroll: boolean) => void;
+  useRegex: boolean;
 }
 
 export interface SearchButtonProps {
@@ -85,6 +86,7 @@ export const SearchButton = ({
   const [searching, setSearching] = useState(false);
   const [hasResults, setHasResults] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [useRegex, setUseRegex] = useState(false);
   const [results, setResults] = useState<SearchResults>();
   const [activeOccurrenceIndex, setActiveOccurrenceIndexState] = useState(0);
   const [activeResultsTab, setActiveResultsTab] =
@@ -100,8 +102,9 @@ export const SearchButton = ({
       getPassageOccurrences(
         [...(results?.alignments || []), ...(results?.passages || [])],
         searchQuery,
+        useRegex,
       ),
-    [results?.alignments, results?.passages, searchQuery],
+    [results?.alignments, results?.passages, searchQuery, useRegex],
   );
   const activeOccurrence = passageOccurrences[activeOccurrenceIndex];
   const activeOccurrenceStart = activeOccurrence?.start ?? null;
@@ -144,6 +147,7 @@ export const SearchButton = ({
         text: searchQuery,
         uuid: workUuid,
         toh,
+        useRegex,
       });
       setHasResults(
         !!nextResults &&
@@ -160,7 +164,7 @@ export const SearchButton = ({
 
       setSearching(false);
     },
-    [searchQuery, toh, workUuid],
+    [searchQuery, toh, useRegex, workUuid],
   );
 
   const setActiveOccurrenceIndex = useCallback(
@@ -205,6 +209,7 @@ export const SearchButton = ({
   useEffect(() => {
     setResults(undefined);
     setSearchQuery('');
+    setUseRegex(false);
     setActiveOccurrenceIndexState(0);
     setShouldScrollActiveOccurrence(false);
     pendingOccurrenceSelectionRef.current = null;
@@ -331,6 +336,7 @@ export const SearchButton = ({
       scrollActiveOccurrenceIntoView,
       setActiveOccurrenceIndex,
       setShouldScrollActiveOccurrence,
+      useRegex,
     }),
     [
       activeOccurrence,
@@ -345,6 +351,7 @@ export const SearchButton = ({
       searchQuery,
       searching,
       setActiveOccurrenceIndex,
+      useRegex,
     ],
   );
 
@@ -379,21 +386,37 @@ export const SearchButton = ({
                 <XIcon className="size-3 my-auto" />
               </Button>
             </div>
-            <Input
-              autoFocus
-              placeholder="Type to search..."
-              value={searchQuery}
-              className="w-full text-foreground px-4 py-6"
-              onChange={(e) => {
-                const nextValue = e.target.value;
-                if (nextValue === searchQuery) {
-                  return;
-                }
-                setActiveOccurrenceIndexState(0);
-                pendingOccurrenceSelectionRef.current = null;
-                setSearchQuery(nextValue);
-              }}
-            />
+            <div className="relative flex items-center">
+              <Input
+                autoFocus
+                placeholder="Type to search..."
+                value={searchQuery}
+                className="w-full text-foreground px-4 py-6 pr-16"
+                onChange={(e) => {
+                  const nextValue = e.target.value;
+                  if (nextValue === searchQuery) {
+                    return;
+                  }
+                  setActiveOccurrenceIndexState(0);
+                  pendingOccurrenceSelectionRef.current = null;
+                  setSearchQuery(nextValue);
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                title={useRegex ? 'Regex mode on' : 'Regex mode off'}
+                className={`absolute right-2 font-mono text-xs px-2 h-7 ${useRegex ? 'bg-accent text-accent-foreground hover:bg-accent/80' : 'text-muted-foreground'}`}
+                onClick={() => {
+                  setUseRegex((prev) => !prev);
+                  setActiveOccurrenceIndexState(0);
+                  pendingOccurrenceSelectionRef.current = null;
+                }}
+              >
+                .*
+              </Button>
+            </div>
             {searchQuery && renderActions?.(actionContext)}
           </div>
           {searchQuery && (
@@ -433,6 +456,7 @@ export const SearchButton = ({
                             activePassageUuid={activePassageUuid}
                             query={searchQuery}
                             results={results[tab]}
+                            useRegex={useRegex}
                             onCardClick={onCardClick}
                           />
                         </TabsContent>

--- a/libs/lib-search/src/lib/ui/SearchButton.tsx
+++ b/libs/lib-search/src/lib/ui/SearchButton.tsx
@@ -96,6 +96,7 @@ export const SearchButton = ({
   const pendingOccurrenceSelectionRef = useRef<SearchPendingSelection | null>(
     null,
   );
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const passageOccurrences = useMemo(
     () =>
@@ -389,6 +390,7 @@ export const SearchButton = ({
             <div className="relative flex items-center">
               <Input
                 autoFocus
+                ref={searchInputRef}
                 placeholder="Type to search..."
                 value={searchQuery}
                 className="w-full text-foreground px-4 py-6 pr-16"
@@ -412,6 +414,7 @@ export const SearchButton = ({
                   setUseRegex((prev) => !prev);
                   setActiveOccurrenceIndexState(0);
                   pendingOccurrenceSelectionRef.current = null;
+                  searchInputRef.current?.focus();
                 }}
               >
                 .*

--- a/libs/lib-search/src/lib/ui/SearchResultCard.tsx
+++ b/libs/lib-search/src/lib/ui/SearchResultCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import { highlightText, removeDiacritics, removeHtmlTags, useIsMobile } from '@eightyfourthousand/lib-utils';
 import {
   AlignmentMatch,
@@ -10,17 +11,59 @@ import {
 } from '../types';
 import { Separator } from '@eightyfourthousand/design-system';
 
+const markClassName = (isActive: boolean) =>
+  isActive
+    ? 'bg-accent/20 text-foreground font-semibold ring-2 ring-accent ring-offset-1 ring-offset-background rounded-sm'
+    : 'bg-highlight text-foreground font-semibold';
+
 const renderPassageHighlight = ({
   activeOccurrenceStart,
   query,
   text,
+  useRegex,
 }: {
   activeOccurrenceStart?: number;
   query: string;
   text: string;
+  useRegex?: boolean;
 }) => {
   if (!query.trim()) {
     return text;
+  }
+
+  if (useRegex) {
+    let regex: RegExp;
+    try {
+      regex = new RegExp(query, 'gi');
+    } catch {
+      return text;
+    }
+
+    const nodes: React.ReactNode[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(text)) !== null) {
+      if (match[0].length === 0) {
+        regex.lastIndex++;
+        continue;
+      }
+      if (match.index > lastIndex) {
+        nodes.push(text.slice(lastIndex, match.index));
+      }
+      nodes.push(
+        <mark key={match.index} className={markClassName(match.index === activeOccurrenceStart)}>
+          {match[0]}
+        </mark>,
+      );
+      lastIndex = regex.lastIndex;
+    }
+
+    if (lastIndex < text.length) {
+      nodes.push(text.slice(lastIndex));
+    }
+
+    return nodes;
   }
 
   const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -39,14 +82,7 @@ const renderPassageHighlight = ({
     offset += part.length;
 
     return (
-      <mark
-        key={index}
-        className={
-          start === activeOccurrenceStart
-            ? 'bg-accent/20 text-foreground font-semibold ring-2 ring-accent ring-offset-1 ring-offset-background rounded-sm'
-            : 'bg-highlight text-foreground font-semibold'
-        }
-      >
+      <mark key={index} className={markClassName(start === activeOccurrenceStart)}>
         {part}
       </mark>
     );
@@ -57,10 +93,12 @@ export const PassageResult = ({
   activeOccurrenceStart,
   match,
   query,
+  useRegex,
 }: {
   activeOccurrenceStart?: number;
   match: PassageMatch;
   query: string;
+  useRegex?: boolean;
 }) => {
   return (
     <div>
@@ -68,6 +106,7 @@ export const PassageResult = ({
         activeOccurrenceStart,
         query,
         text: match.content,
+        useRegex,
       })}
     </div>
   );
@@ -77,10 +116,12 @@ export const AlignmentResult = ({
   activeOccurrenceStart,
   match,
   query,
+  useRegex,
 }: {
   activeOccurrenceStart?: number;
   match: AlignmentMatch;
   query: string;
+  useRegex?: boolean;
 }) => {
   return (
     <div className="grid md:grid-cols-2 gap-4">
@@ -89,6 +130,7 @@ export const AlignmentResult = ({
           activeOccurrenceStart,
           query,
           text: match.content,
+          useRegex,
         })}
       </div>
       <div className="text-lg">{highlightText(match.source, query)}</div>
@@ -134,12 +176,14 @@ export const SearchResultCard = ({
   activeOccurrenceStart,
   match,
   query,
+  useRegex,
   onClick,
 }: {
   isActive?: boolean;
   activeOccurrenceStart?: number;
   match: SearchResult;
   query: string;
+  useRegex?: boolean;
   onClick: () => void;
 }) => {
   const isMobile = useIsMobile();
@@ -155,6 +199,7 @@ export const SearchResultCard = ({
             activeOccurrenceStart={isActive ? activeOccurrenceStart : undefined}
             match={match as PassageMatch}
             query={query}
+            useRegex={useRegex}
           />
         );
       case 'alignment':
@@ -163,6 +208,7 @@ export const SearchResultCard = ({
             activeOccurrenceStart={isActive ? activeOccurrenceStart : undefined}
             match={match as AlignmentMatch}
             query={query}
+            useRegex={useRegex}
           />
         );
       case 'bibliography':

--- a/libs/lib-search/src/lib/ui/SearchResultsList.tsx
+++ b/libs/lib-search/src/lib/ui/SearchResultsList.tsx
@@ -6,12 +6,14 @@ export const SearchResultsList = ({
   activePassageUuid,
   query,
   results,
+  useRegex,
   onCardClick,
 }: {
   activeOccurrenceStart?: number;
   activePassageUuid?: string;
   query: string;
   results: SearchResult[];
+  useRegex?: boolean;
   onCardClick: (result: SearchResult) => void;
 }) => {
   return (
@@ -26,6 +28,7 @@ export const SearchResultsList = ({
             isActive={isActive}
             match={result}
             query={query}
+            useRegex={useRegex}
             onClick={() => onCardClick(result)}
           />
         )


### PR DESCRIPTION
### Summary

The `translation_search` rpc function on Supabase has been updated to perform regex search when the `use_regex` flag is passed in. In addition, it will also search against `passages` table content for English when searching alignments since the materialized view may be out of date.

In the reader and editor, there is now an option to enable regex search in the UI. When selected it will pass a true value for `use_regex` for search and similarly use the regex for to replace instances of matches.

### Linear

- [DEV-599](https://linear.app/84000/issue/DEV-599)
