### PR TITLE
SSR Content in Main Panel

### DIFF
--- a/libs/lib-editing/src/lib/components/reader/TranslationReader.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationReader.tsx
@@ -1,8 +1,33 @@
 'use client';
 
+import { cn } from '@eightyfourthousand/lib-utils';
 import { TranslationEditor } from '../editor';
-import { PaginationProvider } from '../editor/PaginationProvider';
+import { PaginationProvider, usePagination } from '../editor/PaginationProvider';
 import { TranslationRenderer, useNavigation } from '../shared';
+import { TranslationSSRContent } from './TranslationSSRContent';
+import type { TranslationEditorContent } from '../editor';
+
+const ReaderBody = ({
+  content,
+  className,
+}: {
+  content: TranslationEditorContent;
+  className?: string;
+}) => {
+  const { editor } = usePagination();
+
+  if (!editor) {
+    return (
+      <div className={cn('flex h-full', className)}>
+        <div className="relative flex flex-col flex-1 h-full">
+          <TranslationSSRContent content={content} className="flex-1" />
+        </div>
+      </div>
+    );
+  }
+
+  return <TranslationEditor className={className} />;
+};
 
 export const TranslationReader = ({
   content,
@@ -22,7 +47,7 @@ export const TranslationReader = ({
       content={content}
       isEditable={false}
     >
-      <TranslationEditor className={className} />
+      <ReaderBody content={content} className={className} />
     </PaginationProvider>
   );
 };

--- a/libs/lib-editing/src/lib/components/reader/TranslationReader.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationReader.tsx
@@ -2,7 +2,10 @@
 
 import { cn } from '@eightyfourthousand/lib-utils';
 import { TranslationEditor } from '../editor';
-import { PaginationProvider, usePagination } from '../editor/PaginationProvider';
+import {
+  PaginationProvider,
+  usePagination,
+} from '../editor/PaginationProvider';
 import { TranslationRenderer, useNavigation } from '../shared';
 import { TranslationSSRContent } from './TranslationSSRContent';
 import type { TranslationEditorContent } from '../editor';


### PR DESCRIPTION
### Summary

Use SEO-friendly content on initial page load, and replace it after hydration with full functionality.

In this initial pass, it is only applied to the center column in the reader. It is not used in the editor since it is not publicly accessible.

### Linear

- [DEV-634](https://linear.app/84000/issue/DEV-634)
