### PR TITLE
Include title and toh in bookmarks

### DIFF
--- a/libs/data-access/src/lib/local-storage.ts
+++ b/libs/data-access/src/lib/local-storage.ts
@@ -5,6 +5,8 @@ export type BookmarkItem = {
   uuid: string;
   label: string;
   body: string;
+  workTitle?: string;
+  toh?: string;
 };
 
 const LIBRARY_KEY = 'library';

--- a/libs/data-access/src/lib/use-bookmark.ts
+++ b/libs/data-access/src/lib/use-bookmark.ts
@@ -9,6 +9,8 @@ type BookmarkOptions = {
   tab: string;
   label?: string;
   body?: string;
+  workTitle?: string;
+  toh?: string;
 };
 
 const listeners = new Set<() => void>();
@@ -40,10 +42,19 @@ export function useBookmark(uuid: string, options?: BookmarkOptions) {
         tab: options?.tab ?? '',
         label: options?.label ?? '',
         body: options?.body ?? '',
+        workTitle: options?.workTitle,
+        toh: options?.toh,
       });
     }
     emitChange();
-  }, [uuid, options?.type, options?.subType, options?.tab]);
+  }, [
+    uuid,
+    options?.type,
+    options?.subType,
+    options?.tab,
+    options?.workTitle,
+    options?.toh,
+  ]);
 
   return { isBookmarked: bookmarked, toggle };
 }

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/Passage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/Passage.tsx
@@ -44,6 +44,9 @@ const PassageComponent = (props: NodeViewProps) => {
   const excerpt =
     textContent.slice(0, 100) + (textContent.length > 100 ? '...' : '');
 
+  const { panels, toh, updatePanel, imprint } = useNavigation();
+  const workTitle = imprint?.mainTitles?.en ?? toh;
+
   const { isBookmarked, toggle: toggleBookmark } = useBookmark(
     node.attrs.uuid,
     {
@@ -52,10 +55,10 @@ const PassageComponent = (props: NodeViewProps) => {
       tab: node.attrs.type ?? '',
       label: node.attrs.label,
       body: excerpt,
+      workTitle,
+      toh,
     },
   );
-
-  const { panels, toh, updatePanel } = useNavigation();
 
   // Compute values directly instead of using effects to avoid re-render loops
   const isCompare = panels.main.open && panels.main.tab === 'compare';

--- a/libs/lib-editing/src/lib/components/shared/LabeledElement.tsx
+++ b/libs/lib-editing/src/lib/components/shared/LabeledElement.tsx
@@ -35,14 +35,17 @@ export const LabeledElement = ({
   contentType?: PanelContentType;
   children: ReactNode;
 }) => {
+  const { toh, imprint } = useNavigation();
+  const workTitle = imprint?.mainTitles?.en ?? toh;
   const { isBookmarked, toggle } = useBookmark(id ?? '', {
     type: contentType ?? '',
     tab: contentType ?? '',
     body: excerpt,
     label,
+    workTitle,
+    toh,
   });
 
-  const { toh } = useNavigation();
   const [showRevisionForm, setShowRevisionForm] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 

--- a/nx.json
+++ b/nx.json
@@ -128,5 +128,8 @@
       "lib-editing"
     ]
   },
-  "neverConnectToCloud": true
+  "neverConnectToCloud": true,
+  "sync": {
+    "disabledTaskSyncGenerators": ["@nx/js:typescript-sync"]
+  }
 }


### PR DESCRIPTION
### Summary

When saving bookmarks to local storage, include work title and Tohoku number for more convenient display.

### Linear

- [DEV-629](https://linear.app/84000/issue/DEV-629)
