### PR TITLE
Use Glossary UUIDs

### DIFF
--- a/apps/api-graphql/src/graphql/schema/glossary/glossary.graphql
+++ b/apps/api-graphql/src/graphql/schema/glossary/glossary.graphql
@@ -172,7 +172,7 @@ extend type Work {
   """
   glossaryTerms(
     """
-    Cursor for pagination (glossary term authority UUID)
+    Cursor for pagination (glossary term UUID)
     """
     cursor: String
 

--- a/libs/data-access/src/lib/glossary/pagination.spec.ts
+++ b/libs/data-access/src/lib/glossary/pagination.spec.ts
@@ -1,0 +1,216 @@
+import {
+  getWorkGlossaryTermsPage,
+  type GlossaryTermIndexRow,
+} from './pagination';
+
+type QueryResult = {
+  data?: unknown[];
+  count?: number | null;
+  error: null;
+};
+
+type FakeGlossaryTermIndexRow = GlossaryTermIndexRow & {
+  work_uuid: string;
+};
+
+class FakeGlossaryQuery {
+  private selectColumns = '';
+  private filters: Array<{ column: string; value: unknown }> = [];
+  private greaterThan?: number;
+  private lessThan?: number;
+  private ascending = true;
+  private limitValue?: number;
+  private head = false;
+
+  constructor(
+    private readonly rows: FakeGlossaryTermIndexRow[],
+    private readonly queries: FakeGlossaryQuery[],
+  ) {
+    this.queries.push(this);
+  }
+
+  select(columns: string, options?: { count?: string; head?: boolean }) {
+    this.selectColumns = columns;
+    this.head = options?.head ?? false;
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    this.filters.push({ column, value });
+    return this;
+  }
+
+  gt(_column: string, value: number) {
+    this.greaterThan = value;
+    return this;
+  }
+
+  lt(_column: string, value: number) {
+    this.lessThan = value;
+    return this;
+  }
+
+  gte(_column: string, value: number) {
+    this.greaterThan = value - 1;
+    return this;
+  }
+
+  lte(_column: string, value: number) {
+    this.lessThan = value + 1;
+    return this;
+  }
+
+  order(_column: string, options: { ascending: boolean }) {
+    this.ascending = options.ascending;
+    return this;
+  }
+
+  limit(value: number) {
+    this.limitValue = value;
+    return this;
+  }
+
+  then<TResult1 = QueryResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: QueryResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ) {
+    return Promise.resolve(this.execute()).then(onfulfilled, onrejected);
+  }
+
+  hasFilter(column: string, value: unknown) {
+    return this.filters.some(
+      (filter) => filter.column === column && filter.value === value,
+    );
+  }
+
+  private execute(): QueryResult {
+    const workUuid = this.filters.find(
+      (filter) => filter.column === 'work_uuid',
+    )?.value;
+    let data = this.rows.filter((row) => row.work_uuid === workUuid);
+
+    for (const filter of this.filters) {
+      if (filter.column === 'work_uuid') continue;
+      data = data.filter(
+        (row) =>
+          row[filter.column as keyof FakeGlossaryTermIndexRow] === filter.value,
+      );
+    }
+
+    if (this.greaterThan !== undefined) {
+      data = data.filter((row) => Number(row.term_number) > this.greaterThan!);
+    }
+
+    if (this.lessThan !== undefined) {
+      data = data.filter((row) => Number(row.term_number) < this.lessThan!);
+    }
+
+    data = [...data].sort((a, b) => {
+      const delta = Number(a.term_number) - Number(b.term_number);
+      return this.ascending ? delta : -delta;
+    });
+
+    if (this.limitValue !== undefined) {
+      data = data.slice(0, this.limitValue);
+    }
+
+    return this.head
+      ? { count: data.length, error: null }
+      : { data: this.projectRows(data), error: null };
+  }
+
+  private projectRows(data: FakeGlossaryTermIndexRow[]) {
+    if (!this.selectColumns.includes('term_number')) {
+      return data;
+    }
+
+    if (
+      this.selectColumns.includes('glossary_uuid') &&
+      !this.selectColumns.includes('definition')
+    ) {
+      return data.map(({ glossary_uuid, term_number }) => ({
+        glossary_uuid,
+        term_number,
+      }));
+    }
+
+    return data;
+  }
+}
+
+const createRow = ({
+  glossaryUuid,
+  authorityUuid,
+  termNumber,
+}: {
+  glossaryUuid: string;
+  authorityUuid: string;
+  termNumber: number;
+}): FakeGlossaryTermIndexRow => ({
+  glossary_uuid: glossaryUuid,
+  authority_uuid: authorityUuid,
+  term_number: termNumber,
+  definition: null,
+  english: `Term ${termNumber}`,
+  wylie: null,
+  tibetan: null,
+  sanskrit_plain: null,
+  sanskrit_attested: null,
+  chinese: null,
+  pali: null,
+  alternatives: null,
+  work_uuid: 'work-1',
+}) as FakeGlossaryTermIndexRow;
+
+const createClient = (rows: FakeGlossaryTermIndexRow[]) => {
+  const queries: FakeGlossaryQuery[] = [];
+  return {
+    queries,
+    client: {
+      from: () => new FakeGlossaryQuery(rows, queries),
+    } as never,
+  };
+};
+
+describe('getWorkGlossaryTermsPage', () => {
+  it('uses glossary UUIDs for forward pagination cursors', async () => {
+    const { client, queries } = createClient([
+      createRow({
+        glossaryUuid: 'glossary-1',
+        authorityUuid: 'authority-a',
+        termNumber: 1,
+      }),
+      createRow({
+        glossaryUuid: 'glossary-2',
+        authorityUuid: 'authority-a',
+        termNumber: 2,
+      }),
+      createRow({
+        glossaryUuid: 'glossary-3',
+        authorityUuid: 'authority-b',
+        termNumber: 3,
+      }),
+    ]);
+
+    const result = await getWorkGlossaryTermsPage({
+      client,
+      workUuid: 'work-1',
+      cursor: 'glossary-1',
+      limit: 1,
+      direction: 'FORWARD',
+      withAttestations: false,
+    });
+
+    expect(
+      queries.some((query) => query.hasFilter('glossary_uuid', 'glossary-1')),
+    ).toBe(true);
+    expect(
+      queries.some((query) => query.hasFilter('authority_uuid', 'glossary-1')),
+    ).toBe(false);
+    expect(result.nodes.map((node) => node.uuid)).toEqual(['glossary-2']);
+    expect(result.pageInfo.nextCursor).toBe('glossary-2');
+    expect(result.pageInfo.prevCursor).toBe('glossary-2');
+  });
+});

--- a/libs/data-access/src/lib/glossary/pagination.ts
+++ b/libs/data-access/src/lib/glossary/pagination.ts
@@ -218,14 +218,14 @@ export const getWorkGlossaryTermsPage = async ({
   ] = await Promise.all([
     client
       .from('glossary_term_index')
-      .select('authority_uuid', { count: 'exact', head: true })
+      .select('glossary_uuid', { count: 'exact', head: true })
       .eq('work_uuid', workUuid),
     cursor
       ? client
           .from('glossary_term_index')
-          .select('authority_uuid, term_number')
+          .select('glossary_uuid, term_number')
           .eq('work_uuid', workUuid)
-          .eq('authority_uuid', cursor)
+          .eq('glossary_uuid', cursor)
           .limit(1)
       : Promise.resolve({ data: [], error: null }),
   ]);
@@ -247,7 +247,7 @@ export const getWorkGlossaryTermsPage = async ({
 
   const cursorRow = cursor
     ? ((cursorRows ?? [])[0] as
-        | { authority_uuid: string; term_number: number | string }
+        | { glossary_uuid: string; term_number: number | string }
         | undefined)
     : undefined;
 
@@ -329,8 +329,8 @@ export const getWorkGlossaryTermsPage = async ({
 
   return buildGlossaryTermConnection(
     nodes,
-    hasMoreAfter ? lastRow.authority_uuid : null,
-    hasMoreBefore ? firstRow.authority_uuid : null,
+    hasMoreAfter ? lastRow.glossary_uuid : null,
+    hasMoreBefore ? firstRow.glossary_uuid : null,
     hasMoreAfter,
     hasMoreBefore,
     totalCount,
@@ -367,13 +367,13 @@ export const getWorkGlossaryTermsAround = async ({
   ] = await Promise.all([
     client
       .from('glossary_term_index')
-      .select('authority_uuid', { count: 'exact', head: true })
+      .select('glossary_uuid', { count: 'exact', head: true })
       .eq('work_uuid', workUuid),
     client
       .from('glossary_term_index')
-      .select('authority_uuid, term_number')
+      .select('glossary_uuid, term_number')
       .eq('work_uuid', workUuid)
-      .eq('authority_uuid', cursor)
+      .eq('glossary_uuid', cursor)
       .limit(1),
   ]);
 
@@ -396,7 +396,7 @@ export const getWorkGlossaryTermsAround = async ({
 
   const totalCount = count ?? 0;
   const cursorRow = (cursorRows ?? [])[0] as
-    | { authority_uuid: string; term_number: number | string }
+    | { glossary_uuid: string; term_number: number | string }
     | undefined;
 
   if (!cursorRow) {
@@ -462,8 +462,8 @@ export const getWorkGlossaryTermsAround = async ({
 
   return buildGlossaryTermConnection(
     nodes,
-    hasMoreAfter && lastRow ? lastRow.authority_uuid : null,
-    hasMoreBefore && firstRow ? firstRow.authority_uuid : null,
+    hasMoreAfter && lastRow ? lastRow.glossary_uuid : null,
+    hasMoreBefore && firstRow ? firstRow.glossary_uuid : null,
     hasMoreAfter,
     hasMoreBefore,
     totalCount,

--- a/libs/data-access/src/lib/lookup-entity.spec.ts
+++ b/libs/data-access/src/lib/lookup-entity.spec.ts
@@ -1,0 +1,55 @@
+import { lookupEntity } from './lookup-entity';
+import { getGlossaryInstance } from './glossary';
+
+jest.mock('./client-ssr', () => ({
+  createServerClient: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('./bibliography', () => ({
+  getBibliographyEntry: jest.fn(),
+}));
+
+jest.mock('./passage', () => ({
+  getPassage: jest.fn(),
+  getPassageUuidByXmlId: jest.fn(),
+}));
+
+jest.mock('./publications', () => ({
+  getTranslationMetadataByToh: jest.fn(),
+  getTranslationMetadataByUuid: jest.fn(),
+}));
+
+jest.mock('./glossary', () => ({
+  getGlossaryInstance: jest.fn(),
+}));
+
+const mockedGetGlossaryInstance = jest.mocked(getGlossaryInstance);
+
+describe('lookupEntity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes glossary entities using the glossary UUID in the panel hash', async () => {
+    mockedGetGlossaryInstance.mockResolvedValue({
+      uuid: 'glossary-uuid',
+      authority: 'authority-uuid',
+      workUuid: 'work-uuid',
+      definition: null,
+      termNumber: 1,
+      names: {},
+    });
+
+    await expect(
+      lookupEntity({
+        type: 'glossary',
+        entity: 'glossary-uuid',
+      }),
+    ).resolves.toBe('/work-uuid?right=open%3Aglossary%3Aglossary-uuid');
+
+    expect(mockedGetGlossaryInstance).toHaveBeenCalledWith({
+      client: {},
+      uuid: 'glossary-uuid',
+    });
+  });
+});

--- a/libs/data-access/src/lib/lookup-entity.ts
+++ b/libs/data-access/src/lib/lookup-entity.ts
@@ -45,11 +45,11 @@ export const lookupEntity = async ({
     case 'glossary':
       {
         const item = await getGlossaryInstance({ client, uuid: entity });
-        if (!item?.workUuid || !item.authority) {
+        if (!item?.workUuid || !item.uuid) {
           return;
         }
 
-        query.set('right', `open:glossary:${item.authority}`);
+        query.set('right', `open:glossary:${item.uuid}`);
         path = `${prefix}/${item.workUuid}?${query.toString()}`;
       }
       break;

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ts
@@ -107,13 +107,13 @@ export const GlossaryInstanceNode = Mark.create<GlossaryInstanceOptions>({
       }
 
       dom.addEventListener('click', () => {
-        const { authority } = props.mark.attrs;
-        if (!authority) {
+        const { glossary } = props.mark.attrs;
+        if (!glossary) {
           return;
         }
 
         const query = new URLSearchParams(window.location.search);
-        query.set('right', `open:glossary:${authority}`);
+        query.set('right', `open:glossary:${glossary}`);
         window.history.pushState({}, '', `?${query.toString()}`);
       });
 

--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryTermList.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryTermList.tsx
@@ -44,9 +44,9 @@ export const GlossaryTermList = ({
         )}
         {terms.map((instance, index) => (
           <LabeledElement
-            id={instance.authority || instance.uuid || `glossary-${index}`}
+            id={instance.uuid || instance.authority || `glossary-${index}`}
             uuid={instance.uuid}
-            key={instance.authority || instance.uuid || `glossary-${index}`}
+            key={instance.uuid || instance.authority || `glossary-${index}`}
             label={`g.${instance.termNumber}`}
             excerpt={instance.names.english}
             contentType="glossary"

--- a/libs/lib-search/jest.config.ts
+++ b/libs/lib-search/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'lib-search',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/lib-search',
+};

--- a/libs/lib-search/project.json
+++ b/libs/lib-search/project.json
@@ -15,6 +15,14 @@
         "rootDir": "libs/lib-search/src",
         "generateExportsField": false
       }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/lib-search/jest.config.ts",
+        "passWithNoTests": true
+      }
     }
   }
 }

--- a/libs/lib-search/src/lib/types/search.spec.ts
+++ b/libs/lib-search/src/lib/types/search.spec.ts
@@ -1,0 +1,21 @@
+import { glossaryMatchFromDTO } from './search';
+
+describe('glossaryMatchFromDTO', () => {
+  it('uses glossary UUID as the searchable result identity', () => {
+    const result = glossaryMatchFromDTO({
+      authority_uuid: 'authority-uuid',
+      glossary_uuid: 'glossary-uuid',
+      content: 'Buddha',
+      entry: {
+        uuid: 'glossary-uuid',
+        authority_uuid: 'authority-uuid',
+        work_uuid: 'work-uuid',
+        definition: 'Definition',
+        names: {},
+      },
+    });
+
+    expect(result.uuid).toBe('glossary-uuid');
+    expect(result.entry.authority).toBe('authority-uuid');
+  });
+});

--- a/libs/lib-search/src/lib/types/search.ts
+++ b/libs/lib-search/src/lib/types/search.ts
@@ -1,4 +1,8 @@
-import { GlossaryTermInstance, GlossaryTermInstanceDTO, glossaryTermInstanceFromDTO } from "@eightyfourthousand/data-access";
+import {
+  GlossaryTermInstance,
+  GlossaryTermInstanceDTO,
+  glossaryTermInstanceFromDTO,
+} from '@eightyfourthousand/data-access';
 
 export const RESULTS_ENTITIES = [
   'alignments',
@@ -110,7 +114,7 @@ export const glossaryMatchFromDTO = (
 ): GlossaryMatch => {
   return {
     type: 'glossary',
-    uuid: dto.authority_uuid,
+    uuid: dto.glossary_uuid,
     content: dto.content,
     entry: glossaryTermInstanceFromDTO(dto.entry),
   };


### PR DESCRIPTION
### Summary

Switches back to using glossary uuids for internal navigation, instead of authority uuids. This is a prerequisite for reworking how the glossary term index is generated, with the goal of eventually supporting multiple glossary entries for an authority.

There should be no change in functionality after deploying.

### Linear

- [DEV-624](https://linear.app/84000/issue/DEV-624)