### PR TITLE
Foreign Mark

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/Bold.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Bold.ts
@@ -22,6 +22,16 @@ export const Bold = TipTapBold.extend({
           });
         },
       },
+      lang: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-lang'),
+        renderHTML(attributes) {
+          if (!attributes.lang) {
+            return attributes;
+          }
+          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
+        },
+      },
     };
   },
   addCommands() {
@@ -29,13 +39,17 @@ export const Bold = TipTapBold.extend({
     return {
       ...this.parent?.(),
       setBold() {
-        return ({ commands }) => {
-          return commands.setMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.setMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
       toggleBold() {
-        return ({ commands }) => {
-          return commands.toggleMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.toggleMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
     };

--- a/libs/lib-editing/src/lib/components/editor/extensions/Foreign/Foreign.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Foreign/Foreign.ts
@@ -62,33 +62,25 @@ export const ForeignMark = Mark.create<ForeignOptions>({
   },
 
   addCommands() {
+    const name = this.name;
     return {
       setForeign:
         (lang?: ExtendedTranslationLanguage) =>
-        ({ chain }) => {
-          return chain()
-            .setMark(this.name)
-            .updateAttributes(this.name, {
-              lang,
-              uuid: uuidv4(),
-            })
-            .run();
+        ({ commands }) => {
+          return commands.setMark(name, { lang, uuid: uuidv4() });
         },
       toggleForeign:
         (lang?: ExtendedTranslationLanguage) =>
-        ({ commands }) => {
-          if (this.editor.isActive(this.name, { lang })) {
-            return commands.unsetForeign();
+        ({ commands, editor }) => {
+          if (editor.isActive(name, { lang })) {
+            return commands.unsetMark(name);
           }
-          return commands.setForeign(lang);
+          return commands.setMark(name, { lang, uuid: uuidv4() });
         },
       unsetForeign:
         () =>
-        ({ chain }) => {
-          return chain()
-            .unsetMark(this.name)
-            .resetAttributes(this.name, 'lang')
-            .run();
+        ({ commands }) => {
+          return commands.unsetMark(name);
         },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/Foreign/Foreign.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Foreign/Foreign.ts
@@ -1,0 +1,95 @@
+import { ExtendedTranslationLanguage } from '@eightyfourthousand/data-access';
+import { Mark, mergeAttributes } from '@tiptap/core';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface ForeignOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    foreign: {
+      setForeign: (lang?: ExtendedTranslationLanguage) => ReturnType;
+      toggleForeign: (lang?: ExtendedTranslationLanguage) => ReturnType;
+      unsetForeign: () => ReturnType;
+    };
+  }
+}
+
+export const ForeignMark = Mark.create<ForeignOptions>({
+  name: 'foreign',
+
+  addAttributes() {
+    return {
+      uuid: {
+        default: undefined,
+      },
+      type: {
+        default: 'span',
+      },
+      textStyle: {
+        default: 'foreign',
+      },
+      lang: {
+        default: undefined,
+      },
+    };
+  },
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  parseHTML() {
+    return [
+      { tag: 'span[data-text-style="foreign"]' },
+      { tag: 'i[data-text-style="foreign"]' },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes, mark }) {
+    const lang = mark.attrs.lang;
+    return [
+      'i',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-text-style': 'foreign',
+        ...(lang ? { lang, 'data-lang': lang } : {}),
+      }),
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      setForeign:
+        (lang?: ExtendedTranslationLanguage) =>
+        ({ chain }) => {
+          return chain()
+            .setMark(this.name)
+            .updateAttributes(this.name, {
+              lang,
+              uuid: uuidv4(),
+            })
+            .run();
+        },
+      toggleForeign:
+        (lang?: ExtendedTranslationLanguage) =>
+        ({ commands }) => {
+          if (this.editor.isActive(this.name, { lang })) {
+            return commands.unsetForeign();
+          }
+          return commands.setForeign(lang);
+        },
+      unsetForeign:
+        () =>
+        ({ chain }) => {
+          return chain()
+            .unsetMark(this.name)
+            .resetAttributes(this.name, 'lang')
+            .run();
+        },
+    };
+  },
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/Italic.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Italic.ts
@@ -13,13 +13,6 @@ export const Italic = TiptapItalic.extend({
           return mergeAttributes(attributes, { 'data-type': attributes.type });
         },
       },
-      lang: {
-        default: undefined,
-        parseHTML: (element) => element.getAttribute('data-lang'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
-        },
-      },
       textStyle: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-text-style'),
@@ -29,6 +22,16 @@ export const Italic = TiptapItalic.extend({
           });
         },
       },
+      lang: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-lang'),
+        renderHTML(attributes) {
+          if (!attributes.lang) {
+            return attributes;
+          }
+          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
+        },
+      },
     };
   },
   addCommands() {
@@ -36,13 +39,17 @@ export const Italic = TiptapItalic.extend({
     return {
       ...this.parent?.(),
       setItalic() {
-        return ({ commands }) => {
-          return commands.setMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.setMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
       toggleItalic() {
-        return ({ commands }) => {
-          return commands.toggleMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.toggleMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
     };

--- a/libs/lib-editing/src/lib/components/editor/extensions/SmallCaps.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/SmallCaps.ts
@@ -55,6 +55,16 @@ export const SmallCaps = Mark.create<SmallCapsOptions>({
           });
         },
       },
+      lang: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-lang'),
+        renderHTML(attributes) {
+          if (!attributes.lang) {
+            return attributes;
+          }
+          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
+        },
+      },
     };
   },
 
@@ -83,16 +93,21 @@ export const SmallCaps = Mark.create<SmallCapsOptions>({
   },
 
   addCommands() {
+    const name = this.name;
     return {
       setSmallCaps:
         () =>
-        ({ commands }) => {
-          return commands.setMark(this.name, { uuid: uuidv4() });
+        ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.setMark(name, { uuid: uuidv4(), lang, textStyle });
         },
       toggleSmallCaps:
         () =>
-        ({ commands }) => {
-          return commands.toggleMark(this.name, { uuid: uuidv4() });
+        ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.toggleMark(name, { uuid: uuidv4(), lang, textStyle });
         },
       unsetSmallCaps:
         () =>

--- a/libs/lib-editing/src/lib/components/editor/extensions/Subscript.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Subscript.ts
@@ -22,6 +22,16 @@ export const Subscript = TipTapSubscript.extend({
           });
         },
       },
+      lang: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-lang'),
+        renderHTML(attributes) {
+          if (!attributes.lang) {
+            return attributes;
+          }
+          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
+        },
+      },
     };
   },
   addCommands() {
@@ -29,13 +39,17 @@ export const Subscript = TipTapSubscript.extend({
     return {
       ...this.parent?.(),
       setSubscript() {
-        return ({ commands }) => {
-          return commands.setMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.setMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
       toggleSubscript() {
-        return ({ commands }) => {
-          return commands.toggleMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.toggleMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
     };

--- a/libs/lib-editing/src/lib/components/editor/extensions/Superscript.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Superscript.ts
@@ -22,6 +22,16 @@ export const Superscript = TipTapSuperscript.extend({
           });
         },
       },
+      lang: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-lang'),
+        renderHTML(attributes) {
+          if (!attributes.lang) {
+            return attributes;
+          }
+          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
+        },
+      },
     };
   },
   addCommands() {
@@ -29,13 +39,17 @@ export const Superscript = TipTapSuperscript.extend({
     return {
       ...this.parent?.(),
       setSuperscript() {
-        return ({ commands }) => {
-          return commands.setMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.setMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
       toggleSuperscript() {
-        return ({ commands }) => {
-          return commands.toggleMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.toggleMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
     };

--- a/libs/lib-editing/src/lib/components/editor/extensions/TranslationMetadata.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/TranslationMetadata.ts
@@ -18,6 +18,10 @@ export default Extension.create({
             default: null,
             parseHTML: (element) => element.getAttribute('uuid') || uuidv4(),
             renderHTML: (attributes) => {
+              if (!attributes.uuid) {
+                return attributes;
+              }
+
               return mergeAttributes(attributes, {
                 uuid: attributes.uuid || uuidv4(),
               });
@@ -27,6 +31,10 @@ export default Extension.create({
             default: null,
             parseHTML: (element) => element.getAttribute('type'),
             renderHTML: (attributes) => {
+              if (!attributes.type) {
+                return attributes;
+              }
+
               return mergeAttributes(attributes, {
                 type: attributes.type,
               });
@@ -36,6 +44,10 @@ export default Extension.create({
             default: undefined,
             parseHTML: (element) => element.getAttribute('toh'),
             renderHTML: (attributes) => {
+              if (!attributes.toh) {
+                return attributes;
+              }
+
               return mergeAttributes(attributes, {
                 toh: attributes.toh,
               });
@@ -46,6 +58,10 @@ export default Extension.create({
             parseHTML: (element) =>
               element.getAttribute('invalid') === 'true' ? true : false,
             renderHTML: (attributes) => {
+              if (attributes.invalid === null) {
+                return attributes;
+              }
+
               return mergeAttributes(attributes, {
                 invalid: attributes.invalid,
               });

--- a/libs/lib-editing/src/lib/components/editor/extensions/Underline.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Underline.ts
@@ -22,6 +22,16 @@ export const Underline = TipTapUnderline.extend({
           });
         },
       },
+      lang: {
+        default: undefined,
+        parseHTML: (element) => element.getAttribute('data-lang'),
+        renderHTML(attributes) {
+          if (!attributes.lang) {
+            return attributes;
+          }
+          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
+        },
+      },
     };
   },
   addCommands() {
@@ -29,13 +39,17 @@ export const Underline = TipTapUnderline.extend({
     return {
       ...this.parent?.(),
       setUnderline() {
-        return ({ commands }) => {
-          return commands.setMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.setMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
       toggleUnderline() {
-        return ({ commands }) => {
-          return commands.toggleMark(name, { uuid: uuidv4() });
+        return ({ commands, tr }) => {
+          const lang = tr.selection.$from.parent.attrs.lang;
+          const textStyle = tr.selection.$from.parent.attrs.textStyle;
+          return commands.toggleMark(name, { uuid: uuidv4(), lang, textStyle });
         };
       },
     };

--- a/libs/lib-editing/src/lib/components/editor/extensions/translationSSRExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/translationSSRExtensions.ts
@@ -5,6 +5,7 @@ import { Abbreviation, HasAbbreviation } from './Abbreviation/Abbreviation';
 import { Audio } from './Audio/Audio';
 import { Bold } from './Bold';
 import { EndNoteLinkMarkSSR } from './EndNoteLink/EndNoteLinkMark.ssr';
+import { ForeignMark } from './Foreign/Foreign';
 import { GlossaryInstanceNodeSSR } from './GlossaryInstance/GlossaryInstanceNode.ssr';
 import Heading from './Heading/Heading';
 import Image from './Image';
@@ -35,6 +36,7 @@ export const translationSSRExtensions: Extensions = [
   Audio,
   Bold,
   EndNoteLinkMarkSSR,
+  ForeignMark,
   GlossaryInstanceNodeSSR,
   HasAbbreviation,
   Heading,

--- a/libs/lib-editing/src/lib/components/editor/hooks/useTranslationExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/hooks/useTranslationExtensions.ts
@@ -38,6 +38,7 @@ import { SmallCaps } from '../extensions/SmallCaps';
 import { Italic } from '../extensions/Italic';
 import { Indent } from '../extensions/Indent';
 import { InternalLink } from '../extensions/InternalLink';
+import { ForeignMark } from '../extensions/Foreign/Foreign';
 import { MantraMark } from '../extensions/Mantra/Mantra';
 import { Mention } from '../extensions/Mention/Mention';
 import { EndNoteLinkMark } from '../extensions/EndNoteLink/EndNoteLinkMark';
@@ -96,6 +97,7 @@ export const useTranslationExtensions = ({
     Bold,
     EndNoteLinkMark,
     EnsureUniqueUuids,
+    ForeignMark,
     GlobalConfig,
     GlossaryInstanceNode,
     Heading,

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/ForeignSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/ForeignSelector.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { Editor } from '@tiptap/core';
+import { useEditorState } from '@tiptap/react';
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@eightyfourthousand/design-system';
+import { CheckIcon, ChevronDownIcon, LanguagesIcon } from 'lucide-react';
+import { cn } from '@eightyfourthousand/lib-utils';
+
+interface SelectorResult {
+  isEnglish: boolean;
+  isSanskrit: boolean;
+  isTibetan: boolean;
+  isWylie: boolean;
+  isMixed: boolean;
+}
+
+interface MenuItem {
+  name: string;
+  onClick: (editor: Editor) => void;
+  isActive: (state: SelectorResult) => boolean;
+}
+
+const items: MenuItem[] = [
+  {
+    name: 'English',
+    onClick: (editor: Editor) => {
+      editor.chain().focus().toggleForeign('en').run();
+    },
+    isActive: (state: SelectorResult) => state.isEnglish,
+  },
+  {
+    name: 'Sanskrit',
+    onClick: (editor: Editor) => {
+      editor.chain().focus().toggleForeign('Sa-Ltn').run();
+    },
+    isActive: (state: SelectorResult) => state.isSanskrit,
+  },
+  {
+    name: 'Wylie',
+    onClick: (editor: Editor) => {
+      editor.chain().focus().toggleForeign('Bo-Ltn').run();
+    },
+    isActive: (state: SelectorResult) => state.isWylie,
+  },
+  {
+    name: 'Tibetan',
+    onClick: (editor: Editor) => {
+      editor.chain().focus().toggleForeign('bo').run();
+    },
+    isActive: (state: SelectorResult) => state.isTibetan,
+  },
+  {
+    name: 'Mixed',
+    onClick: (editor: Editor) => {
+      editor.chain().focus().toggleForeign().run();
+    },
+    isActive: (state: SelectorResult) => state.isMixed,
+  },
+];
+
+export const ForeignSelector = ({ editor }: { editor: Editor }) => {
+  const editorState = useEditorState({
+    editor,
+    selector: (instance) => ({
+      isEnglish: instance.editor.isActive('foreign', { lang: 'en' }),
+      isSanskrit: instance.editor.isActive('foreign', { lang: 'Sa-Ltn' }),
+      isTibetan: instance.editor.isActive('foreign', { lang: 'bo' }),
+      isWylie: instance.editor.isActive('foreign', { lang: 'Bo-Ltn' }),
+      isMixed: instance.editor.isActive('foreign', { lang: undefined }),
+    }),
+  });
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" className="rounded-none">
+          <LanguagesIcon
+            className={cn(
+              'size-3',
+              editorState.isEnglish ||
+                editorState.isSanskrit ||
+                editorState.isTibetan ||
+                editorState.isWylie ||
+                editorState.isMixed
+                ? 'text-primary'
+                : 'text-muted-foreground',
+            )}
+            strokeWidth={2.5}
+          />
+          <ChevronDownIcon className="size-2" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-28 shadow-xl rounded-md border p-1"
+        align="end"
+        noPortal
+      >
+        {items.map((item) => (
+          <div
+            key={item.name}
+            className="flex items-center text-sm rounded-md hover:bg-muted text-foreground px-2 py-1.5 cursor-pointer"
+            onClick={() => item.onClick(editor)}
+          >
+            <span>{item.name}</span>
+            <div className="flex-1"></div>
+            {item.isActive(editorState) && (
+              <CheckIcon className="size-3.5 ms-4" />
+            )}
+          </div>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/ForeignSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/ForeignSelector.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+import { ExtendedTranslationLanguage } from '@eightyfourthousand/data-access';
 import { Editor } from '@tiptap/core';
 import { useEditorState } from '@tiptap/react';
 import {
@@ -21,49 +23,21 @@ interface SelectorResult {
 
 interface MenuItem {
   name: string;
-  onClick: (editor: Editor) => void;
+  lang?: ExtendedTranslationLanguage;
   isActive: (state: SelectorResult) => boolean;
 }
 
 const items: MenuItem[] = [
-  {
-    name: 'English',
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleForeign('en').run();
-    },
-    isActive: (state: SelectorResult) => state.isEnglish,
-  },
-  {
-    name: 'Sanskrit',
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleForeign('Sa-Ltn').run();
-    },
-    isActive: (state: SelectorResult) => state.isSanskrit,
-  },
-  {
-    name: 'Wylie',
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleForeign('Bo-Ltn').run();
-    },
-    isActive: (state: SelectorResult) => state.isWylie,
-  },
-  {
-    name: 'Tibetan',
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleForeign('bo').run();
-    },
-    isActive: (state: SelectorResult) => state.isTibetan,
-  },
-  {
-    name: 'Mixed',
-    onClick: (editor: Editor) => {
-      editor.chain().focus().toggleForeign().run();
-    },
-    isActive: (state: SelectorResult) => state.isMixed,
-  },
+  { name: 'English', lang: 'en', isActive: (s) => s.isEnglish },
+  { name: 'Sanskrit', lang: 'Sa-Ltn', isActive: (s) => s.isSanskrit },
+  { name: 'Wylie', lang: 'Bo-Ltn', isActive: (s) => s.isWylie },
+  { name: 'Tibetan', lang: 'bo', isActive: (s) => s.isTibetan },
+  { name: 'Mixed', lang: undefined, isActive: (s) => s.isMixed },
 ];
 
 export const ForeignSelector = ({ editor }: { editor: Editor }) => {
+  const [open, setOpen] = useState(false);
+
   const editorState = useEditorState({
     editor,
     selector: (instance) => ({
@@ -75,8 +49,19 @@ export const ForeignSelector = ({ editor }: { editor: Editor }) => {
     }),
   });
 
+  const handleSelect = (lang?: ExtendedTranslationLanguage) => {
+    const to = editor.state.selection.to;
+    editor
+      .chain()
+      .toggleForeign(lang)
+      .setTextSelection(to)
+      .blur()
+      .run();
+    setOpen(false);
+  };
+
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="ghost" className="rounded-none">
           <LanguagesIcon
@@ -104,7 +89,7 @@ export const ForeignSelector = ({ editor }: { editor: Editor }) => {
           <div
             key={item.name}
             className="flex items-center text-sm rounded-md hover:bg-muted text-foreground px-2 py-1.5 cursor-pointer"
-            onClick={() => item.onClick(editor)}
+            onClick={() => handleSelect(item.lang)}
           >
             <span>{item.name}</span>
             <div className="flex-1"></div>

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/ForeignSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/ForeignSelector.tsx
@@ -10,7 +10,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@eightyfourthousand/design-system';
-import { CheckIcon, ChevronDownIcon, LanguagesIcon } from 'lucide-react';
+import { CheckIcon, ChevronDownIcon, LanguagesIcon, XIcon } from 'lucide-react';
 import { cn } from '@eightyfourthousand/lib-utils';
 
 interface SelectorResult {
@@ -49,11 +49,29 @@ export const ForeignSelector = ({ editor }: { editor: Editor }) => {
     }),
   });
 
+  const isActive =
+    editorState.isEnglish ||
+    editorState.isSanskrit ||
+    editorState.isTibetan ||
+    editorState.isWylie ||
+    editorState.isMixed;
+
   const handleSelect = (lang?: ExtendedTranslationLanguage) => {
     const to = editor.state.selection.to;
     editor
       .chain()
       .toggleForeign(lang)
+      .setTextSelection(to)
+      .blur()
+      .run();
+    setOpen(false);
+  };
+
+  const handleRemove = () => {
+    const to = editor.state.selection.to;
+    editor
+      .chain()
+      .unsetForeign()
       .setTextSelection(to)
       .blur()
       .run();
@@ -67,13 +85,7 @@ export const ForeignSelector = ({ editor }: { editor: Editor }) => {
           <LanguagesIcon
             className={cn(
               'size-3',
-              editorState.isEnglish ||
-                editorState.isSanskrit ||
-                editorState.isTibetan ||
-                editorState.isWylie ||
-                editorState.isMixed
-                ? 'text-primary'
-                : 'text-muted-foreground',
+              isActive ? 'text-primary' : 'text-muted-foreground',
             )}
             strokeWidth={2.5}
           />
@@ -98,6 +110,16 @@ export const ForeignSelector = ({ editor }: { editor: Editor }) => {
             )}
           </div>
         ))}
+        {isActive && (
+          <div
+            className="flex items-center text-sm rounded-md hover:bg-muted text-muted-foreground px-2 py-1.5 cursor-pointer border-t mt-1 pt-1.5"
+            onClick={handleRemove}
+          >
+            <span>Remove</span>
+            <div className="flex-1"></div>
+            <XIcon className="size-3.5 ms-4" />
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/ForeignSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/ForeignSelector.tsx
@@ -111,14 +111,17 @@ export const ForeignSelector = ({ editor }: { editor: Editor }) => {
           </div>
         ))}
         {isActive && (
-          <div
-            className="flex items-center text-sm rounded-md hover:bg-muted text-muted-foreground px-2 py-1.5 cursor-pointer border-t mt-1 pt-1.5"
-            onClick={handleRemove}
-          >
-            <span>Remove</span>
-            <div className="flex-1"></div>
-            <XIcon className="size-3.5 ms-4" />
-          </div>
+          <>
+            <div className="h-px bg-border my-1" />
+            <div
+              className="flex items-center text-sm rounded-md hover:bg-muted text-foreground px-2 py-1.5 cursor-pointer"
+              onClick={handleRemove}
+            >
+              <span>Remove</span>
+              <div className="flex-1"></div>
+              <XIcon className="size-3.5 ms-4" />
+            </div>
+          </>
         )}
       </PopoverContent>
     </Popover>

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/TranslationTextButtons.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/TranslationTextButtons.tsx
@@ -12,6 +12,7 @@ import {
   UnderlineIcon,
 } from 'lucide-react';
 import { Button, Separator } from '@eightyfourthousand/design-system';
+import { ForeignSelector } from './ForeignSelector';
 import { LinkSelector } from './LinkSelector';
 import { MantraSelector } from './MantraSelector';
 import { EndNoteSelector } from './EndNoteSelector';
@@ -115,6 +116,7 @@ export const TranslationTextButtons = ({ editor }: { editor: Editor }) => {
           </Button>
         );
       })}
+      <ForeignSelector editor={editor} />
       <MantraSelector editor={editor} />
       <Separator orientation="vertical" className="h-10" />
       <GlossarySelector editor={editor} />

--- a/libs/lib-editing/src/lib/exporters/annotation.ts
+++ b/libs/lib-editing/src/lib/exporters/annotation.ts
@@ -50,6 +50,7 @@ const EXPORTERS: Partial<
   bulletList: list,
   code,
   endNoteLink,
+  foreign: span,
   glossaryInstance,
   hasAbbreviation,
   heading,

--- a/libs/lib-editing/src/lib/exporters/span.ts
+++ b/libs/lib-editing/src/lib/exporters/span.ts
@@ -1,4 +1,7 @@
-import { ExtendedTranslationLanguage, SpanAnnotation } from '@eightyfourthousand/data-access';
+import {
+  ExtendedTranslationLanguage,
+  SpanAnnotation,
+} from '@eightyfourthousand/data-access';
 import { Exporter, ExporterContext } from './export';
 import { SpanMarkType } from '../types';
 
@@ -6,6 +9,7 @@ const SPAN_TYPE_FOR_MARK_TYPE: {
   [key in SpanMarkType]: string;
 } = {
   bold: 'text-bold',
+  foreign: 'foreign',
   smallCaps: 'small-caps',
   subscript: 'subscript',
   superscript: 'superscript',

--- a/libs/lib-editing/src/lib/transformers/span.ts
+++ b/libs/lib-editing/src/lib/transformers/span.ts
@@ -2,7 +2,6 @@ import { ExtendedTranslationLanguage, SpanAnnotation } from '@eightyfourthousand
 import type { Transformer } from './transformer';
 import { type SpanMarkType, MARK_TYPES } from '../types';
 import { splitContent } from './split-content';
-import { ITALIC_LANGUAGES } from './annotate';
 import { recurse } from './recurse';
 
 const MARK_TYPE_FOR_SPAN_TYPE: {
@@ -12,12 +11,7 @@ const MARK_TYPE_FOR_SPAN_TYPE: {
 } = {
   distinct: () => 'italic',
   emphasis: () => 'italic',
-  foreign: (lang) => {
-    if (lang && ITALIC_LANGUAGES.includes(lang)) {
-      return 'italic';
-    }
-    return undefined;
-  },
+  foreign: () => 'foreign',
   'small-caps': () => 'smallCaps',
   subscript: () => 'subscript',
   superscript: () => 'superscript',

--- a/libs/lib-editing/src/lib/types.ts
+++ b/libs/lib-editing/src/lib/types.ts
@@ -1,5 +1,6 @@
 export const MARK_TYPES = [
   'bold',
+  'foreign',
   'italic',
   'smallCaps',
   'subscript',


### PR DESCRIPTION
### Summary

- Adds a new `foreign` mark extension that gives first-class support for the corresponding `text-style` in the `span` annotation. It can be toggled using the bubble menu in the editor.
- Adds high level support for `lang` in all marks the map to `span` in the database.
- Ensure marks preserve the `lang` property when splitting (this is the root issue in ED-1263, where splitting a mark by making part of it another style did not carry `lang` over to the new annotations)

### Linear

- [ED-1263](https://linear.app/84000/issue/Ed-1263)