### PR TITLE
MCP Auth Support

### DIFF
--- a/libs/lib-agent/src/index.ts
+++ b/libs/lib-agent/src/index.ts
@@ -1,3 +1,15 @@
 export { createMcpHandler } from './lib/server';
 export type { McpToolDefinition, McpHandlerOptions } from './lib/types';
 export { createReadTools } from './lib/tools/read';
+export {
+  validateBearerToken,
+  requirePermission,
+  decodeRole,
+  ROLE_HIERARCHY,
+} from './lib/auth';
+export type {
+  AuthResult,
+  AuthSuccess,
+  AuthFailure,
+  PermissionResult,
+} from './lib/auth';

--- a/libs/lib-agent/src/lib/auth.spec.ts
+++ b/libs/lib-agent/src/lib/auth.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * @jest-environment node
+ */
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('jwt-decode', () => ({
+  jwtDecode: jest.fn(),
+}));
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  createTokenClient: jest.fn(),
+  hasPermission: jest.fn(),
+}));
+
+import { jwtDecode } from 'jwt-decode';
+import {
+  createTokenClient,
+  hasPermission,
+} from '@eightyfourthousand/data-access';
+import {
+  validateBearerToken,
+  requirePermission,
+  decodeRole,
+  ROLE_HIERARCHY,
+} from './auth';
+
+const mockedJwtDecode = jest.mocked(jwtDecode);
+const mockedCreateTokenClient = jest.mocked(createTokenClient);
+const mockedHasPermission = jest.mocked(hasPermission);
+
+const makeRequest = (authHeader?: string) =>
+  new Request('http://localhost/api/mcp', {
+    method: 'POST',
+    headers: authHeader ? { Authorization: authHeader } : {},
+  });
+
+describe('validateBearerToken', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 401 when Authorization header is missing', () => {
+    const result = validateBearerToken(makeRequest());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      expect(result.response.headers.get('WWW-Authenticate')).toContain(
+        'Bearer',
+      );
+      expect(result.response.headers.get('WWW-Authenticate')).toContain(
+        'resource_metadata',
+      );
+    }
+  });
+
+  it('returns 401 for non-Bearer auth scheme', () => {
+    const result = validateBearerToken(makeRequest('Basic dXNlcjpwYXNz'));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      expect(result.response.headers.get('WWW-Authenticate')).toContain(
+        'Bearer',
+      );
+    }
+  });
+
+  it('returns 401 when JWT is invalid', () => {
+    mockedJwtDecode.mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    const result = validateBearerToken(makeRequest('Bearer bad.token.here'));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  it('returns auth context for valid JWT', () => {
+    mockedJwtDecode.mockReturnValue({
+      sub: 'user-123',
+      email: 'test@84000.co',
+      user_role: 'editor',
+    });
+    const mockClient = {} as DataClient;
+    mockedCreateTokenClient.mockReturnValue(mockClient);
+
+    const result = validateBearerToken(makeRequest('Bearer valid.jwt.token'));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.client).toBe(mockClient);
+      expect(result.userId).toBe('user-123');
+      expect(result.email).toBe('test@84000.co');
+      expect(result.role).toBe('editor');
+    }
+    expect(mockedCreateTokenClient).toHaveBeenCalledWith('valid.jwt.token');
+  });
+
+  it('defaults role to reader when user_role is missing', () => {
+    mockedJwtDecode.mockReturnValue({ sub: 'user-456' });
+    mockedCreateTokenClient.mockReturnValue({} as DataClient);
+
+    const result = validateBearerToken(makeRequest('Bearer valid.jwt.token'));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.role).toBe('reader');
+    }
+  });
+});
+
+describe('requirePermission', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const client = {} as DataClient;
+
+  it('returns ok when permission is granted', async () => {
+    mockedHasPermission.mockResolvedValue(true);
+
+    const result = await requirePermission(client, 'projects.read');
+
+    expect(result.ok).toBe(true);
+    expect(mockedHasPermission).toHaveBeenCalledWith({
+      client,
+      permission: 'projects.read',
+    });
+  });
+
+  it('returns 403 when permission is denied', async () => {
+    mockedHasPermission.mockResolvedValue(false);
+
+    const result = await requirePermission(client, 'editor.admin');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(403);
+      const body = await result.response.json();
+      expect(body.error).toBe('forbidden');
+    }
+  });
+});
+
+describe('decodeRole', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('extracts role from JWT', () => {
+    mockedJwtDecode.mockReturnValue({ user_role: 'admin' });
+    expect(decodeRole('some.token')).toBe('admin');
+  });
+
+  it('defaults to reader when role is missing', () => {
+    mockedJwtDecode.mockReturnValue({});
+    expect(decodeRole('some.token')).toBe('reader');
+  });
+
+  it('defaults to reader on invalid token', () => {
+    mockedJwtDecode.mockImplementation(() => {
+      throw new Error('bad');
+    });
+    expect(decodeRole('bad')).toBe('reader');
+  });
+});
+
+describe('ROLE_HIERARCHY', () => {
+  it('lists roles from least to most privileged', () => {
+    expect(ROLE_HIERARCHY).toEqual([
+      'reader',
+      'scholar',
+      'translator',
+      'editor',
+      'admin',
+    ]);
+  });
+});

--- a/libs/lib-agent/src/lib/auth.ts
+++ b/libs/lib-agent/src/lib/auth.ts
@@ -1,0 +1,106 @@
+import { jwtDecode } from 'jwt-decode';
+import { createTokenClient, hasPermission } from '@eightyfourthousand/data-access';
+import type {
+  DataClient,
+  UserRole,
+  UserPermission,
+} from '@eightyfourthousand/data-access';
+
+export type AuthSuccess = {
+  ok: true;
+  client: DataClient;
+  userId: string;
+  email: string;
+  role: UserRole;
+};
+
+export type AuthFailure = {
+  ok: false;
+  response: Response;
+};
+
+export type AuthResult = AuthSuccess | AuthFailure;
+
+export type PermissionResult = { ok: true } | { ok: false; response: Response };
+
+export const ROLE_HIERARCHY: UserRole[] = [
+  'reader',
+  'scholar',
+  'translator',
+  'editor',
+  'admin',
+];
+
+const createUnauthorizedResponse = (
+  message = 'Authentication required',
+): Response =>
+  new Response(JSON.stringify({ error: 'unauthorized', message }), {
+    status: 401,
+    headers: {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate':
+        'Bearer realm="84000-mcp", resource_metadata="/.well-known/oauth-protected-resource"',
+    },
+  });
+
+const createForbiddenResponse = (
+  message = 'Insufficient permissions',
+): Response =>
+  new Response(JSON.stringify({ error: 'forbidden', message }), {
+    status: 403,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+export const validateBearerToken = (req: Request): AuthResult => {
+  const authHeader = req.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return { ok: false, response: createUnauthorizedResponse() };
+  }
+
+  const token = authHeader.substring(7);
+
+  try {
+    const decoded = jwtDecode<{
+      sub: string;
+      email?: string;
+      user_role?: UserRole;
+    }>(token);
+
+    const client = createTokenClient(token);
+    const role = decoded.user_role ?? 'reader';
+
+    return {
+      ok: true,
+      client,
+      userId: decoded.sub,
+      email: decoded.email ?? '',
+      role: ROLE_HIERARCHY.includes(role) ? role : 'reader',
+    };
+  } catch {
+    return {
+      ok: false,
+      response: createUnauthorizedResponse('Invalid token'),
+    };
+  }
+};
+
+export const requirePermission = async (
+  client: DataClient,
+  permission: UserPermission,
+): Promise<PermissionResult> => {
+  const allowed = await hasPermission({ client, permission });
+  if (!allowed) {
+    return { ok: false, response: createForbiddenResponse() };
+  }
+  return { ok: true };
+};
+
+export const decodeRole = (token: string): UserRole => {
+  try {
+    const decoded = jwtDecode<{ user_role?: UserRole }>(token);
+    const role = decoded.user_role ?? 'reader';
+    return ROLE_HIERARCHY.includes(role) ? role : 'reader';
+  } catch {
+    return 'reader';
+  }
+};

--- a/libs/lib-agent/src/lib/tools/read/lookup-entity.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/lookup-entity.spec.ts
@@ -2,11 +2,11 @@ import { createLookupEntityTool } from './lookup-entity';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
 jest.mock('@eightyfourthousand/data-access/ssr', () => ({
-  lookupEntity: jest.fn(),
+  lookupEntityWithClient: jest.fn(),
 }));
 
-import { lookupEntity } from '@eightyfourthousand/data-access/ssr';
-const mocked = jest.mocked(lookupEntity);
+import { lookupEntityWithClient } from '@eightyfourthousand/data-access/ssr';
+const mocked = jest.mocked(lookupEntityWithClient);
 
 describe('lookup-entity tool', () => {
   const client = {} as DataClient;
@@ -28,9 +28,9 @@ describe('lookup-entity tool', () => {
     );
 
     expect(mocked).toHaveBeenCalledWith({
+      client,
       type: 'translation',
       entity: '1',
-      prefix: undefined,
       xmlId: undefined,
     });
     expect(result.content[0]).toEqual({

--- a/libs/lib-agent/src/lib/tools/read/search-translation.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-translation.spec.ts
@@ -2,11 +2,11 @@ import { createSearchTranslationTool } from './search-translation';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
 jest.mock('@eightyfourthousand/lib-search', () => ({
-  search: jest.fn(),
+  searchWithClient: jest.fn(),
 }));
 
-import { search } from '@eightyfourthousand/lib-search';
-const mockedSearch = jest.mocked(search);
+import { searchWithClient } from '@eightyfourthousand/lib-search';
+const mockedSearch = jest.mocked(searchWithClient);
 
 describe('search-translation tool', () => {
   const client = {} as DataClient;
@@ -30,6 +30,7 @@ describe('search-translation tool', () => {
     );
 
     expect(mockedSearch).toHaveBeenCalledWith({
+      client,
       text: 'dharma',
       uuid: 'work-1',
       toh: '1',


### PR DESCRIPTION
### Summary

Adds an auth seam to be used by the Studio MCP server. Identity is still delegated to Supabase Auth The MCP server becomes a Resource Server.

### Linear

- [DEV-608](https://linear.app/84000/issue/DEV-608)
