### PR TITLE
SSR-Friendly Marks

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ssr.ts
@@ -1,0 +1,70 @@
+import { Mark, mergeAttributes } from '@tiptap/core';
+import { cn } from '@eightyfourthousand/lib-utils';
+
+export interface EndNoteLinkSSROptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+interface EndNoteItem {
+  uuid: string;
+  location?: string;
+  toh?: string;
+  endNote: string;
+  label?: string;
+}
+
+const isEndNoteItem = (value: unknown): value is EndNoteItem => {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.uuid === 'string' && typeof v.endNote === 'string';
+};
+
+export const EndNoteLinkMarkSSR = Mark.create<EndNoteLinkSSROptions>({
+  name: 'endNoteLink',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      notes: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('notes'),
+      },
+    };
+  },
+
+  renderHTML({ mark }) {
+    const raw = mark.attrs.notes;
+    const notes: EndNoteItem[] = Array.isArray(raw) ? raw.filter(isEndNoteItem) : [];
+    notes.sort((a, b) => (a.label || '').localeCompare(b.label || ''));
+
+    const sup = (note: EndNoteItem, marginClass: string) => {
+      const itemLabel = note.label?.split('.').pop() || '';
+      return [
+        'sup',
+        {
+          class: cn('end-note-link', note.toh, marginClass),
+          type: 'endNoteLink',
+          endNote: note.endNote,
+          uuid: note.uuid,
+        },
+        itemLabel,
+      ] as unknown;
+    };
+
+    const startSups = notes
+      .filter((n) => n.location === 'start')
+      .map((n) => sup(n, 'me-0.75'));
+    const endSups = notes
+      .filter((n) => n.location !== 'start')
+      .map((n) => sup(n, ''));
+
+    return ['span', mergeAttributes(this.options.HTMLAttributes, {}), ...startSups, 0, ...endSups];
+  },
+});
+
+export default EndNoteLinkMarkSSR;

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
@@ -1,11 +1,8 @@
-import { Mark, mergeAttributes } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { v4 as uuidv4 } from 'uuid';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { createUpdateAttributes, registerEditorElement } from '../../util';
-
-export interface EndNoteLinkOptions {
-  HTMLAttributes: Record<string, unknown>;
-}
+import { EndNoteLinkMarkSSR } from './EndNoteLinkMark.ssr';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -16,25 +13,7 @@ declare module '@tiptap/core' {
   }
 }
 
-export const EndNoteLinkMark = Mark.create<EndNoteLinkOptions>({
-  name: 'endNoteLink',
-
-  addAttributes() {
-    return {
-      ...this.parent?.(),
-      notes: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('notes'),
-      },
-    };
-  },
-
-  addOptions() {
-    return {
-      HTMLAttributes: {},
-    };
-  },
-
+export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
   addMarkView() {
     return (props) => {
       const isEditable = props.editor.isEditable;

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
@@ -1,5 +1,4 @@
 import { Mark, mergeAttributes } from '@tiptap/core';
-import { cn } from '@eightyfourthousand/lib-utils';
 
 export interface GlossaryInstanceSSROptions {
   HTMLAttributes: Record<string, unknown>;
@@ -30,10 +29,6 @@ export const GlossaryInstanceNodeSSR = Mark.create<GlossaryInstanceSSROptions>({
         default: undefined,
         parseHTML: (element) => element.getAttribute('uuid'),
       },
-      toh: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('data-toh'),
-      },
       isInline: { default: true },
     };
   },
@@ -43,13 +38,13 @@ export const GlossaryInstanceNodeSSR = Mark.create<GlossaryInstanceSSROptions>({
   },
 
   renderHTML({ mark, HTMLAttributes }) {
-    const { authority, glossary, uuid, toh } = mark.attrs as Record<
+    const { authority, glossary, uuid } = mark.attrs as Record<
       string,
       string | undefined
     >;
 
     const attrs: Record<string, string> = {
-      class: cn('glossary-instance', typeof toh === 'string' ? toh : undefined),
+      class: 'glossary-instance',
       type: 'glossaryInstance',
     };
     if (authority) attrs['authority'] = authority;

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
@@ -1,0 +1,63 @@
+import { Mark, mergeAttributes } from '@tiptap/core';
+import { cn } from '@eightyfourthousand/lib-utils';
+
+export interface GlossaryInstanceSSROptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export const GlossaryInstanceNodeSSR = Mark.create<GlossaryInstanceSSROptions>({
+  name: 'glossaryInstance',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {
+        className: 'glossary-instance',
+      },
+    };
+  },
+
+  addAttributes() {
+    return {
+      authority: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('authority'),
+      },
+      glossary: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('glossary'),
+      },
+      uuid: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('uuid'),
+      },
+      toh: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-toh'),
+      },
+      isInline: { default: true },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[type="glossaryInstance"]' }];
+  },
+
+  renderHTML({ mark, HTMLAttributes }) {
+    const { authority, glossary, uuid, toh } = mark.attrs as Record<
+      string,
+      string | undefined
+    >;
+
+    const attrs: Record<string, string> = {
+      class: cn('glossary-instance', typeof toh === 'string' ? toh : undefined),
+      type: 'glossaryInstance',
+    };
+    if (authority) attrs['authority'] = authority;
+    if (glossary) attrs['glossary'] = glossary;
+    if (uuid) attrs['uuid'] = uuid;
+
+    return ['span', mergeAttributes(HTMLAttributes, attrs), 0];
+  },
+});
+
+export default GlossaryInstanceNodeSSR;

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ts
@@ -1,11 +1,7 @@
-import { Mark } from '@tiptap/core';
 import { v4 as uuidv4 } from 'uuid';
-import { createMarkViewDom, registerEditorElement } from '../../util';
 import { cn } from '@eightyfourthousand/lib-utils';
-
-export interface GlossaryInstanceOptions {
-  HTMLAttributes: Record<string, unknown>;
-}
+import { createMarkViewDom, registerEditorElement } from '../../util';
+import { GlossaryInstanceNodeSSR } from './GlossaryInstanceNode.ssr';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -19,67 +15,7 @@ declare module '@tiptap/core' {
   }
 }
 
-export const GlossaryInstanceNode = Mark.create<GlossaryInstanceOptions>({
-  name: 'glossaryInstance',
-
-  addAttributes() {
-    return {
-      ...this.parent?.(),
-      authority: {
-        default: undefined,
-        parseHTML(element) {
-          return element.getAttribute('authority');
-        },
-      },
-      glossary: {
-        default: undefined,
-        parseHTML(element) {
-          return element.getAttribute('glossary');
-        },
-      },
-      uuid: {
-        default: undefined,
-        parseHTML(element) {
-          return element.getAttribute('uuid');
-        },
-      },
-      isInline: { default: true },
-    };
-  },
-
-  addOptions() {
-    return {
-      HTMLAttributes: {
-        className: 'glossary-instance',
-      },
-    };
-  },
-
-  parseHTML() {
-    return [
-      {
-        tag: 'span[type="glossaryInstance"]',
-        getAttrs: (dom) => {
-          const authority = (dom as HTMLElement).getAttribute('authority');
-          const glossary = (dom as HTMLElement).getAttribute('glossary');
-
-          if (!authority || !glossary) {
-            return false;
-          }
-          return null;
-        },
-      },
-    ];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    return [
-      'span',
-      { class: HTMLAttributes.className, type: 'glossaryInstance' },
-      0,
-    ];
-  },
-
+export const GlossaryInstanceNode = GlossaryInstanceNodeSSR.extend({
   addMarkView() {
     return (props) => {
       const isEditable = props.editor.isEditable;

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ssr.ts
@@ -46,10 +46,6 @@ export const InternalLinkSSR = Mark.create<InternalLinkSSROptions>({
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-link-toh'),
       },
-      toh: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('data-toh'),
-      },
     };
   },
 
@@ -66,11 +62,10 @@ export const InternalLinkSSR = Mark.create<InternalLinkSSROptions>({
       isSameWork,
       subtype,
       linkToh,
-      toh,
     } = mark.attrs as Record<string, string | boolean | undefined>;
 
     const attrs: Record<string, string> = {
-      class: cn(LINK_STYLE, typeof toh === 'string' ? toh : undefined),
+      class: cn(LINK_STYLE),
       type: 'internalLink',
     };
     if (entity) attrs['entity'] = String(entity);

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ssr.ts
@@ -1,0 +1,98 @@
+import { Mark, mergeAttributes } from '@tiptap/core';
+import { cn, safeHref } from '@eightyfourthousand/lib-utils';
+import { LINK_STYLE } from '@eightyfourthousand/design-system';
+
+export interface InternalLinkSSROptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export const InternalLinkSSR = Mark.create<InternalLinkSSROptions>({
+  name: 'internalLink',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      entity: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('entity'),
+      },
+      type: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('entity-type'),
+      },
+      href: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('href'),
+      },
+      uuid: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('uuid'),
+      },
+      isSameWork: {
+        default: undefined,
+        parseHTML: (element) =>
+          element.getAttribute('data-same-work') === 'true',
+      },
+      subtype: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-subtype'),
+      },
+      linkToh: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-link-toh'),
+      },
+      toh: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-toh'),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'a[type="internalLink"]' }];
+  },
+
+  renderHTML({ mark, HTMLAttributes }) {
+    const href = safeHref(mark.attrs.href as string | null | undefined);
+    const {
+      entity,
+      type: entityType,
+      uuid,
+      isSameWork,
+      subtype,
+      linkToh,
+      toh,
+    } = mark.attrs as Record<string, string | boolean | undefined>;
+
+    const attrs: Record<string, string> = {
+      class: cn(LINK_STYLE, typeof toh === 'string' ? toh : undefined),
+      type: 'internalLink',
+    };
+    if (entity) attrs['entity'] = String(entity);
+    if (entityType) attrs['entity-type'] = String(entityType);
+    if (uuid) attrs['uuid'] = String(uuid);
+    if (isSameWork) attrs['data-same-work'] = 'true';
+    if (subtype) attrs['data-subtype'] = String(subtype);
+    if (linkToh) attrs['data-link-toh'] = String(linkToh);
+
+    if (!href) {
+      return ['span', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, attrs), 0];
+    }
+
+    return [
+      'a',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        ...attrs,
+        href,
+      }),
+      0,
+    ];
+  },
+});
+
+export default InternalLinkSSR;

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
@@ -1,13 +1,9 @@
-import { Mark, mergeAttributes } from '@tiptap/core';
 import { v4 as uuidv4 } from 'uuid';
 import { createMarkViewDom, registerEditorElement } from '../../util';
 import { PANEL_FOR_SECTION, TAB_FOR_SECTION } from '../../../shared/types';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { LINK_STYLE } from '@eightyfourthousand/design-system';
-
-export interface InternalLinkOptions {
-  HTMLAttributes: Record<string, unknown>;
-}
+import { InternalLinkSSR } from './InternalLink.ssr';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -18,60 +14,7 @@ declare module '@tiptap/core' {
   }
 }
 
-export const InternalLink = Mark.create<InternalLinkOptions>({
-  name: 'internalLink',
-  addAttributes() {
-    return {
-      entity: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('entity'),
-      },
-      type: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('entity-type'),
-      },
-      href: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('href'),
-      },
-      uuid: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('uuid'),
-      },
-      isSameWork: {
-        default: undefined,
-        parseHTML: (element) =>
-          element.getAttribute('data-same-work') === 'true',
-      },
-      subtype: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('data-subtype'),
-      },
-      linkToh: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('data-link-toh'),
-      },
-    };
-  },
-  addOptions() {
-    return {
-      HTMLAttributes: {},
-    };
-  },
-  parseHTML() {
-    return [
-      {
-        tag: 'a[type="internalLink"]',
-      },
-    ];
-  },
-  renderHTML({ HTMLAttributes }) {
-    return [
-      'a',
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
-      0,
-    ];
-  },
+export const InternalLink = InternalLinkSSR.extend({
   addMarkView() {
     return (props) => {
       const isEditable = props.editor.isEditable;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ssr.ts
@@ -14,10 +14,6 @@ export const LinkSSR = TipTapLink.extend({
   },
 
   addMarkView: undefined,
-  addCommands: undefined,
-  addProseMirrorPlugins: undefined,
-  addPasteRules: undefined,
-  addInputRules: undefined,
 
   renderHTML({ mark, HTMLAttributes }) {
     const href = safeHref(mark.attrs.href as string | null | undefined);

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ssr.ts
@@ -1,0 +1,47 @@
+import { Link as TipTapLink } from '@tiptap/extension-link';
+import { mergeAttributes } from '@tiptap/core';
+import { safeHref } from '@eightyfourthousand/lib-utils';
+
+export const LinkSSR = TipTapLink.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      uuid: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('uuid'),
+      },
+    };
+  },
+
+  addMarkView: undefined,
+  addCommands: undefined,
+  addProseMirrorPlugins: undefined,
+  addPasteRules: undefined,
+  addInputRules: undefined,
+
+  renderHTML({ mark, HTMLAttributes }) {
+    const href = safeHref(mark.attrs.href as string | null | undefined);
+    const uuid = mark.attrs.uuid as string | undefined;
+
+    if (!href) {
+      return [
+        'span',
+        mergeAttributes(HTMLAttributes, uuid ? { uuid } : {}),
+        0,
+      ];
+    }
+
+    return [
+      'a',
+      mergeAttributes(HTMLAttributes, {
+        href,
+        target: '_blank',
+        rel: 'noreferrer noopener',
+        ...(uuid ? { uuid } : {}),
+      }),
+      0,
+    ];
+  },
+});
+
+export default LinkSSR;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ts
@@ -1,17 +1,8 @@
-import { Link as TipTapLink } from '@tiptap/extension-link';
 import { v4 as uuidv4 } from 'uuid';
 import { createMarkViewDom, registerEditorElement } from '../../util';
+import { LinkSSR } from './Link.ssr';
 
-export const Link = TipTapLink.extend({
-  addAttributes() {
-    return {
-      ...this.parent?.(),
-      uuid: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('uuid'),
-      },
-    };
-  },
+export const Link = LinkSSR.extend({
   addCommands() {
     const name = this.name;
     return {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -1,0 +1,100 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+import { safeHref } from '@eightyfourthousand/lib-utils';
+
+export interface MentionSSROptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+interface MentionItem {
+  uuid?: string;
+  entity?: string;
+  linkType?: string;
+  text?: string;
+  displayText?: string;
+  isSameWork?: boolean;
+  subtype?: string;
+  linkToh?: string;
+}
+
+const isMentionItem = (value: unknown): value is MentionItem => {
+  return !!value && typeof value === 'object';
+};
+
+export const MentionSSR = Node.create<MentionSSROptions>({
+  name: 'mention',
+  group: 'inline',
+  inline: true,
+  atom: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      items: {
+        default: [],
+        parseHTML: (element) => {
+          const itemsAttr = element.getAttribute('data-items');
+          if (!itemsAttr) return [];
+          try {
+            return JSON.parse(itemsAttr);
+          } catch {
+            return [];
+          }
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-type="mention"]' }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const raw = node.attrs.items;
+    const items: MentionItem[] = Array.isArray(raw) ? raw.filter(isMentionItem) : [];
+
+    const children = items.map((item) => {
+      const label = item.text || item.displayText || item.entity || '';
+
+      if (!item.entity || !item.linkType) {
+        return ['span', { class: 'mention-link pe-1' }, label] as unknown;
+      }
+
+      const href = safeHref(`/entity/${item.linkType}/${item.entity}`);
+      const attrs: Record<string, string> = { class: 'mention-link pe-1' };
+      if (item.uuid) attrs['uuid'] = item.uuid;
+      if (item.entity) attrs['entity'] = item.entity;
+      if (item.linkType) attrs['entity-type'] = item.linkType;
+
+      if (item.isSameWork) {
+        attrs['href'] = '#';
+        attrs['data-same-work'] = 'true';
+        if (item.subtype) attrs['data-subtype'] = item.subtype;
+        if (item.linkToh) attrs['data-link-toh'] = item.linkToh;
+      } else if (href) {
+        attrs['href'] = href;
+        attrs['target'] = '_blank';
+        attrs['rel'] = 'noreferrer noopener';
+      } else {
+        return ['span', { class: 'mention-link pe-1' }, label] as unknown;
+      }
+
+      return ['a', attrs, label] as unknown;
+    });
+
+    return [
+      'span',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        class: 'mention-container',
+        'data-type': 'mention',
+      }),
+      ...children,
+    ];
+  },
+});
+
+export default MentionSSR;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -1,11 +1,7 @@
-import { Node, mergeAttributes } from '@tiptap/core';
 import { v4 as uuidv4 } from 'uuid';
 import { registerEditorElement } from '../../util';
 import { PANEL_FOR_SECTION, TAB_FOR_SECTION } from '../../../shared/types';
-
-export interface MentionOptions {
-  HTMLAttributes: Record<string, unknown>;
-}
+import { MentionSSR } from './Mention.ssr';
 
 export interface MentionItem {
   uuid: string;
@@ -26,50 +22,7 @@ declare module '@tiptap/core' {
   }
 }
 
-export const Mention = Node.create<MentionOptions>({
-  name: 'mention',
-  group: 'inline',
-  inline: true,
-  atom: true,
-
-  addOptions() {
-    return {
-      HTMLAttributes: {},
-    };
-  },
-
-  addAttributes() {
-    return {
-      items: {
-        default: [],
-        parseHTML: (element) => {
-          const itemsAttr = element.getAttribute('data-items');
-          if (itemsAttr) {
-            try {
-              return JSON.parse(itemsAttr);
-            } catch {
-              return [];
-            }
-          }
-          return [];
-        },
-      },
-    };
-  },
-
-  parseHTML() {
-    return [{ tag: 'span[data-type="mention"]' }];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    return [
-      'span',
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-        'data-type': 'mention',
-      }),
-    ];
-  },
-
+export const Mention = MentionSSR.extend({
   addNodeView() {
     return (props) => {
       const isEditable = props.editor.isEditable;

--- a/libs/lib-utils/src/index.ts
+++ b/libs/lib-utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/style';
 export * from './lib/highlight';
 export * from './lib/hooks';
 export * from './lib/string';
+export * from './lib/url';

--- a/libs/lib-utils/src/lib/url.spec.ts
+++ b/libs/lib-utils/src/lib/url.spec.ts
@@ -1,0 +1,38 @@
+import { safeHref } from './url';
+
+describe('safeHref', () => {
+  it('returns undefined for empty/missing input', () => {
+    expect(safeHref(undefined)).toBeUndefined();
+    expect(safeHref(null)).toBeUndefined();
+    expect(safeHref('')).toBeUndefined();
+    expect(safeHref('   ')).toBeUndefined();
+  });
+
+  it('allows relative paths', () => {
+    expect(safeHref('/foo')).toBe('/foo');
+    expect(safeHref('/foo/bar?q=1')).toBe('/foo/bar?q=1');
+  });
+
+  it('allows hash links', () => {
+    expect(safeHref('#anchor')).toBe('#anchor');
+  });
+
+  it('allows http(s) and mailto', () => {
+    expect(safeHref('http://example.com')).toBe('http://example.com');
+    expect(safeHref('https://example.com/path')).toBe('https://example.com/path');
+    expect(safeHref('mailto:a@b.co')).toBe('mailto:a@b.co');
+  });
+
+  it('rejects unsafe protocols', () => {
+    expect(safeHref('javascript:alert(1)')).toBeUndefined();
+    expect(safeHref('  JavaScript:alert(1)')).toBeUndefined();
+    expect(safeHref('data:text/html,<script>')).toBeUndefined();
+    expect(safeHref('vbscript:msgbox')).toBeUndefined();
+    expect(safeHref('file:///etc/passwd')).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace before evaluating', () => {
+    expect(safeHref('  https://example.com  ')).toBe('https://example.com');
+    expect(safeHref('  /foo  ')).toBe('/foo');
+  });
+});

--- a/libs/lib-utils/src/lib/url.ts
+++ b/libs/lib-utils/src/lib/url.ts
@@ -1,0 +1,25 @@
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
+
+export const safeHref = (
+  href: string | null | undefined,
+): string | undefined => {
+  if (!href) return undefined;
+
+  const trimmed = href.trim();
+  if (!trimmed) return undefined;
+
+  if (trimmed.startsWith('/') || trimmed.startsWith('#')) {
+    return trimmed;
+  }
+
+  try {
+    const parsed = new URL(trimmed, 'https://placeholder.invalid');
+    if (SAFE_PROTOCOLS.has(parsed.protocol.toLowerCase())) {
+      return trimmed;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
### Summary

As a follow-up to DEV-633, create variants for all marks with client-side functionality that can be rendered well on the backend for SEO. This includes:

- EndNoteLink
- GlossaryInstance
- InternalLink
- Link
- Mention

There is no functional change, but it consolidates a pattern where the SSR node or mark serves as the base that the client-only version extends.

### Linear

- [DEV-631](https://linear.app/84000/issue/DEV-631)