### PR TITLE
SSR in Right Panel

### DIFF
--- a/apps/web-reader/src/app/[slug]/layout.tsx
+++ b/apps/web-reader/src/app/[slug]/layout.tsx
@@ -1,23 +1,33 @@
 import { ReaderLayout, TranslationSkeleton } from '@eightyfourthousand/lib-editing';
 import {
   generateMetadata,
+  hasBodyTranslationContent,
   TranslationStructuredData,
 } from '@eightyfourthousand/lib-editing/ssr';
 import { ReactNode, Suspense } from 'react';
+import { isUuid } from '@eightyfourthousand/lib-utils';
 
 export { generateMetadata };
 
-const Layout = (props: {
+const Layout = async (props: {
   left: ReactNode;
   main: ReactNode;
   right: ReactNode;
   params: Promise<{ slug: string }>;
 }) => {
+  const { slug } = await props.params;
+  const initialHasTranslationContent = isUuid(slug)
+    ? await hasBodyTranslationContent({ uuid: slug })
+    : true;
+
   return (
     <>
       <TranslationStructuredData params={props.params} />
       <Suspense fallback={<TranslationSkeleton />}>
-        <ReaderLayout {...props} />
+        <ReaderLayout
+          {...props}
+          initialHasTranslationContent={initialHasTranslationContent}
+        />
       </Suspense>
     </>
   );

--- a/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPanel.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPanel.tsx
@@ -7,7 +7,6 @@ import { BackMatterPanel } from '../shared/BackMatterPanel';
 import { TranslationRenderer } from '../shared/types';
 import { TranslationReader } from '.';
 import { TranslationEditorContent } from '../editor';
-import { useNavigation } from '../shared/NavigationProvider';
 
 export const ReaderBackMatterPanel = ({
   workUuid,
@@ -24,11 +23,6 @@ export const ReaderBackMatterPanel = ({
   abbreviations: TranslationEditorContent;
   withAttestations?: boolean;
 }) => {
-  const { hasTranslationContent } = useNavigation();
-  if (!hasTranslationContent) {
-    return null;
-  }
-
   const renderTranslation = useCallback(
     ({ content, name, className }: TranslationRenderer) => (
       <TranslationReader

--- a/libs/lib-editing/src/lib/components/reader/ReaderLayout.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderLayout.tsx
@@ -16,16 +16,21 @@ export const ReaderLayout = ({
   main,
   right,
   params,
+  initialHasTranslationContent,
 }: {
   withHeader?: boolean;
   left: ReactNode;
   main: ReactNode;
   right: ReactNode;
   params: Promise<{ slug: string }>;
+  initialHasTranslationContent?: boolean;
 }) => {
   const { slug } = use(params);
   return (
-    <NavigationProvider uuid={slug}>
+    <NavigationProvider
+      uuid={slug}
+      initialHasTranslationContent={initialHasTranslationContent}
+    >
       <ThreeColumnRenderer withHeader={withHeader}>
         <LeftPanel>{left}</LeftPanel>
         <MainPanelHeader>

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
@@ -1,4 +1,5 @@
 import type { Extensions, JSONContent } from '@tiptap/core';
+import { getSchema } from '@tiptap/core';
 import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string';
 import { translationSSRExtensions } from '../editor/extensions/translationSSRExtensions';
 import { extractPlainText } from './ssr-text-fallback';
@@ -40,7 +41,14 @@ const collectTypes = (
 };
 
 const assertCoverage = (doc: JSONContent, extensions: Extensions) => {
-  const known = new Set(extensions.map((e) => e.name));
+  // Resolve bundles like StarterKit into their constituent node/mark specs so
+  // the coverage check sees blockquote, code, hardBreak, etc. that are
+  // registered indirectly.
+  const schema = getSchema(extensions);
+  const known = new Set([
+    ...Object.keys(schema.nodes),
+    ...Object.keys(schema.marks),
+  ]);
   const nodeTypes = new Set<string>();
   const markTypes = new Set<string>();
   collectTypes(doc, nodeTypes, markTypes);

--- a/libs/lib-editing/src/lib/components/reader/has-body-translation-content.ts
+++ b/libs/lib-editing/src/lib/components/reader/has-body-translation-content.ts
@@ -1,0 +1,20 @@
+import {
+  BODY_MATTER_FILTER,
+  createBuildGraphQLClient,
+  getTranslationBlocks,
+} from '@eightyfourthousand/client-graphql/ssr';
+
+export const hasBodyTranslationContent = async ({
+  uuid,
+}: {
+  uuid: string;
+}): Promise<boolean> => {
+  const client = createBuildGraphQLClient();
+  const { blocks } = await getTranslationBlocks({
+    client,
+    uuid,
+    type: BODY_MATTER_FILTER,
+    maxPassages: 1,
+  });
+  return blocks.length > 0;
+};

--- a/libs/lib-editing/src/lib/components/reader/ssr.ts
+++ b/libs/lib-editing/src/lib/components/reader/ssr.ts
@@ -2,3 +2,4 @@ export { ReaderBodyPage } from './ReaderBodyPage';
 export { ReaderLeftPanelPage } from './ReaderLeftPanelPage';
 export { ReaderBackMatterPage } from './ReaderBackMatterPage';
 export { TranslationSSRContent } from './TranslationSSRContent';
+export { hasBodyTranslationContent } from './has-body-translation-content';

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -74,9 +74,11 @@ const parsePanelParams = (
 
 export const NavigationProvider = ({
   uuid,
+  initialHasTranslationContent = true,
   children,
 }: {
   uuid: string;
+  initialHasTranslationContent?: boolean;
   children: ReactNode;
 }) => {
   const graphqlClient = createGraphQLClient();
@@ -88,7 +90,9 @@ export const NavigationProvider = ({
   const isPanelTransitioning = useRef(false);
   const [toh, setToh] = useState<TohokuCatalogEntry | undefined>();
   const [showOuterContent, setShowOuterContent] = useState(true);
-  const [hasTranslationContent, setHasTranslationContent] = useState(true);
+  const [hasTranslationContent, setHasTranslationContent] = useState(
+    initialHasTranslationContent,
+  );
   const [imprint, setImprint] = useState<Imprint | undefined>();
   const bibliographyCache = useRef<{ [uuid: string]: BibliographyEntryItem }>(
     {},


### PR DESCRIPTION
### Summary

The right slot's BackMatterPanel and the ThreeColumnRenderer gate
visibility on hasTranslationContent. The flag defaulted to true on the
server and was corrected from a body-panel useEffect, so works without
body matter rendered the right column briefly before collapsing it.
Probe body matter on the server and seed NavigationProvider with the
correct initial value, so left/main/right slots hydrate without a flash.

Also drop the `if (\!hasTranslationContent) return null` short-circuit in
ReaderBackMatterPanel — it preceded a useCallback, making hook order
conditional. The column-level gate in ThreeColumnRenderer already hides
the slot when there is no translation content.


### Linear

- [DEV-637](https://linear.app/84000/issue/DEV-637)
