### PR TITLE
Render Foreign Mark as Span 

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/Foreign/Foreign.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Foreign/Foreign.ts
@@ -43,19 +43,16 @@ export const ForeignMark = Mark.create<ForeignOptions>({
   },
 
   parseHTML() {
-    return [
-      { tag: 'span[data-text-style="foreign"]' },
-      { tag: 'i[data-text-style="foreign"]' },
-    ];
+    return [{ tag: 'span[data-text-style="foreign"]' }];
   },
 
   renderHTML({ HTMLAttributes, mark }) {
     const lang = mark.attrs.lang;
     return [
-      'i',
+      'span',
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         'data-text-style': 'foreign',
-        ...(lang ? { lang, 'data-lang': lang } : {}),
+        ...(lang ? { lang } : {}),
       }),
       0,
     ];


### PR DESCRIPTION
### Summary

Use a `<span>` for `foreign` marks instead of `<i>` and rely on existing logic to make different languages italic.

### Linear

- [DEV-1269](https://linear.app/84000/issue/DEV-1269)
