### PR TITLE
Work XML ID redirect

### DIFF
--- a/apps/web-reader/src/proxy.ts
+++ b/apps/web-reader/src/proxy.ts
@@ -1,27 +1,22 @@
-import { getWorkUuidByToh } from '@eightyfourthousand/data-access';
-import { createServerClient } from '@eightyfourthousand/data-access/ssr';
+import {
+  isTohRequest,
+  isXmlidRequest,
+  redirectOnToh,
+  redirectOnXmlid,
+} from '@eightyfourthousand/lib-editing';
 import { type NextRequest, NextResponse } from 'next/server';
 
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
   // match tohoku catalog shortlinks like /toh1234
-  if (pathname.match(/^\/toh\d+/)) {
-    const url = request.nextUrl.clone();
-    const toh = pathname.split('/')[1]?.split('.')[0];
+  if (isTohRequest(pathname)) {
+    return redirectOnToh(pathname, request);
+  }
 
-    if (toh) {
-      const client = await createServerClient();
-      const workUuid = await getWorkUuidByToh({ client, toh });
-
-      if (!workUuid) {
-        return NextResponse.next();
-      }
-
-      url.pathname = `/${workUuid}`;
-      url.searchParams.set('toh', toh);
-      return NextResponse.redirect(url);
-    }
+  // match xmlid shortlinks like /UT22084-001-001
+  if (isXmlidRequest(pathname)) {
+    return redirectOnXmlid(pathname, request);
   }
 
   const isKnowledgeBase = pathname.startsWith('/knowledgebase');

--- a/libs/data-access/src/lib/publications.ts
+++ b/libs/data-access/src/lib/publications.ts
@@ -60,6 +60,29 @@ export const getWorkUuidByToh = async ({
   return data.work_uuid ?? null;
 };
 
+export const getWorkUuidByXmlid = async ({
+  client,
+  xmlid,
+}: {
+  client: DataClient;
+  xmlid: string;
+}): Promise<string | null> => {
+  const { data, error } = await client
+    .from('works')
+    .select('uuid')
+    .eq('xmlId', xmlid)
+    .single();
+
+  if (error || !data) {
+    if (error) {
+      console.error('Error fetching work UUID by XMLID:', error);
+    }
+    return null;
+  }
+
+  return data.uuid ?? null;
+};
+
 export const getTranslationPassages = async ({
   client,
   uuid,

--- a/libs/lib-editing/src/lib/components/shared/index.ts
+++ b/libs/lib-editing/src/lib/components/shared/index.ts
@@ -7,5 +7,6 @@ export * from './TranslationSkeleton';
 export * from './TranslationTable';
 export * from './bibliography';
 export * from './glossary';
+export * from './redirects';
 export * from './titles';
 export * from './types';

--- a/libs/lib-editing/src/lib/components/shared/redirects.ts
+++ b/libs/lib-editing/src/lib/components/shared/redirects.ts
@@ -1,0 +1,57 @@
+import {
+  getWorkUuidByToh,
+  getWorkUuidByXmlid,
+} from '@eightyfourthousand/data-access';
+import { createServerClient } from '@eightyfourthousand/data-access/ssr';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const isTohRequest = (pathname: string) => {
+  return pathname.match(/^\/toh\d+/);
+};
+
+export const isXmlidRequest = (pathname: string) => {
+  return pathname.match(/^\/UT(?:22084|23703)-\d{3}-\d{3}/i);
+};
+
+export const redirectOnToh = async (pathname: string, request: NextRequest) => {
+  const url = request.nextUrl.clone();
+  const toh = pathname.split('/')[1]?.split('.')[0];
+
+  if (!toh) {
+    return NextResponse.next();
+  }
+
+  const client = await createServerClient();
+  const workUuid = await getWorkUuidByToh({ client, toh });
+
+  if (!workUuid) {
+    return NextResponse.next();
+  }
+
+  url.pathname = `/${workUuid}`;
+  url.searchParams.set('toh', toh);
+  return NextResponse.redirect(url);
+};
+
+export const redirectOnXmlid = async (
+  pathname: string,
+  request: NextRequest,
+) => {
+  const url = request.nextUrl.clone();
+  const xmlid = pathname.split('/')[1]?.split('.')[0];
+
+  if (!xmlid) {
+    return NextResponse.next();
+  }
+
+  const client = await createServerClient();
+  const workUuid = await getWorkUuidByXmlid({ client, xmlid });
+
+  if (!workUuid) {
+    return NextResponse.next();
+  }
+
+  url.pathname = `/${workUuid}`;
+  url.searchParams.set('xmlid', xmlid);
+  return NextResponse.redirect(url);
+};


### PR DESCRIPTION
### Summary

Provide a redirect utility function for Tohoku and XML ID slugs. The former was already supported but was defined with `web-reader`. Now it is exported in `lib-editing`.

### Linear

- [DEV-657](https://linear.app/84000/issue/DEV-657)

### Notes

A follow-up PR will address arbitrary xml ids in the url hash (beyond passage id, which is currently supported)
