### PR TITLE
Fix Prefix Endnote SSR Rendering

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ssr.ts
@@ -1,23 +1,8 @@
 import { Mark, mergeAttributes } from '@tiptap/core';
-import { cn } from '@eightyfourthousand/lib-utils';
 
 export interface EndNoteLinkSSROptions {
   HTMLAttributes: Record<string, unknown>;
 }
-
-interface EndNoteItem {
-  uuid: string;
-  location?: string;
-  toh?: string;
-  endNote: string;
-  label?: string;
-}
-
-const isEndNoteItem = (value: unknown): value is EndNoteItem => {
-  if (!value || typeof value !== 'object') return false;
-  const v = value as Record<string, unknown>;
-  return typeof v.uuid === 'string' && typeof v.endNote === 'string';
-};
 
 export const EndNoteLinkMarkSSR = Mark.create<EndNoteLinkSSROptions>({
   name: 'endNoteLink',
@@ -37,33 +22,12 @@ export const EndNoteLinkMarkSSR = Mark.create<EndNoteLinkSSROptions>({
     };
   },
 
-  renderHTML({ mark }) {
-    const raw = mark.attrs.notes;
-    const notes: EndNoteItem[] = Array.isArray(raw) ? raw.filter(isEndNoteItem) : [];
-    notes.sort((a, b) => (a.label || '').localeCompare(b.label || ''));
-
-    const sup = (note: EndNoteItem, marginClass: string) => {
-      const itemLabel = note.label?.split('.').pop() || '';
-      return [
-        'sup',
-        {
-          class: cn('end-note-link', note.toh, marginClass),
-          type: 'endNoteLink',
-          endNote: note.endNote,
-          uuid: note.uuid,
-        },
-        itemLabel,
-      ] as unknown;
-    };
-
-    const startSups = notes
-      .filter((n) => n.location === 'start')
-      .map((n) => sup(n, 'me-0.75'));
-    const endSups = notes
-      .filter((n) => n.location !== 'start')
-      .map((n) => sup(n, ''));
-
-    return ['span', mergeAttributes(this.options.HTMLAttributes, {}), ...startSups, 0, ...endSups];
+  // NOTE: ProseMirror mark specs only support a single content hole and the
+  // `@tiptap/static-renderer` does not handle siblings around it, so we cannot
+  // render the start/end <sup> superscripts here. SSR rendering for this mark
+  // is handled by a custom markMapping override in TranslationSSRContent.
+  renderHTML() {
+    return ['span', mergeAttributes(this.options.HTMLAttributes, {}), 0];
   },
 });
 

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -115,6 +115,98 @@ describe('TranslationSSRContent', () => {
     errorSpy.mockRestore();
   });
 
+  it('renders endNoteLink marks with start-positioned sups before the content', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'marked',
+                  marks: [
+                    {
+                      type: 'endNoteLink',
+                      attrs: {
+                        notes: [
+                          {
+                            uuid: 'n-start',
+                            endNote: 'en-1',
+                            location: 'start',
+                            label: '1.a',
+                            toh: 'toh1',
+                          },
+                          {
+                            uuid: 'n-end',
+                            endNote: 'en-2',
+                            label: '1.b',
+                            toh: 'toh1',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const el = TranslationSSRContent({ content: doc }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    expect(html).toContain('marked');
+    expect(html).toMatch(/<sup[^>]*me-0\.75[^>]*endNote="en-1"[^>]*>a<\/sup>marked/);
+    expect(html).toMatch(/marked<sup[^>]*endNote="en-2"[^>]*>b<\/sup>/);
+  });
+
+  it('renders endNoteLink marks with only end-positioned sups', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'marked',
+                  marks: [
+                    {
+                      type: 'endNoteLink',
+                      attrs: {
+                        notes: [
+                          {
+                            uuid: 'n-end',
+                            endNote: 'en-only',
+                            label: '1.c',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const el = TranslationSSRContent({ content: doc }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    expect(html).toMatch(/marked<sup[^>]*endNote="en-only"[^>]*>c<\/sup>/);
+  });
+
   it('exposes the default SSR extension set including passage and bold', () => {
     const names = translationSSRExtensions.map((e) => e.name);
     expect(names).toEqual(expect.arrayContaining(['passage', 'bold']));

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
@@ -1,8 +1,64 @@
 import type { Extensions, JSONContent } from '@tiptap/core';
 import { getSchema } from '@tiptap/core';
 import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string';
+import { cn } from '@eightyfourthousand/lib-utils';
 import { translationSSRExtensions } from '../editor/extensions/translationSSRExtensions';
 import { extractPlainText } from './ssr-text-fallback';
+
+type EndNoteItem = {
+  uuid: string;
+  endNote: string;
+  location?: string;
+  toh?: string;
+  label?: string;
+};
+
+const isEndNoteItem = (value: unknown): value is EndNoteItem => {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.uuid === 'string' && typeof v.endNote === 'string';
+};
+
+const escapeHTML = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const escapeHTMLAttribute = (value: string) =>
+  escapeHTML(value).replace(/"/g, '&quot;');
+
+const renderEndNoteLinkMark = ({
+  mark,
+  children,
+}: {
+  mark: { attrs: Record<string, unknown> };
+  children?: string | string[];
+}): string => {
+  const raw = mark.attrs.notes;
+  const notes: EndNoteItem[] = Array.isArray(raw) ? raw.filter(isEndNoteItem) : [];
+  notes.sort((a, b) => (a.label || '').localeCompare(b.label || ''));
+
+  const supHtml = (n: EndNoteItem, marginClass: string) => {
+    const cls = cn('end-note-link', n.toh, marginClass);
+    const itemLabel = n.label?.split('.').pop() || '';
+    return (
+      `<sup class="${escapeHTMLAttribute(cls)}"` +
+      ` type="endNoteLink"` +
+      ` endNote="${escapeHTMLAttribute(n.endNote)}"` +
+      ` uuid="${escapeHTMLAttribute(n.uuid)}">` +
+      `${escapeHTML(itemLabel)}</sup>`
+    );
+  };
+
+  const start = notes
+    .filter((n) => n.location === 'start')
+    .map((n) => supHtml(n, 'me-0.75'))
+    .join('');
+  const end = notes
+    .filter((n) => n.location !== 'start')
+    .map((n) => supHtml(n, ''))
+    .join('');
+  const body = ([] as unknown[]).concat(children ?? '').filter(Boolean).join('');
+
+  return `<span>${start}${body}${end}</span>`;
+};
 
 type Content = JSONContent | JSONContent[];
 
@@ -76,7 +132,11 @@ export const TranslationSSRContent = ({
     if (process.env.NODE_ENV !== 'production') {
       assertCoverage(doc, exts);
     }
-    const html = renderToHTMLString({ content: doc, extensions: exts });
+    const html = renderToHTMLString({
+      content: doc,
+      extensions: exts,
+      options: { markMapping: { endNoteLink: renderEndNoteLinkMark } },
+    });
     return (
       <div className={className} dangerouslySetInnerHTML={{ __html: html }} />
     );


### PR DESCRIPTION
### Summary

Create a custom SSR rendering function for endnote links to handle the special case of prefix notes. This is technically a violation of the ProseMirror spec that TipTap is able to adapt at runtime. Previously, translations with prefix endnotes in the initial passages were failing to parse and falling back to plain text.