### PR TITLE
MCP read tools

### DIFF
--- a/apps/web-main/src/app/api/mcp/route.ts
+++ b/apps/web-main/src/app/api/mcp/route.ts
@@ -1,3 +1,16 @@
-import { createMcpHandler } from '@eightyfourthousand/lib-agent';
+import { createMcpHandler, createReadTools } from '@eightyfourthousand/lib-agent';
+import { createServerClient } from '@eightyfourthousand/data-access/ssr';
 
-export const { GET, POST, DELETE } = createMcpHandler({ tools: [] });
+export async function GET() {
+  return new Response('Method not allowed', { status: 405 });
+}
+
+export async function POST(req: Request) {
+  const client = await createServerClient();
+  const { POST } = createMcpHandler({ tools: createReadTools(client) });
+  return POST(req);
+}
+
+export async function DELETE() {
+  return new Response('Method not allowed', { status: 405 });
+}

--- a/apps/web-reader/src/app/api/mcp/route.ts
+++ b/apps/web-reader/src/app/api/mcp/route.ts
@@ -1,3 +1,16 @@
-import { createMcpHandler } from '@eightyfourthousand/lib-agent';
+import { createMcpHandler, createReadTools } from '@eightyfourthousand/lib-agent';
+import { createServerClient } from '@eightyfourthousand/data-access/ssr';
 
-export const { GET, POST, DELETE } = createMcpHandler({ tools: [] });
+export async function GET() {
+  return new Response('Method not allowed', { status: 405 });
+}
+
+export async function POST(req: Request) {
+  const client = await createServerClient();
+  const { POST } = createMcpHandler({ tools: createReadTools(client) });
+  return POST(req);
+}
+
+export async function DELETE() {
+  return new Response('Method not allowed', { status: 405 });
+}

--- a/libs/data-access/src/lib/lookup-entity.ts
+++ b/libs/data-access/src/lib/lookup-entity.ts
@@ -7,8 +7,15 @@ import {
 } from './publications';
 import { panelAndTabForContentType } from './panel-url';
 import { getGlossaryInstance } from './glossary';
+import { DataClient } from './types';
 
-const ALLOWED_TYPES = ['bibliography', 'glossary', 'passage', 'translation', 'work'];
+const ALLOWED_TYPES = [
+  'bibliography',
+  'glossary',
+  'passage',
+  'translation',
+  'work',
+];
 
 export const lookupEntity = async ({
   type,
@@ -27,6 +34,31 @@ export const lookupEntity = async ({
     return;
   }
   const client = await createServerClient();
+  return await lookupEntityWithClient({
+    client,
+    type,
+    entity,
+    prefix,
+    xmlId,
+    searchParams,
+  });
+};
+
+export const lookupEntityWithClient = async ({
+  client,
+  type,
+  entity,
+  prefix = '',
+  xmlId,
+  searchParams,
+}: {
+  client: DataClient;
+  type: string;
+  entity: string;
+  prefix?: string;
+  xmlId?: string;
+  searchParams?: URLSearchParams;
+}) => {
   let path = '';
   const query = searchParams || new URLSearchParams();
 

--- a/libs/lib-agent/project.json
+++ b/libs/lib-agent/project.json
@@ -5,6 +5,13 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/lib-agent/jest.config.ts"
+      }
+    },
     "build": {
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],

--- a/libs/lib-agent/src/index.ts
+++ b/libs/lib-agent/src/index.ts
@@ -1,2 +1,3 @@
 export { createMcpHandler } from './lib/server';
 export type { McpToolDefinition, McpHandlerOptions } from './lib/types';
+export { createReadTools } from './lib/tools/read';

--- a/libs/lib-agent/src/lib/tools/read/get-bibliography-entry.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-bibliography-entry.spec.ts
@@ -1,0 +1,35 @@
+import { createGetBibliographyEntryTool } from './get-bibliography-entry';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getBibliographyEntry: jest.fn(),
+}));
+
+import { getBibliographyEntry } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(getBibliographyEntry);
+
+describe('get-bibliography-entry tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetBibliographyEntryTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns entry data', async () => {
+    const entry = { uuid: 'b1', html: '<p>ref</p>' };
+    mocked.mockResolvedValue(entry as any);
+
+    const result = await tool.handler({ uuid: 'b1' }, extra);
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(entry, null, 2),
+    });
+  });
+
+  it('returns error when not found', async () => {
+    mocked.mockResolvedValue(null);
+
+    const result = await tool.handler({ uuid: 'missing' }, extra);
+    expect(result.isError).toBe(true);
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-bibliography-entry.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-bibliography-entry.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getBibliographyEntry } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The UUID of the bibliography entry'),
+};
+
+export function createGetBibliographyEntryTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'get-bibliography-entry',
+    description: 'Retrieve a single bibliography entry by UUID.',
+    inputSchema,
+    annotations: {
+      title: 'Get Bibliography Entry',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ uuid }) => {
+      const entry = await getBibliographyEntry({ client, uuid });
+      if (!entry) {
+        return errorResult(`No bibliography entry found for UUID: ${uuid}`);
+      }
+      return jsonResult(entry);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-bibliography-entry.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-bibliography-entry.ts
@@ -5,7 +5,7 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult, errorResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The UUID of the bibliography entry'),
+  uuid: z.uuid().describe('The UUID of the bibliography entry'),
 };
 
 export function createGetBibliographyEntryTool(

--- a/libs/lib-agent/src/lib/tools/read/get-glossary-instances.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-glossary-instances.spec.ts
@@ -1,0 +1,33 @@
+import { createGetGlossaryInstancesTool } from './get-glossary-instances';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getGlossaryInstances: jest.fn(),
+}));
+
+import { getGlossaryInstances } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(getGlossaryInstances);
+
+describe('get-glossary-instances tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetGlossaryInstancesTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('get-glossary-instances');
+  });
+
+  it('passes uuid and withAttestations', async () => {
+    mocked.mockResolvedValue([]);
+
+    await tool.handler({ uuid: 'w1', withAttestations: true }, extra);
+
+    expect(mocked).toHaveBeenCalledWith({
+      client,
+      uuid: 'w1',
+      withAttestations: true,
+    });
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-glossary-instances.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-glossary-instances.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getGlossaryInstances } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The work UUID'),
+  withAttestations: z
+    .boolean()
+    .optional()
+    .describe('Include Sanskrit attestation variants'),
+};
+
+export function createGetGlossaryInstancesTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'get-glossary-instances',
+    description:
+      'Get all glossary term instances for a work, sorted alphabetically by English name.',
+    inputSchema,
+    annotations: {
+      title: 'Get Glossary Instances',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ uuid, withAttestations }) => {
+      const instances = await getGlossaryInstances({
+        client,
+        uuid,
+        withAttestations,
+      });
+      return jsonResult(instances);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-glossary-instances.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-glossary-instances.ts
@@ -5,7 +5,7 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The work UUID'),
+  uuid: z.uuid().describe('The work UUID'),
   withAttestations: z
     .boolean()
     .optional()

--- a/libs/lib-agent/src/lib/tools/read/get-glossary-term.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-glossary-term.spec.ts
@@ -1,0 +1,42 @@
+import { createGetGlossaryTermTool } from './get-glossary-term';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getGlossaryInstance: jest.fn(),
+}));
+
+import { getGlossaryInstance } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(getGlossaryInstance);
+
+describe('get-glossary-term tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetGlossaryTermTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('get-glossary-term');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('returns glossary term data', async () => {
+    const term = { uuid: 'g1', names: { english: 'Buddha' } };
+    mocked.mockResolvedValue(term as any);
+
+    const result = await tool.handler({ uuid: 'g1' }, extra);
+
+    expect(mocked).toHaveBeenCalledWith({ client, uuid: 'g1' });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(term, null, 2),
+    });
+  });
+
+  it('returns error when not found', async () => {
+    mocked.mockResolvedValue(undefined);
+
+    const result = await tool.handler({ uuid: 'missing' }, extra);
+    expect(result.isError).toBe(true);
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-glossary-term.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-glossary-term.ts
@@ -5,7 +5,7 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult, errorResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The UUID of the glossary term'),
+  uuid: z.uuid().describe('The UUID of the glossary term'),
 };
 
 export function createGetGlossaryTermTool(

--- a/libs/lib-agent/src/lib/tools/read/get-glossary-term.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-glossary-term.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getGlossaryInstance } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The UUID of the glossary term'),
+};
+
+export function createGetGlossaryTermTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'get-glossary-term',
+    description:
+      'Retrieve a single glossary term by UUID, including names in all languages, definition, and attestations.',
+    inputSchema,
+    annotations: {
+      title: 'Get Glossary Term',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ uuid }) => {
+      const term = await getGlossaryInstance({ client, uuid });
+      if (!term) {
+        return errorResult(`No glossary term found for UUID: ${uuid}`);
+      }
+      return jsonResult(term);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-imprint.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-imprint.spec.ts
@@ -1,0 +1,37 @@
+import { createGetImprintTool } from './get-imprint';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getTranslationImprint: jest.fn(),
+}));
+
+import { getTranslationImprint } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(getTranslationImprint);
+
+describe('get-imprint tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetImprintTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns imprint data', async () => {
+    const imprint = { title: 'Test', license: 'CC' };
+    mocked.mockResolvedValue(imprint as any);
+
+    const result = await tool.handler({ uuid: 'w1', toh: '1' }, extra);
+
+    expect(mocked).toHaveBeenCalledWith({ client, uuid: 'w1', toh: '1' });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(imprint, null, 2),
+    });
+  });
+
+  it('returns error when not found', async () => {
+    mocked.mockResolvedValue(undefined);
+
+    const result = await tool.handler({ uuid: 'w1', toh: '999' }, extra);
+    expect(result.isError).toBe(true);
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-imprint.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-imprint.ts
@@ -5,8 +5,8 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult, errorResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The work UUID'),
-  toh: z.string().describe('Tohoku catalog number (e.g. "1", "123")'),
+  uuid: z.uuid().describe('The work UUID'),
+  toh: z.string().describe('Tohoku catalog number (e.g. "toh1", "toh123")'),
 };
 
 export function createGetImprintTool(client: DataClient): McpToolDefinition {
@@ -23,7 +23,7 @@ export function createGetImprintTool(client: DataClient): McpToolDefinition {
     handler: async ({ uuid, toh }) => {
       const imprint = await getTranslationImprint({ client, uuid, toh });
       if (!imprint) {
-        return errorResult(`No imprint found for work ${uuid}, toh ${toh}`);
+        return errorResult(`No imprint found for work ${uuid}, ${toh}`);
       }
       return jsonResult(imprint);
     },

--- a/libs/lib-agent/src/lib/tools/read/get-imprint.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-imprint.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getTranslationImprint } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The work UUID'),
+  toh: z.string().describe('Tohoku catalog number (e.g. "1", "123")'),
+};
+
+export function createGetImprintTool(client: DataClient): McpToolDefinition {
+  return {
+    name: 'get-imprint',
+    description:
+      'Get the imprint (publication metadata, license, contributors) for a translation.',
+    inputSchema,
+    annotations: {
+      title: 'Get Imprint',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ uuid, toh }) => {
+      const imprint = await getTranslationImprint({ client, uuid, toh });
+      if (!imprint) {
+        return errorResult(`No imprint found for work ${uuid}, toh ${toh}`);
+      }
+      return jsonResult(imprint);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-passage.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-passage.spec.ts
@@ -1,0 +1,44 @@
+import { createGetPassageTool } from './get-passage';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getPassage: jest.fn(),
+}));
+
+import { getPassage } from '@eightyfourthousand/data-access';
+const mockedGetPassage = jest.mocked(getPassage);
+
+describe('get-passage tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetPassageTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('get-passage');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('returns passage data as JSON', async () => {
+    const passage = { uuid: 'abc', content: 'Hello', label: '1.1' };
+    mockedGetPassage.mockResolvedValue(passage as any);
+
+    const result = await tool.handler({ uuid: 'abc' }, extra);
+
+    expect(mockedGetPassage).toHaveBeenCalledWith({ client, uuid: 'abc' });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(passage, null, 2),
+    });
+  });
+
+  it('returns error when passage not found', async () => {
+    mockedGetPassage.mockResolvedValue(undefined);
+
+    const result = await tool.handler({ uuid: 'missing' }, extra);
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('missing');
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-passage.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-passage.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getPassage } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The UUID of the passage'),
+};
+
+export function createGetPassageTool(client: DataClient): McpToolDefinition {
+  return {
+    name: 'get-passage',
+    description:
+      'Retrieve a single passage by UUID, including its content, annotations, and metadata.',
+    inputSchema,
+    annotations: { title: 'Get Passage', readOnlyHint: true, openWorldHint: false },
+    handler: async ({ uuid }) => {
+      const passage = await getPassage({ client, uuid });
+      if (!passage) {
+        return errorResult(`No passage found for UUID: ${uuid}`);
+      }
+      return jsonResult(passage);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-passage.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-passage.ts
@@ -5,7 +5,7 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult, errorResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The UUID of the passage'),
+  uuid: z.uuid().describe('The UUID of the passage'),
 };
 
 export function createGetPassageTool(client: DataClient): McpToolDefinition {
@@ -14,7 +14,11 @@ export function createGetPassageTool(client: DataClient): McpToolDefinition {
     description:
       'Retrieve a single passage by UUID, including its content, annotations, and metadata.',
     inputSchema,
-    annotations: { title: 'Get Passage', readOnlyHint: true, openWorldHint: false },
+    annotations: {
+      title: 'Get Passage',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     handler: async ({ uuid }) => {
       const passage = await getPassage({ client, uuid });
       if (!passage) {

--- a/libs/lib-agent/src/lib/tools/read/get-toc.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-toc.spec.ts
@@ -1,0 +1,37 @@
+import { createGetTocTool } from './get-toc';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getTranslationToc: jest.fn(),
+}));
+
+import { getTranslationToc } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(getTranslationToc);
+
+describe('get-toc tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetTocTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns TOC data', async () => {
+    const toc = { frontMatter: [], body: [], backMatter: [] };
+    mocked.mockResolvedValue(toc as any);
+
+    const result = await tool.handler({ uuid: 'w1' }, extra);
+
+    expect(mocked).toHaveBeenCalledWith({ client, uuid: 'w1' });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(toc, null, 2),
+    });
+  });
+
+  it('returns error when not found', async () => {
+    mocked.mockResolvedValue(undefined);
+
+    const result = await tool.handler({ uuid: 'missing' }, extra);
+    expect(result.isError).toBe(true);
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-toc.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-toc.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getTranslationToc } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The work UUID'),
+};
+
+export function createGetTocTool(client: DataClient): McpToolDefinition {
+  return {
+    name: 'get-toc',
+    description:
+      'Get the table of contents for a translation, organized into front matter, body, and back matter.',
+    inputSchema,
+    annotations: {
+      title: 'Get Table of Contents',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ uuid }) => {
+      const toc = await getTranslationToc({ client, uuid });
+      if (!toc) {
+        return errorResult(`No table of contents found for work: ${uuid}`);
+      }
+      return jsonResult(toc);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-toc.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-toc.ts
@@ -5,7 +5,7 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult, errorResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The work UUID'),
+  uuid: z.uuid().describe('The work UUID'),
 };
 
 export function createGetTocTool(client: DataClient): McpToolDefinition {

--- a/libs/lib-agent/src/lib/tools/read/get-translation-passages.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation-passages.spec.ts
@@ -1,0 +1,82 @@
+import { createGetTranslationPassagesTool } from './get-translation-passages';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getTranslationPassages: jest.fn(),
+  getTranslationPassagesAround: jest.fn(),
+}));
+
+import {
+  getTranslationPassages,
+  getTranslationPassagesAround,
+} from '@eightyfourthousand/data-access';
+
+const mockedSequential = jest.mocked(getTranslationPassages);
+const mockedAround = jest.mocked(getTranslationPassagesAround);
+
+describe('get-translation-passages tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetTranslationPassagesTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+  const page = { passages: [], hasMoreAfter: false, hasMoreBefore: false };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('get-translation-passages');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('uses sequential pagination by default', async () => {
+    mockedSequential.mockResolvedValue(page as any);
+
+    await tool.handler({ uuid: 'work-1' }, extra);
+
+    expect(mockedSequential).toHaveBeenCalledWith({
+      client,
+      uuid: 'work-1',
+      type: undefined,
+      cursor: undefined,
+      maxPassages: undefined,
+      maxCharacters: undefined,
+      direction: undefined,
+    });
+    expect(mockedAround).not.toHaveBeenCalled();
+  });
+
+  it('uses around pagination when passageUuid is provided', async () => {
+    mockedAround.mockResolvedValue(page as any);
+
+    await tool.handler(
+      { uuid: 'work-1', passageUuid: 'passage-1' },
+      extra,
+    );
+
+    expect(mockedAround).toHaveBeenCalledWith({
+      client,
+      uuid: 'work-1',
+      passageUuid: 'passage-1',
+      type: undefined,
+      maxPassages: undefined,
+      maxCharacters: undefined,
+    });
+    expect(mockedSequential).not.toHaveBeenCalled();
+  });
+
+  it('passes direction and cursor for sequential pagination', async () => {
+    mockedSequential.mockResolvedValue(page as any);
+
+    await tool.handler(
+      { uuid: 'work-1', cursor: 'c1', direction: 'backward', maxPassages: 10 },
+      extra,
+    );
+
+    expect(mockedSequential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursor: 'c1',
+        direction: 'backward',
+        maxPassages: 10,
+      }),
+    );
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-translation-passages.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation-passages.ts
@@ -8,20 +8,23 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The work UUID'),
+  uuid: z.uuid().describe('The work UUID'),
   type: z
     .string()
     .optional()
-    .describe('Passage type filter (e.g. "translation", "introduction")'),
+    .describe(
+      'Passage type filter (e.g. "translation", "introduction", "(translation|introduction)")',
+    ),
   cursor: z
     .string()
     .optional()
     .describe('Pagination cursor for sequential browsing'),
   passageUuid: z
     .string()
-    .uuid()
     .optional()
-    .describe('Center results around this passage UUID instead of paginating sequentially'),
+    .describe(
+      'Center results around this passage UUID instead of paginating sequentially',
+    ),
   maxPassages: z
     .number()
     .int()
@@ -33,7 +36,9 @@ const inputSchema = {
     .int()
     .positive()
     .optional()
-    .describe('Character budget — stop returning passages once this limit is reached'),
+    .describe(
+      'Character budget — stop returning passages once this limit is reached. Passage can vary widely in length.',
+    ),
   direction: z
     .enum(['forward', 'backward'])
     .optional()

--- a/libs/lib-agent/src/lib/tools/read/get-translation-passages.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation-passages.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import {
+  getTranslationPassages,
+  getTranslationPassagesAround,
+} from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The work UUID'),
+  type: z
+    .string()
+    .optional()
+    .describe('Passage type filter (e.g. "translation", "introduction")'),
+  cursor: z
+    .string()
+    .optional()
+    .describe('Pagination cursor for sequential browsing'),
+  passageUuid: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Center results around this passage UUID instead of paginating sequentially'),
+  maxPassages: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Maximum number of passages to return'),
+  maxCharacters: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Character budget — stop returning passages once this limit is reached'),
+  direction: z
+    .enum(['forward', 'backward'])
+    .optional()
+    .describe('Pagination direction (ignored when passageUuid is provided)'),
+};
+
+export function createGetTranslationPassagesTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'get-translation-passages',
+    description:
+      'Get a page of passages for a translation. Supports sequential pagination (cursor + direction) or centering around a specific passage (passageUuid).',
+    inputSchema,
+    annotations: {
+      title: 'Get Translation Passages',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({
+      uuid,
+      type,
+      cursor,
+      passageUuid,
+      maxPassages,
+      maxCharacters,
+      direction,
+    }) => {
+      if (passageUuid) {
+        const page = await getTranslationPassagesAround({
+          client,
+          uuid,
+          passageUuid,
+          type,
+          maxPassages,
+          maxCharacters,
+        });
+        return jsonResult(page);
+      }
+
+      const page = await getTranslationPassages({
+        client,
+        uuid,
+        type,
+        cursor,
+        maxPassages,
+        maxCharacters,
+        direction,
+      });
+      return jsonResult(page);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-translation.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation.spec.ts
@@ -1,0 +1,79 @@
+import { createGetTranslationTool } from './get-translation';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getTranslationMetadataByUuid: jest.fn(),
+  getTranslationMetadataByToh: jest.fn(),
+}));
+
+import {
+  getTranslationMetadataByUuid,
+  getTranslationMetadataByToh,
+} from '@eightyfourthousand/data-access';
+
+const mockedByUuid = jest.mocked(getTranslationMetadataByUuid);
+const mockedByToh = jest.mocked(getTranslationMetadataByToh);
+
+describe('get-translation tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetTranslationTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('get-translation');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('looks up by uuid', async () => {
+    const work = { uuid: 'abc', title: 'Test Work' };
+    mockedByUuid.mockResolvedValue(work as any);
+
+    const result = await tool.handler({ uuid: 'abc' }, extra);
+
+    expect(mockedByUuid).toHaveBeenCalledWith({ client, uuid: 'abc' });
+    expect(mockedByToh).not.toHaveBeenCalled();
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(work, null, 2),
+    });
+  });
+
+  it('looks up by toh', async () => {
+    const work = { uuid: 'abc', title: 'Test Work' };
+    mockedByToh.mockResolvedValue(work as any);
+
+    const result = await tool.handler({ toh: '1' }, extra);
+
+    expect(mockedByToh).toHaveBeenCalledWith({ client, toh: '1' });
+    expect(mockedByUuid).not.toHaveBeenCalled();
+  });
+
+  it('returns error when neither uuid nor toh provided', async () => {
+    const result = await tool.handler({}, extra);
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns error when both uuid and toh provided', async () => {
+    const result = await tool.handler({ uuid: 'abc', toh: '1' }, extra);
+    expect(result.isError).toBe(true);
+  });
+
+  it('handles thrown errors from getTranslationMetadataByUuid', async () => {
+    mockedByUuid.mockRejectedValue(new Error('DB error'));
+
+    const result = await tool.handler({ uuid: 'abc' }, extra);
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('DB error');
+  });
+
+  it('returns error when work not found by toh', async () => {
+    mockedByToh.mockResolvedValue(null);
+
+    const result = await tool.handler({ toh: '999' }, extra);
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-translation.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation.ts
@@ -10,13 +10,14 @@ import { jsonResult, errorResult } from './util';
 const inputSchema = {
   uuid: z
     .string()
-    .uuid()
     .optional()
     .describe('Work UUID — provide this or toh, not both'),
   toh: z
     .string()
     .optional()
-    .describe('Tohoku catalog number (e.g. "1", "123") — provide this or uuid, not both'),
+    .describe(
+      'Tohoku catalog number (e.g. "toh1", "toh123") — provide this or uuid, not both',
+    ),
 };
 
 export function createGetTranslationTool(
@@ -43,7 +44,7 @@ export function createGetTranslationTool(
       try {
         const work = uuid
           ? await getTranslationMetadataByUuid({ client, uuid })
-          : await getTranslationMetadataByToh({ client, toh: toh! });
+          : await getTranslationMetadataByToh({ client, toh });
 
         if (!work) {
           return errorResult(

--- a/libs/lib-agent/src/lib/tools/read/get-translation.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import {
+  getTranslationMetadataByUuid,
+  getTranslationMetadataByToh,
+} from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  uuid: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Work UUID — provide this or toh, not both'),
+  toh: z
+    .string()
+    .optional()
+    .describe('Tohoku catalog number (e.g. "1", "123") — provide this or uuid, not both'),
+};
+
+export function createGetTranslationTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'get-translation',
+    description:
+      'Get translation metadata (title, description, publication info, catalog numbers) by UUID or Tohoku number.',
+    inputSchema,
+    annotations: {
+      title: 'Get Translation',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ uuid, toh }) => {
+      if (!uuid && !toh) {
+        return errorResult('Provide either uuid or toh.');
+      }
+      if (uuid && toh) {
+        return errorResult('Provide only one of uuid or toh, not both.');
+      }
+
+      try {
+        const work = uuid
+          ? await getTranslationMetadataByUuid({ client, uuid })
+          : await getTranslationMetadataByToh({ client, toh: toh! });
+
+        if (!work) {
+          return errorResult(
+            `No translation found for ${uuid ? `UUID: ${uuid}` : `toh: ${toh}`}`,
+          );
+        }
+        return jsonResult(work);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorResult(message);
+      }
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-work-titles.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-work-titles.spec.ts
@@ -1,0 +1,37 @@
+import { createGetWorkTitlesTool } from './get-work-titles';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getWorkTitles: jest.fn(),
+}));
+
+import { getWorkTitles } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(getWorkTitles);
+
+describe('get-work-titles tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetWorkTitlesTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('get-work-titles');
+  });
+
+  it('returns titles array', async () => {
+    const titles = [
+      { language: 'en', title: 'The Heart Sutra' },
+      { language: 'bo', title: 'shes rab snying po' },
+    ];
+    mocked.mockResolvedValue(titles as any);
+
+    const result = await tool.handler({ uuid: 'w1' }, extra);
+
+    expect(mocked).toHaveBeenCalledWith({ client, uuid: 'w1' });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(titles, null, 2),
+    });
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-work-titles.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-work-titles.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getWorkTitles } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The work UUID'),
+};
+
+export function createGetWorkTitlesTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'get-work-titles',
+    description:
+      'Get all titles for a work in different languages (English, Tibetan, Sanskrit, etc.).',
+    inputSchema,
+    annotations: {
+      title: 'Get Work Titles',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ uuid }) => {
+      const titles = await getWorkTitles({ client, uuid });
+      return jsonResult(titles);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/get-work-titles.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-work-titles.ts
@@ -5,12 +5,10 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The work UUID'),
+  uuid: z.string().describe('The work UUID'),
 };
 
-export function createGetWorkTitlesTool(
-  client: DataClient,
-): McpToolDefinition {
+export function createGetWorkTitlesTool(client: DataClient): McpToolDefinition {
   return {
     name: 'get-work-titles',
     description:

--- a/libs/lib-agent/src/lib/tools/read/index.ts
+++ b/libs/lib-agent/src/lib/tools/read/index.ts
@@ -1,0 +1,51 @@
+import type { DataClient } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+
+import { createGetTranslationTool } from './get-translation';
+import { createGetPassageTool } from './get-passage';
+import { createGetTranslationPassagesTool } from './get-translation-passages';
+import { createSearchTranslationTool } from './search-translation';
+import { createGetGlossaryTermTool } from './get-glossary-term';
+import { createListGlossaryTermsTool } from './list-glossary-terms';
+import { createSearchGlossaryTermsTool } from './search-glossary-terms';
+import { createGetGlossaryInstancesTool } from './get-glossary-instances';
+import { createGetBibliographyEntryTool } from './get-bibliography-entry';
+import { createListWorkBibliographiesTool } from './list-work-bibliographies';
+import { createGetImprintTool } from './get-imprint';
+import { createGetTocTool } from './get-toc';
+import { createLookupEntityTool } from './lookup-entity';
+import { createGetWorkTitlesTool } from './get-work-titles';
+
+export function createReadTools(client: DataClient): McpToolDefinition[] {
+  return [
+    createGetTranslationTool(client),
+    createGetPassageTool(client),
+    createGetTranslationPassagesTool(client),
+    createSearchTranslationTool(client),
+    createGetGlossaryTermTool(client),
+    createListGlossaryTermsTool(client),
+    createSearchGlossaryTermsTool(client),
+    createGetGlossaryInstancesTool(client),
+    createGetBibliographyEntryTool(client),
+    createListWorkBibliographiesTool(client),
+    createGetImprintTool(client),
+    createGetTocTool(client),
+    createLookupEntityTool(client),
+    createGetWorkTitlesTool(client),
+  ];
+}
+
+export { createGetTranslationTool } from './get-translation';
+export { createGetPassageTool } from './get-passage';
+export { createGetTranslationPassagesTool } from './get-translation-passages';
+export { createSearchTranslationTool } from './search-translation';
+export { createGetGlossaryTermTool } from './get-glossary-term';
+export { createListGlossaryTermsTool } from './list-glossary-terms';
+export { createSearchGlossaryTermsTool } from './search-glossary-terms';
+export { createGetGlossaryInstancesTool } from './get-glossary-instances';
+export { createGetBibliographyEntryTool } from './get-bibliography-entry';
+export { createListWorkBibliographiesTool } from './list-work-bibliographies';
+export { createGetImprintTool } from './get-imprint';
+export { createGetTocTool } from './get-toc';
+export { createLookupEntityTool } from './lookup-entity';
+export { createGetWorkTitlesTool } from './get-work-titles';

--- a/libs/lib-agent/src/lib/tools/read/list-glossary-terms.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/list-glossary-terms.spec.ts
@@ -1,0 +1,40 @@
+import { createListGlossaryTermsTool } from './list-glossary-terms';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getWorkGlossaryTermsPage: jest.fn(),
+}));
+
+import { getWorkGlossaryTermsPage } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(getWorkGlossaryTermsPage);
+
+describe('list-glossary-terms tool', () => {
+  const client = {} as DataClient;
+  const tool = createListGlossaryTermsTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('list-glossary-terms');
+  });
+
+  it('passes all parameters to data-access', async () => {
+    const page = { nodes: [], pageInfo: {}, totalCount: 0 };
+    mocked.mockResolvedValue(page as any);
+
+    await tool.handler(
+      { workUuid: 'w1', limit: 10, cursor: 'c1', direction: 'FORWARD', withAttestations: true },
+      extra,
+    );
+
+    expect(mocked).toHaveBeenCalledWith({
+      client,
+      workUuid: 'w1',
+      limit: 10,
+      cursor: 'c1',
+      direction: 'FORWARD',
+      withAttestations: true,
+    });
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/list-glossary-terms.ts
+++ b/libs/lib-agent/src/lib/tools/read/list-glossary-terms.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getWorkGlossaryTermsPage } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult } from './util';
+
+const inputSchema = {
+  workUuid: z.string().uuid().describe('The work UUID'),
+  limit: z.number().int().positive().optional().describe('Page size (default 50, max 200)'),
+  cursor: z.string().optional().describe('Pagination cursor'),
+  direction: z
+    .enum(['FORWARD', 'BACKWARD', 'AROUND'])
+    .optional()
+    .describe('Pagination direction'),
+  withAttestations: z
+    .boolean()
+    .optional()
+    .describe('Include Sanskrit attestation variants'),
+};
+
+export function createListGlossaryTermsTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'list-glossary-terms',
+    description:
+      'List glossary terms for a work with pagination. Returns term names, definitions, and page info.',
+    inputSchema,
+    annotations: {
+      title: 'List Glossary Terms',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ workUuid, limit, cursor, direction, withAttestations }) => {
+      const page = await getWorkGlossaryTermsPage({
+        client,
+        workUuid,
+        limit,
+        cursor,
+        direction,
+        withAttestations,
+      });
+      return jsonResult(page);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/list-glossary-terms.ts
+++ b/libs/lib-agent/src/lib/tools/read/list-glossary-terms.ts
@@ -5,8 +5,13 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult } from './util';
 
 const inputSchema = {
-  workUuid: z.string().uuid().describe('The work UUID'),
-  limit: z.number().int().positive().optional().describe('Page size (default 50, max 200)'),
+  workUuid: z.string().describe('The work UUID'),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Page size (default 50, max 200)'),
   cursor: z.string().optional().describe('Pagination cursor'),
   direction: z
     .enum(['FORWARD', 'BACKWARD', 'AROUND'])
@@ -31,7 +36,13 @@ export function createListGlossaryTermsTool(
       readOnlyHint: true,
       openWorldHint: false,
     },
-    handler: async ({ workUuid, limit, cursor, direction, withAttestations }) => {
+    handler: async ({
+      workUuid,
+      limit,
+      cursor,
+      direction,
+      withAttestations,
+    }) => {
       const page = await getWorkGlossaryTermsPage({
         client,
         workUuid,

--- a/libs/lib-agent/src/lib/tools/read/list-work-bibliographies.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/list-work-bibliographies.spec.ts
@@ -1,0 +1,30 @@
+import { createListWorkBibliographiesTool } from './list-work-bibliographies';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getBibliographyEntries: jest.fn(),
+}));
+
+import { getBibliographyEntries } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(getBibliographyEntries);
+
+describe('list-work-bibliographies tool', () => {
+  const client = {} as DataClient;
+  const tool = createListWorkBibliographiesTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns bibliography entries', async () => {
+    const entries = [{ heading: 'Primary', entries: [] }];
+    mocked.mockResolvedValue(entries as any);
+
+    const result = await tool.handler({ uuid: 'w1' }, extra);
+
+    expect(mocked).toHaveBeenCalledWith({ client, uuid: 'w1' });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(entries, null, 2),
+    });
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/list-work-bibliographies.ts
+++ b/libs/lib-agent/src/lib/tools/read/list-work-bibliographies.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getBibliographyEntries } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().uuid().describe('The work UUID'),
+};
+
+export function createListWorkBibliographiesTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'list-work-bibliographies',
+    description:
+      'List all bibliography entries for a work, grouped by heading.',
+    inputSchema,
+    annotations: {
+      title: 'List Work Bibliographies',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ uuid }) => {
+      const entries = await getBibliographyEntries({ client, uuid });
+      return jsonResult(entries);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/list-work-bibliographies.ts
+++ b/libs/lib-agent/src/lib/tools/read/list-work-bibliographies.ts
@@ -5,7 +5,7 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult } from './util';
 
 const inputSchema = {
-  uuid: z.string().uuid().describe('The work UUID'),
+  uuid: z.string().describe('The work UUID'),
 };
 
 export function createListWorkBibliographiesTool(

--- a/libs/lib-agent/src/lib/tools/read/lookup-entity.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/lookup-entity.spec.ts
@@ -1,0 +1,51 @@
+import { createLookupEntityTool } from './lookup-entity';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access/ssr', () => ({
+  lookupEntity: jest.fn(),
+}));
+
+import { lookupEntity } from '@eightyfourthousand/data-access/ssr';
+const mocked = jest.mocked(lookupEntity);
+
+describe('lookup-entity tool', () => {
+  const client = {} as DataClient;
+  const tool = createLookupEntityTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('lookup-entity');
+  });
+
+  it('returns path when entity is found', async () => {
+    mocked.mockResolvedValue('/abc-uuid?toh=1');
+
+    const result = await tool.handler(
+      { type: 'translation', entity: '1' },
+      extra,
+    );
+
+    expect(mocked).toHaveBeenCalledWith({
+      type: 'translation',
+      entity: '1',
+      prefix: undefined,
+      xmlId: undefined,
+    });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify({ path: '/abc-uuid?toh=1' }, null, 2),
+    });
+  });
+
+  it('returns error when entity not resolved', async () => {
+    mocked.mockResolvedValue(undefined);
+
+    const result = await tool.handler(
+      { type: 'work', entity: 'missing' },
+      extra,
+    );
+    expect(result.isError).toBe(true);
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/lookup-entity.ts
+++ b/libs/lib-agent/src/lib/tools/read/lookup-entity.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { lookupEntity } from '@eightyfourthousand/data-access/ssr';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  type: z
+    .enum(['bibliography', 'glossary', 'passage', 'translation', 'work'])
+    .describe('The entity type'),
+  entity: z
+    .string()
+    .describe('Entity identifier — UUID for most types, or toh number for translations'),
+  prefix: z.string().optional().describe('URL path prefix'),
+  xmlId: z
+    .string()
+    .optional()
+    .describe('XML ID for passage lookup within a translation'),
+};
+
+export function createLookupEntityTool(
+  _client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'lookup-entity',
+    description:
+      'Resolve an entity to its reader URL path. Returns the path to view the entity in the reader application.',
+    inputSchema,
+    annotations: {
+      title: 'Lookup Entity',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ type, entity, prefix, xmlId }) => {
+      const path = await lookupEntity({ type, entity, prefix, xmlId });
+      if (!path) {
+        return errorResult(
+          `Could not resolve ${type} entity: ${entity}`,
+        );
+      }
+      return jsonResult({ path });
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/lookup-entity.ts
+++ b/libs/lib-agent/src/lib/tools/read/lookup-entity.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { DataClient } from '@eightyfourthousand/data-access';
-import { lookupEntity } from '@eightyfourthousand/data-access/ssr';
+import { lookupEntityWithClient } from '@eightyfourthousand/data-access/ssr';
 import type { McpToolDefinition } from '../../types';
 import { jsonResult, errorResult } from './util';
 
@@ -10,17 +10,16 @@ const inputSchema = {
     .describe('The entity type'),
   entity: z
     .string()
-    .describe('Entity identifier — UUID for most types, or toh number for translations'),
-  prefix: z.string().optional().describe('URL path prefix'),
+    .describe(
+      'Entity identifier — UUID for most types, or toh number for translations',
+    ),
   xmlId: z
     .string()
     .optional()
     .describe('XML ID for passage lookup within a translation'),
 };
 
-export function createLookupEntityTool(
-  _client: DataClient,
-): McpToolDefinition {
+export function createLookupEntityTool(client: DataClient): McpToolDefinition {
   return {
     name: 'lookup-entity',
     description:
@@ -31,12 +30,15 @@ export function createLookupEntityTool(
       readOnlyHint: true,
       openWorldHint: false,
     },
-    handler: async ({ type, entity, prefix, xmlId }) => {
-      const path = await lookupEntity({ type, entity, prefix, xmlId });
+    handler: async ({ type, entity, xmlId }) => {
+      const path = await lookupEntityWithClient({
+        client,
+        type,
+        entity,
+        xmlId,
+      });
       if (!path) {
-        return errorResult(
-          `Could not resolve ${type} entity: ${entity}`,
-        );
+        return errorResult(`Could not resolve ${type} entity: ${entity}`);
       }
       return jsonResult({ path });
     },

--- a/libs/lib-agent/src/lib/tools/read/search-glossary-terms.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-glossary-terms.spec.ts
@@ -1,0 +1,38 @@
+import { createSearchGlossaryTermsTool } from './search-glossary-terms';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  searchWorkGlossaryTerms: jest.fn(),
+}));
+
+import { searchWorkGlossaryTerms } from '@eightyfourthousand/data-access';
+const mocked = jest.mocked(searchWorkGlossaryTerms);
+
+describe('search-glossary-terms tool', () => {
+  const client = {} as DataClient;
+  const tool = createSearchGlossaryTermsTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('search-glossary-terms');
+  });
+
+  it('passes query and params to data-access', async () => {
+    mocked.mockResolvedValue([]);
+
+    await tool.handler(
+      { workUuid: 'w1', query: 'bodhi', limit: 5 },
+      extra,
+    );
+
+    expect(mocked).toHaveBeenCalledWith({
+      client,
+      workUuid: 'w1',
+      query: 'bodhi',
+      limit: 5,
+      withAttestations: undefined,
+    });
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/search-glossary-terms.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-glossary-terms.ts
@@ -5,9 +5,14 @@ import type { McpToolDefinition } from '../../types';
 import { jsonResult } from './util';
 
 const inputSchema = {
-  workUuid: z.string().uuid().describe('The work UUID'),
+  workUuid: z.string().describe('The work UUID'),
   query: z.string().describe('Search query — matches against term names'),
-  limit: z.number().int().positive().optional().describe('Max results (default 20, max 50)'),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Max results (default 20, max 50)'),
   withAttestations: z
     .boolean()
     .optional()

--- a/libs/lib-agent/src/lib/tools/read/search-glossary-terms.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-glossary-terms.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { searchWorkGlossaryTerms } from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult } from './util';
+
+const inputSchema = {
+  workUuid: z.string().uuid().describe('The work UUID'),
+  query: z.string().describe('Search query — matches against term names'),
+  limit: z.number().int().positive().optional().describe('Max results (default 20, max 50)'),
+  withAttestations: z
+    .boolean()
+    .optional()
+    .describe('Include Sanskrit attestation variants'),
+};
+
+export function createSearchGlossaryTermsTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'search-glossary-terms',
+    description:
+      'Search glossary terms within a work by name. Returns matching terms with names in all languages and definitions.',
+    inputSchema,
+    annotations: {
+      title: 'Search Glossary Terms',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ workUuid, query, limit, withAttestations }) => {
+      const terms = await searchWorkGlossaryTerms({
+        client,
+        workUuid,
+        query,
+        limit,
+        withAttestations,
+      });
+      return jsonResult(terms);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/search-translation.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-translation.spec.ts
@@ -1,0 +1,54 @@
+import { createSearchTranslationTool } from './search-translation';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/lib-search', () => ({
+  search: jest.fn(),
+}));
+
+import { search } from '@eightyfourthousand/lib-search';
+const mockedSearch = jest.mocked(search);
+
+describe('search-translation tool', () => {
+  const client = {} as DataClient;
+  const tool = createSearchTranslationTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('search-translation');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('returns search results as JSON', async () => {
+    const results = { passages: [{ uuid: 'p1' }], glossaries: [] };
+    mockedSearch.mockResolvedValue(results as any);
+
+    const result = await tool.handler(
+      { text: 'dharma', uuid: 'work-1', toh: '1' },
+      extra,
+    );
+
+    expect(mockedSearch).toHaveBeenCalledWith({
+      text: 'dharma',
+      uuid: 'work-1',
+      toh: '1',
+      useRegex: undefined,
+    });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(results, null, 2),
+    });
+  });
+
+  it('returns error when search fails', async () => {
+    mockedSearch.mockResolvedValue(undefined);
+
+    const result = await tool.handler(
+      { text: 'dharma', uuid: 'work-1', toh: '1' },
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/search-translation.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-translation.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { search } from '@eightyfourthousand/lib-search';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  text: z.string().describe('Search query text'),
+  uuid: z.string().uuid().describe('Work UUID to search within'),
+  toh: z.string().describe('Tohoku catalog number of the work'),
+  useRegex: z.boolean().optional().describe('Use regex search'),
+};
+
+export function createSearchTranslationTool(
+  _client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'search-translation',
+    description:
+      'Full-text search within a translation. Returns matching passages, alignments, bibliographies, and glossary entries.',
+    inputSchema,
+    annotations: {
+      title: 'Search Translation',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ text, uuid, toh, useRegex }) => {
+      const results = await search({ text, uuid, toh, useRegex });
+      if (!results) {
+        return errorResult('Search returned no results.');
+      }
+      return jsonResult(results);
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/search-translation.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-translation.ts
@@ -1,18 +1,18 @@
 import { z } from 'zod';
 import type { DataClient } from '@eightyfourthousand/data-access';
-import { search } from '@eightyfourthousand/lib-search';
+import { searchWithClient } from '@eightyfourthousand/lib-search';
 import type { McpToolDefinition } from '../../types';
 import { jsonResult, errorResult } from './util';
 
 const inputSchema = {
   text: z.string().describe('Search query text'),
-  uuid: z.string().uuid().describe('Work UUID to search within'),
+  uuid: z.string().describe('Work UUID to search within'),
   toh: z.string().describe('Tohoku catalog number of the work'),
   useRegex: z.boolean().optional().describe('Use regex search'),
 };
 
 export function createSearchTranslationTool(
-  _client: DataClient,
+  client: DataClient,
 ): McpToolDefinition {
   return {
     name: 'search-translation',
@@ -25,7 +25,13 @@ export function createSearchTranslationTool(
       openWorldHint: false,
     },
     handler: async ({ text, uuid, toh, useRegex }) => {
-      const results = await search({ text, uuid, toh, useRegex });
+      const results = await searchWithClient({
+        client,
+        text,
+        uuid,
+        toh,
+        useRegex,
+      });
       if (!results) {
         return errorResult('Search returned no results.');
       }

--- a/libs/lib-agent/src/lib/tools/read/util.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/util.spec.ts
@@ -1,0 +1,21 @@
+import { jsonResult, errorResult } from './util';
+
+describe('jsonResult', () => {
+  it('wraps data as JSON text content', () => {
+    const result = jsonResult({ foo: 'bar' });
+    expect(result.content).toEqual([
+      { type: 'text', text: JSON.stringify({ foo: 'bar' }, null, 2) },
+    ]);
+    expect(result.isError).toBeUndefined();
+  });
+});
+
+describe('errorResult', () => {
+  it('returns error content with isError flag', () => {
+    const result = errorResult('something went wrong');
+    expect(result.content).toEqual([
+      { type: 'text', text: 'something went wrong' },
+    ]);
+    expect(result.isError).toBe(true);
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/util.ts
+++ b/libs/lib-agent/src/lib/tools/read/util.ts
@@ -1,0 +1,14 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types';
+
+export function jsonResult(data: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+export function errorResult(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}

--- a/libs/lib-search/src/lib/data/search.ts
+++ b/libs/lib-search/src/lib/data/search.ts
@@ -2,6 +2,7 @@
 
 import { createServerClient } from '@eightyfourthousand/data-access/ssr';
 import { searchResultsFromDTO } from '../types';
+import { DataClient } from '@eightyfourthousand/data-access';
 
 export const search = async ({
   text,
@@ -15,6 +16,22 @@ export const search = async ({
   useRegex?: boolean;
 }) => {
   const client = await createServerClient();
+  return await searchWithClient({ client, text, uuid, toh, useRegex });
+};
+
+export const searchWithClient = async ({
+  client,
+  text,
+  uuid,
+  toh,
+  useRegex = false,
+}: {
+  client: DataClient;
+  text: string;
+  uuid: string;
+  toh: string;
+  useRegex?: boolean;
+}) => {
   const { data, error } = await client.rpc('translation_search', {
     search_term: text,
     work_uuid: uuid,


### PR DESCRIPTION
### Summary

Adds the basic set of read only tools that can be called using the MCP server. This maps to the same operations used by the reader, including fetching the list of translations, translation metadata, passages, glossary terms for a work, etc.

### Linear

- [DEV-606](https://linear.app/84000/issue/DEV-606)