### PR TITLE
Gdamron/dev 667 general entity lookup

### DIFF
--- a/apps/api-graphql/src/graphql/resolvers.ts
+++ b/apps/api-graphql/src/graphql/resolvers.ts
@@ -13,6 +13,7 @@ import {
   glossaryTermPassagesPageResolver,
 } from './schema/glossary/glossary.resolver';
 import { healthQueries } from './schema/health/health.query';
+import { lookupQueries } from './schema/lookup/lookup.query';
 import { passageQueries } from './schema/passage/passage.query';
 import {
   replaceMutation,
@@ -36,6 +37,7 @@ export const resolvers = {
 
   Query: {
     ...healthQueries,
+    ...lookupQueries,
     ...passageQueries,
     ...userQueries,
     ...workQueries,

--- a/apps/api-graphql/src/graphql/schema/lookup/lookup.graphql
+++ b/apps/api-graphql/src/graphql/schema/lookup/lookup.graphql
@@ -1,0 +1,24 @@
+enum LookupEntityType {
+  work
+  passage
+  glossary
+  bibliography
+}
+
+type LookupResult {
+  uuid: ID!
+  type: LookupEntityType!
+}
+
+extend type Query {
+  """
+  Resolve a known entity identifier to its canonical UUID and type.
+  Identifier precedence is toh, uuid, then xmlId.
+  """
+  lookup(
+    toh: String
+    uuid: ID
+    xmlId: String
+    type: LookupEntityType
+  ): LookupResult
+}

--- a/apps/api-graphql/src/graphql/schema/lookup/lookup.query.ts
+++ b/apps/api-graphql/src/graphql/schema/lookup/lookup.query.ts
@@ -1,0 +1,23 @@
+import { lookup } from '@eightyfourthousand/data-access';
+import type { GraphQLContext } from '../../context';
+
+export const lookupQueries = {
+  lookup: async (
+    _parent: unknown,
+    args: {
+      toh?: string | null;
+      uuid?: string | null;
+      xmlId?: string | null;
+      type?: string | null;
+    },
+    ctx: GraphQLContext,
+  ) => {
+    return lookup({
+      client: ctx.supabase,
+      toh: args.toh,
+      uuid: args.uuid,
+      xmlId: args.xmlId,
+      type: args.type,
+    });
+  },
+};

--- a/libs/client-graphql/src/index.ts
+++ b/libs/client-graphql/src/index.ts
@@ -8,6 +8,9 @@ export {
 // Functions
 export {
   getPassage,
+  lookup,
+  type LookupEntityType,
+  type LookupResult,
   getTranslationBlocks,
   getTranslationBlocksAround,
   getTranslationTitles,

--- a/libs/client-graphql/src/lib/functions/index.ts
+++ b/libs/client-graphql/src/lib/functions/index.ts
@@ -1,4 +1,5 @@
 export { getPassage } from './get-passage';
+export { lookup, type LookupEntityType, type LookupResult } from './lookup';
 export {
   getTranslationBlocks,
   type TranslationBlocksPage,
@@ -23,7 +24,10 @@ export {
   searchWorkGlossaryTerms,
   type GlossaryTermSearchResult,
 } from './search-work-glossary-terms';
-export { getTermPassages, type GlossaryPassagesPage } from './get-term-passages';
+export {
+  getTermPassages,
+  type GlossaryPassagesPage,
+} from './get-term-passages';
 export { getBibliographyEntry } from './get-bibliography-entry';
 export { getWorkBibliography } from './get-work-bibliography';
 export { getWorkFolios } from './get-work-folios';

--- a/libs/client-graphql/src/lib/functions/lookup.ts
+++ b/libs/client-graphql/src/lib/functions/lookup.ts
@@ -1,0 +1,55 @@
+import type { GraphQLClient } from 'graphql-request';
+import { gql } from 'graphql-request';
+
+export type LookupEntityType = 'work' | 'passage' | 'glossary' | 'bibliography';
+
+export type LookupResult = {
+  uuid: string;
+  type: LookupEntityType;
+};
+
+const LOOKUP = gql`
+  query Lookup(
+    $toh: String
+    $uuid: ID
+    $xmlId: String
+    $type: LookupEntityType
+  ) {
+    lookup(toh: $toh, uuid: $uuid, xmlId: $xmlId, type: $type) {
+      uuid
+      type
+    }
+  }
+`;
+
+type LookupResponse = {
+  lookup: LookupResult | null;
+};
+
+export async function lookup({
+  client,
+  toh,
+  uuid,
+  xmlId,
+  type,
+}: {
+  client: GraphQLClient;
+  toh?: string;
+  uuid?: string;
+  xmlId?: string;
+  type?: LookupEntityType;
+}): Promise<LookupResult | null> {
+  try {
+    const response = await client.request<LookupResponse>(LOOKUP, {
+      toh,
+      uuid,
+      xmlId,
+      type,
+    });
+
+    return response.lookup;
+  } catch (error) {
+    console.error('Error looking up entity:', error);
+    return null;
+  }
+}

--- a/libs/client-graphql/src/lib/generated/graphql.ts
+++ b/libs/client-graphql/src/lib/generated/graphql.ts
@@ -231,6 +231,18 @@ export type License = {
   name?: Maybe<Scalars['String']['output']>;
 };
 
+export type LookupEntityType =
+  | 'bibliography'
+  | 'glossary'
+  | 'passage'
+  | 'work';
+
+export type LookupResult = {
+  __typename?: 'LookupResult';
+  type: LookupEntityType;
+  uuid: Scalars['ID']['output'];
+};
+
 /** Root Mutation type - extend this in other schema files */
 export type Mutation = {
   __typename?: 'Mutation';
@@ -258,6 +270,7 @@ export type MutationReplaceArgs = {
   searchText: Scalars['String']['input'];
   targetUuids: Array<Scalars['ID']['input']>;
   type?: InputMaybe<ReplaceType>;
+  useRegex?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
@@ -417,6 +430,11 @@ export type Query = {
   hasPermission: Scalars['Boolean']['output'];
   /** Health check query */
   health: HealthStatus;
+  /**
+   * Resolve a known entity identifier to its canonical UUID and type.
+   * Identifier precedence is toh, uuid, then xmlId.
+   */
+  lookup?: Maybe<LookupResult>;
   /** Get the currently authenticated user (null if not authenticated) */
   me?: Maybe<CurrentUser>;
   /**
@@ -460,6 +478,15 @@ export type QueryGlossaryTermPassagesArgs = {
 /** Root Query type - extend this in other schema files */
 export type QueryHasPermissionArgs = {
   permission: Permission;
+};
+
+
+/** Root Query type - extend this in other schema files */
+export type QueryLookupArgs = {
+  toh?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<LookupEntityType>;
+  uuid?: InputMaybe<Scalars['ID']['input']>;
+  xmlId?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -518,6 +545,8 @@ export type SavePassagesResult = {
   deletedCount?: Maybe<Scalars['Int']['output']>;
   /** Error message if the save failed */
   error?: Maybe<Scalars['String']['output']>;
+  /** Saved passages (after server-side normalization), used for client-side refresh. */
+  passages: Array<Passage>;
   /** Number of passages saved */
   savedCount: Scalars['Int']['output'];
   /** Whether the save was successful */
@@ -653,10 +682,7 @@ export type Work = {
   publicationVersion: Scalars['String']['output'];
   /** Whether access to this work is restricted */
   restriction: Scalars['Boolean']['output'];
-  /**
-   * Search glossary term instances for this work by English term (ILIKE prefix
-   * match, also searching alternatives). Results are ordered by term_number.
-   */
+  /** Search glossary term instances for this work by English term. Results are ordered by term_number. */
   searchGlossaryTerms: Array<GlossaryTermInstance>;
   /** Section of the canon this work belongs to */
   section: Scalars['String']['output'];
@@ -803,6 +829,16 @@ export type TocFieldsFragment = { __typename?: 'Toc', frontMatter: Array<(
   )> };
 
 export type WorkFieldsFragment = { __typename?: 'Work', uuid: string, title: string, toh: Array<string>, publicationDate?: string | null, publicationVersion: string, pages: number, restriction: boolean, section: string };
+
+export type LookupQueryVariables = Exact<{
+  toh?: InputMaybe<Scalars['String']['input']>;
+  uuid?: InputMaybe<Scalars['ID']['input']>;
+  xmlId?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<LookupEntityType>;
+}>;
+
+
+export type LookupQuery = { __typename?: 'Query', lookup?: { __typename?: 'LookupResult', uuid: string, type: LookupEntityType } | null };
 
 export type GetPassagesQueryVariables = Exact<{
   uuid: Scalars['ID']['input'];
@@ -1101,6 +1137,14 @@ export const WorkFieldsFragmentDoc = gql`
   section
 }
     `;
+export const LookupDocument = gql`
+    query Lookup($toh: String, $uuid: ID, $xmlId: String, $type: LookupEntityType) {
+  lookup(toh: $toh, uuid: $uuid, xmlId: $xmlId, type: $type) {
+    uuid
+    type
+  }
+}
+    `;
 export const GetPassagesDocument = gql`
     query GetPassages($uuid: ID!, $cursor: String, $limit: Int, $direction: PaginationDirection, $filter: PassageFilter) {
   work(uuid: $uuid) {
@@ -1271,6 +1315,9 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
+    Lookup(variables?: LookupQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<LookupQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<LookupQuery>({ document: LookupDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'Lookup', 'query', variables);
+    },
     GetPassages(variables: GetPassagesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetPassagesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetPassagesQuery>({ document: GetPassagesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetPassages', 'query', variables);
     },

--- a/libs/client-graphql/src/lib/graphql/queries/lookup.graphql
+++ b/libs/client-graphql/src/lib/graphql/queries/lookup.graphql
@@ -1,0 +1,6 @@
+query Lookup($toh: String, $uuid: ID, $xmlId: String, $type: LookupEntityType) {
+  lookup(toh: $toh, uuid: $uuid, xmlId: $xmlId, type: $type) {
+    uuid
+    type
+  }
+}

--- a/libs/data-access/src/index.ts
+++ b/libs/data-access/src/index.ts
@@ -15,3 +15,4 @@ export * from './lib/storage';
 export * from './lib/types';
 export * from './lib/local-storage';
 export * from './lib/use-bookmark';
+export * from './lib/lookup';

--- a/libs/data-access/src/lib/lookup.spec.ts
+++ b/libs/data-access/src/lib/lookup.spec.ts
@@ -22,18 +22,31 @@ const createClient = ({
     glossaries,
     bibliographies,
   };
-  const queries: Array<{ table: string; column: string; value: string }> = [];
+  const queries: Array<{
+    table: string;
+    filters: Array<{ column: string; value: string }>;
+  }> = [];
 
   const client = {
     from: jest.fn((table: string) => ({
       select: jest.fn(() => ({
-        eq: jest.fn((column: string, value: string) => ({
-          maybeSingle: jest.fn(async () => {
-            queries.push({ table, column, value });
-            const data = tables[table]?.find((row) => row[column] === value);
-            return { data: data ?? null, error: null };
-          }),
-        })),
+        eq: jest.fn(function eq(column: string, value: string) {
+          const filters = [{ column, value }];
+          const query = {
+            eq: jest.fn((nextColumn: string, nextValue: string) => {
+              filters.push({ column: nextColumn, value: nextValue });
+              return query;
+            }),
+            maybeSingle: jest.fn(async () => {
+              queries.push({ table, filters: [...filters] });
+              const data = tables[table]?.find((row) =>
+                filters.every(({ column, value }) => row[column] === value),
+              );
+              return { data: data ?? null, error: null };
+            }),
+          };
+          return query;
+        }),
       })),
     })),
   };
@@ -58,7 +71,10 @@ describe('lookup', () => {
     ).resolves.toEqual({ uuid: 'work-uuid', type: 'work' });
 
     expect(queries).toEqual([
-      { table: 'work_toh', column: 'toh_clean', value: 'toh1' },
+      {
+        table: 'work_toh',
+        filters: [{ column: 'toh_clean', value: 'toh1' }],
+      },
     ]);
   });
 
@@ -86,13 +102,22 @@ describe('lookup', () => {
     ).resolves.toEqual({ uuid: 'glossary-uuid', type: 'glossary' });
 
     expect(queries).toEqual([
-      { table: 'glossaries', column: 'uuid', value: 'glossary-uuid' },
+      {
+        table: 'glossaries',
+        filters: [{ column: 'uuid', value: 'glossary-uuid' }],
+      },
     ]);
   });
 
   it('looks up untyped xml IDs in entity order', async () => {
     const { client, queries } = createClient({
-      glossaries: [{ uuid: 'glossary-uuid', glossary_xmlId: 'xml-id' }],
+      glossaries: [
+        {
+          uuid: 'glossary-uuid',
+          glossary_xmlId: 'xml-id',
+          termType: 'translationMain',
+        },
+      ],
       bibliographies: [{ uuid: 'bibliography-uuid', xmlId: 'xml-id' }],
     });
 
@@ -106,6 +131,29 @@ describe('lookup', () => {
       'passages',
       'glossaries',
     ]);
+    expect(queries[2]).toEqual({
+      table: 'glossaries',
+      filters: [
+        { column: 'glossary_xmlId', value: 'xml-id' },
+        { column: 'termType', value: 'translationMain' },
+      ],
+    });
+  });
+
+  it('does not return non-translation main glossary xml IDs', async () => {
+    const { client } = createClient({
+      glossaries: [
+        {
+          uuid: 'glossary-uuid',
+          glossary_xmlId: 'xml-id',
+          termType: 'other',
+        },
+      ],
+    });
+
+    await expect(
+      lookup({ client, xmlId: 'xml-id', type: 'glossary' }),
+    ).resolves.toBeNull();
   });
 
   it('returns null when no identifier is provided', async () => {

--- a/libs/data-access/src/lib/lookup.spec.ts
+++ b/libs/data-access/src/lib/lookup.spec.ts
@@ -1,0 +1,117 @@
+import { lookup } from './lookup';
+
+type Row = Record<string, string | null>;
+
+const createClient = ({
+  works = [],
+  workToh = [],
+  passages = [],
+  glossaries = [],
+  bibliographies = [],
+}: {
+  works?: Row[];
+  workToh?: Row[];
+  passages?: Row[];
+  glossaries?: Row[];
+  bibliographies?: Row[];
+}) => {
+  const tables: Record<string, Row[]> = {
+    works,
+    work_toh: workToh,
+    passages,
+    glossaries,
+    bibliographies,
+  };
+  const queries: Array<{ table: string; column: string; value: string }> = [];
+
+  const client = {
+    from: jest.fn((table: string) => ({
+      select: jest.fn(() => ({
+        eq: jest.fn((column: string, value: string) => ({
+          maybeSingle: jest.fn(async () => {
+            queries.push({ table, column, value });
+            const data = tables[table]?.find((row) => row[column] === value);
+            return { data: data ?? null, error: null };
+          }),
+        })),
+      })),
+    })),
+  };
+
+  return { client, queries };
+};
+
+describe('lookup', () => {
+  it('prefers toh over uuid and xmlId', async () => {
+    const { client, queries } = createClient({
+      workToh: [{ toh_clean: 'toh1', work_uuid: 'work-uuid' }],
+      passages: [{ uuid: 'passage-uuid', xmlId: 'xml-id' }],
+    });
+
+    await expect(
+      lookup({
+        client,
+        toh: 'toh1',
+        uuid: 'passage-uuid',
+        xmlId: 'xml-id',
+      }),
+    ).resolves.toEqual({ uuid: 'work-uuid', type: 'work' });
+
+    expect(queries).toEqual([
+      { table: 'work_toh', column: 'toh_clean', value: 'toh1' },
+    ]);
+  });
+
+  it('prefers uuid over xmlId', async () => {
+    const { client, queries } = createClient({
+      passages: [{ uuid: 'passage-uuid', xmlId: 'xml-id' }],
+      glossaries: [{ uuid: 'glossary-uuid', glossary_xmlId: 'xml-id' }],
+    });
+
+    await expect(
+      lookup({ client, uuid: 'passage-uuid', xmlId: 'xml-id' }),
+    ).resolves.toEqual({ uuid: 'passage-uuid', type: 'passage' });
+
+    expect(queries.map(({ table }) => table)).toEqual(['works', 'passages']);
+  });
+
+  it('limits lookup to the provided type', async () => {
+    const { client, queries } = createClient({
+      passages: [{ uuid: 'passage-uuid' }],
+      glossaries: [{ uuid: 'glossary-uuid' }],
+    });
+
+    await expect(
+      lookup({ client, uuid: 'glossary-uuid', type: 'glossary' }),
+    ).resolves.toEqual({ uuid: 'glossary-uuid', type: 'glossary' });
+
+    expect(queries).toEqual([
+      { table: 'glossaries', column: 'uuid', value: 'glossary-uuid' },
+    ]);
+  });
+
+  it('looks up untyped xml IDs in entity order', async () => {
+    const { client, queries } = createClient({
+      glossaries: [{ uuid: 'glossary-uuid', glossary_xmlId: 'xml-id' }],
+      bibliographies: [{ uuid: 'bibliography-uuid', xmlId: 'xml-id' }],
+    });
+
+    await expect(lookup({ client, xmlId: 'xml-id' })).resolves.toEqual({
+      uuid: 'glossary-uuid',
+      type: 'glossary',
+    });
+
+    expect(queries.map(({ table }) => table)).toEqual([
+      'works',
+      'passages',
+      'glossaries',
+    ]);
+  });
+
+  it('returns null when no identifier is provided', async () => {
+    const { client, queries } = createClient({});
+
+    await expect(lookup({ client })).resolves.toBeNull();
+    expect(queries).toEqual([]);
+  });
+});

--- a/libs/data-access/src/lib/lookup.ts
+++ b/libs/data-access/src/lib/lookup.ts
@@ -78,11 +78,13 @@ const lookupXmlIdInTable = async ({
   type: LookupEntityType;
   xmlId: string;
 }): Promise<LookupResult | null> => {
-  const { data, error } = await client
-    .from(table)
-    .select('uuid')
-    .eq(column, xmlId)
-    .maybeSingle();
+  let query = client.from(table).select('uuid').eq(column, xmlId);
+
+  if (type === 'glossary') {
+    query = query.eq('termType', 'translationMain');
+  }
+
+  const { data, error } = await query.maybeSingle();
 
   if (error) {
     console.error(`Error looking up ${type} by xmlId ${xmlId}:`, error);

--- a/libs/data-access/src/lib/lookup.ts
+++ b/libs/data-access/src/lib/lookup.ts
@@ -1,0 +1,169 @@
+import { DataClient } from './types';
+
+export const LOOKUP_ENTITY_TYPES = [
+  'work',
+  'passage',
+  'glossary',
+  'bibliography',
+] as const;
+
+export type LookupEntityType = (typeof LOOKUP_ENTITY_TYPES)[number];
+
+export type LookupResult = {
+  uuid: string;
+  type: LookupEntityType;
+};
+
+const isLookupEntityType = (
+  type: string | null | undefined,
+): type is LookupEntityType =>
+  LOOKUP_ENTITY_TYPES.includes(type as LookupEntityType);
+
+const lookupWorkByToh = async ({
+  client,
+  toh,
+}: {
+  client: DataClient;
+  toh: string;
+}): Promise<LookupResult | null> => {
+  const { data, error } = await client
+    .from('work_toh')
+    .select('work_uuid')
+    .eq('toh_clean', toh)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`Error looking up work by toh ${toh}:`, error);
+    return null;
+  }
+
+  return data?.work_uuid ? { uuid: data.work_uuid, type: 'work' } : null;
+};
+
+const lookupUuidInTable = async ({
+  client,
+  table,
+  type,
+  uuid,
+}: {
+  client: DataClient;
+  table: string;
+  type: LookupEntityType;
+  uuid: string;
+}): Promise<LookupResult | null> => {
+  const { data, error } = await client
+    .from(table)
+    .select('uuid')
+    .eq('uuid', uuid)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`Error looking up ${type} by uuid ${uuid}:`, error);
+    return null;
+  }
+
+  return data?.uuid ? { uuid: data.uuid, type } : null;
+};
+
+const lookupXmlIdInTable = async ({
+  client,
+  table,
+  column,
+  type,
+  xmlId,
+}: {
+  client: DataClient;
+  table: string;
+  column: string;
+  type: LookupEntityType;
+  xmlId: string;
+}): Promise<LookupResult | null> => {
+  const { data, error } = await client
+    .from(table)
+    .select('uuid')
+    .eq(column, xmlId)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`Error looking up ${type} by xmlId ${xmlId}:`, error);
+    return null;
+  }
+
+  return data?.uuid ? { uuid: data.uuid, type } : null;
+};
+
+const TABLE_BY_TYPE: Record<LookupEntityType, string> = {
+  work: 'works',
+  passage: 'passages',
+  glossary: 'glossaries',
+  bibliography: 'bibliographies',
+};
+
+const XML_ID_COLUMN_BY_TYPE: Record<LookupEntityType, string> = {
+  work: 'xmlId',
+  passage: 'xmlId',
+  glossary: 'glossary_xmlId',
+  bibliography: 'xmlId',
+};
+
+const LOOKUP_ORDER: LookupEntityType[] = [
+  'work',
+  'passage',
+  'glossary',
+  'bibliography',
+];
+
+export const lookup = async ({
+  client,
+  toh,
+  uuid,
+  xmlId,
+  type,
+}: {
+  client: DataClient;
+  toh?: string | null;
+  uuid?: string | null;
+  xmlId?: string | null;
+  type?: string | null;
+}): Promise<LookupResult | null> => {
+  const scopedTypes = isLookupEntityType(type) ? [type] : LOOKUP_ORDER;
+
+  if (toh) {
+    if (type && type !== 'work') {
+      return null;
+    }
+    return lookupWorkByToh({ client, toh });
+  }
+
+  if (uuid) {
+    for (const lookupType of scopedTypes) {
+      const result = await lookupUuidInTable({
+        client,
+        table: TABLE_BY_TYPE[lookupType],
+        type: lookupType,
+        uuid,
+      });
+      if (result) {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  if (xmlId) {
+    for (const lookupType of scopedTypes) {
+      const result = await lookupXmlIdInTable({
+        client,
+        table: TABLE_BY_TYPE[lookupType],
+        column: XML_ID_COLUMN_BY_TYPE[lookupType],
+        type: lookupType,
+        xmlId,
+      });
+      if (result) {
+        return result;
+      }
+    }
+  }
+
+  return null;
+};

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -4,6 +4,7 @@ import {
   createGraphQLClient,
   getBibliographyEntry,
   getGlossaryInstance,
+  lookup,
   getPassage,
   getTranslationImprint,
   getTranslationMetadataByUuid,
@@ -35,7 +36,10 @@ import {
   TabName,
 } from './types';
 import { HoverCardProvider } from './HoverCardProvider';
-import { GatedFeature, useFeatureFlagEnabled } from '@eightyfourthousand/lib-instr';
+import {
+  GatedFeature,
+  useFeatureFlagEnabled,
+} from '@eightyfourthousand/lib-instr';
 import { isXmlId, useIsMobile } from '@eightyfourthousand/lib-utils';
 import { RestrictionWarning } from './RestrictionWarning';
 import { NavigationContext, DEFAULT_PANELS } from './NavigationContext';
@@ -273,35 +277,59 @@ export const NavigationProvider = ({
     window.history.replaceState(null, '', newUrl);
   }, [toh, panels]);
 
-  // On initial load, check for an XML ID in the URL hash and resolve it to a passage UUID
+  // On initial load, check for an XML ID in the URL hash and resolve it to an entity UUID.
   useEffect(() => {
     const hash = window.location.hash.replace(/^#/, '');
     if (!hash || !isXmlId(hash)) {
       return;
     }
 
-    // Remove hash from URL immediately
-    window.history.replaceState(
-      null,
-      '',
-      `${window.location.pathname}${window.location.search}`,
-    );
-
     (async () => {
-      const passage = await getPassage({ client: graphqlClient, xmlId: hash });
-      if (!passage) {
+      const result = await lookup({ client: graphqlClient, xmlId: hash });
+      if (!result || result.type === 'work') {
         return;
       }
 
-      const panel = PANEL_FOR_SECTION[passage.type] ?? 'main';
-      const tab = TAB_FOR_SECTION[passage.type] ?? 'translation';
+      let panel: PanelName | undefined;
+      let tab: TabName | undefined;
+      let uuid = result.uuid;
+
+      if (result.type === 'passage') {
+        const passage = await getPassage({
+          client: graphqlClient,
+          uuid: result.uuid,
+        });
+        if (!passage) {
+          return;
+        }
+
+        panel = PANEL_FOR_SECTION[passage.type] ?? 'main';
+        tab = TAB_FOR_SECTION[passage.type] ?? 'translation';
+        uuid = passage.uuid;
+      } else if (result.type === 'glossary') {
+        panel = 'right';
+        tab = 'glossary';
+      } else if (result.type === 'bibliography') {
+        panel = 'right';
+        tab = 'bibliography';
+      }
+
+      if (!panel || !tab) {
+        return;
+      }
+
+      window.history.replaceState(
+        null,
+        '',
+        `${window.location.pathname}${window.location.search}`,
+      );
 
       updatePanel({
         name: panel,
-        state: { open: true, tab, hash: passage.uuid },
+        state: { open: true, tab, hash: uuid },
       });
     })();
-  }, []);
+  }, [graphqlClient, updatePanel]);
 
   useEffect(() => {
     if (!uuid || !toh) {
@@ -397,4 +425,3 @@ export const NavigationProvider = ({
     </NavigationContext.Provider>
   );
 };
-


### PR DESCRIPTION
### Summary

Adds a general-purpose `lookup` query to GraphQL that, when give a uuid, XML ID, or Tohoku number, try to look up a work, passage, glossary instance, or bibliography entry (in that order). The new function is now used in the frontend when handling a hash in the url, so all three entity types will now be resolved. If no result is returned, the has is ignored.

### Linear

- [DEV-667](https://linear.app/84000/issue/DEV-667)
