### PR TITLE
Hold SSR Content Until Editor Is Ready (DEV-636)

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -67,6 +67,7 @@ interface PaginationContextState {
   endCursor?: string;
   startCursor?: string;
   editor?: Editor;
+  isEditorReady?: boolean;
 }
 
 export const PaginationContext = createContext<PaginationContextState>({});
@@ -450,6 +451,7 @@ export const PaginationProvider = ({
         startCursor,
         endCursor,
         editor,
+        isEditorReady,
       }}
     >
       {startCursor && (

--- a/libs/lib-editing/src/lib/components/reader/TranslationReader.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationReader.tsx
@@ -17,9 +17,9 @@ const ReaderBody = ({
   content: TranslationEditorContent;
   className?: string;
 }) => {
-  const { editor } = usePagination();
+  const { editor, isEditorReady } = usePagination();
 
-  if (!editor) {
+  if (!editor || !isEditorReady) {
     return (
       <div className={cn('flex h-full', className)}>
         <div className="relative flex flex-col flex-1 h-full">


### PR DESCRIPTION
### Summary

Gate the `TranslationReader` swap from `TranslationSSRContent` → `TranslationEditor` on `isEditorReady` (set after TipTap's `setContent` in `PaginationProvider`'s `onCreate`) instead of merely on the editor instance existing. Also expose `isEditorReady` through `PaginationContext` so the reader can consume it. Eliminates the hydration flash where the trailing pagination skeleton briefly became the only visible content because the editor instance attached before its doc was populated.

### Linear

- [DEV-636](https://linear.app/84000/issue/DEV-636)

### Notes

- Validation results (crawlability, noindex on restricted work, bounded chunks, no flash) are captured in the DEV-636 Linear comment.
- Test plan:
  - `npx nx dev web-reader --no-tui` → open `/46100652-463b-4aaa-b2cf-629221f46bfb`; confirm SSR text stays continuously visible through hydration.
  - `npx nx typecheck lib-editing && npx nx typecheck web-reader`.
  - `curl` the route; confirm `<meta name="robots" content="noindex, follow">` for the restricted test work, and `index, follow` on a public work.