### PR TITLE
Return Object From lookupEntity

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
+++ b/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
@@ -14,13 +14,12 @@ export async function GET(
   const isEditor = searchParams.get('edit') === 'true';
   const prefix = isEditor ? '/translations/editor' : '/translations/reader';
 
-  const { path } =
-    (await lookupEntity({
-      type,
-      entity,
-      searchParams,
-      prefix,
-    })) || {};
+  const { path } = await lookupEntity({
+    type,
+    entity,
+    searchParams,
+    prefix,
+  });
 
   if (!path) {
     return notFound();

--- a/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
+++ b/apps/web-main/src/app/(DashboardLayout)/entity/[type]/[slug]/route.ts
@@ -14,12 +14,13 @@ export async function GET(
   const isEditor = searchParams.get('edit') === 'true';
   const prefix = isEditor ? '/translations/editor' : '/translations/reader';
 
-  const path = await lookupEntity({
-    type,
-    entity,
-    searchParams,
-    prefix,
-  });
+  const { path } =
+    (await lookupEntity({
+      type,
+      entity,
+      searchParams,
+      prefix,
+    })) || {};
 
   if (!path) {
     return notFound();

--- a/apps/web-main/src/app/(DashboardLayout)/translation/[slug]/route.ts
+++ b/apps/web-main/src/app/(DashboardLayout)/translation/[slug]/route.ts
@@ -10,14 +10,13 @@ export async function GET(
   const query = request.nextUrl.searchParams;
   const xmlId = query.get('xmlId') || undefined;
   query.delete('xmlId');
-  const { path } =
-    (await lookupEntity({
-      type: 'translation',
-      entity,
-      prefix: '/publications/reader',
-      xmlId,
-      searchParams: query,
-    })) || {};
+  const { path } = await lookupEntity({
+    type: 'translation',
+    entity,
+    prefix: '/publications/reader',
+    xmlId,
+    searchParams: query,
+  });
 
   if (!path) {
     return notFound();

--- a/apps/web-main/src/app/(DashboardLayout)/translation/[slug]/route.ts
+++ b/apps/web-main/src/app/(DashboardLayout)/translation/[slug]/route.ts
@@ -10,13 +10,14 @@ export async function GET(
   const query = request.nextUrl.searchParams;
   const xmlId = query.get('xmlId') || undefined;
   query.delete('xmlId');
-  const path = await lookupEntity({
-    type: 'translation',
-    entity,
-    prefix: '/publications/reader',
-    xmlId,
-    searchParams: query,
-  });
+  const { path } =
+    (await lookupEntity({
+      type: 'translation',
+      entity,
+      prefix: '/publications/reader',
+      xmlId,
+      searchParams: query,
+    })) || {};
 
   if (!path) {
     return notFound();

--- a/apps/web-reader/src/app/entity/[type]/[slug]/route.ts
+++ b/apps/web-reader/src/app/entity/[type]/[slug]/route.ts
@@ -11,7 +11,7 @@ export async function GET(
     nextUrl: { searchParams },
   } = request;
 
-  const { path } = (await lookupEntity({ type, entity, searchParams })) || {};
+  const { path } = await lookupEntity({ type, entity, searchParams });
 
   if (!path) {
     return notFound();

--- a/apps/web-reader/src/app/entity/[type]/[slug]/route.ts
+++ b/apps/web-reader/src/app/entity/[type]/[slug]/route.ts
@@ -11,7 +11,7 @@ export async function GET(
     nextUrl: { searchParams },
   } = request;
 
-  const path = await lookupEntity({ type, entity, searchParams });
+  const { path } = (await lookupEntity({ type, entity, searchParams })) || {};
 
   if (!path) {
     return notFound();

--- a/apps/web-reader/src/app/translation/[slug]/route.ts
+++ b/apps/web-reader/src/app/translation/[slug]/route.ts
@@ -10,13 +10,12 @@ export async function GET(
   const query = request.nextUrl.searchParams;
   const xmlId = query.get('xmlId') || undefined;
   query.delete('xmlId');
-  const { path } =
-    (await lookupEntity({
-      type: 'translation',
-      entity,
-      xmlId,
-      searchParams: query,
-    })) || {};
+  const { path } = await lookupEntity({
+    type: 'translation',
+    entity,
+    xmlId,
+    searchParams: query,
+  });
 
   if (!path) {
     return notFound();

--- a/apps/web-reader/src/app/translation/[slug]/route.ts
+++ b/apps/web-reader/src/app/translation/[slug]/route.ts
@@ -10,12 +10,13 @@ export async function GET(
   const query = request.nextUrl.searchParams;
   const xmlId = query.get('xmlId') || undefined;
   query.delete('xmlId');
-  const path = await lookupEntity({
-    type: 'translation',
-    entity,
-    xmlId,
-    searchParams: query,
-  });
+  const { path } =
+    (await lookupEntity({
+      type: 'translation',
+      entity,
+      xmlId,
+      searchParams: query,
+    })) || {};
 
   if (!path) {
     return notFound();

--- a/libs/data-access/src/lib/lookup-entity.ts
+++ b/libs/data-access/src/lib/lookup-entity.ts
@@ -18,10 +18,10 @@ const ALLOWED_TYPES = [
 ];
 
 export interface LookupEntityReturnType {
-  path: string;
-  uuid: string;
-  workUuid: string;
-  query: URLSearchParams;
+  path?: string;
+  uuid?: string;
+  workUuid?: string;
+  query?: URLSearchParams;
 }
 
 export const lookupEntity = async ({
@@ -36,9 +36,9 @@ export const lookupEntity = async ({
   prefix?: string;
   xmlId?: string;
   searchParams?: URLSearchParams;
-}): Promise<LookupEntityReturnType | undefined> => {
+}): Promise<LookupEntityReturnType> => {
   if (!ALLOWED_TYPES.includes(type)) {
-    return;
+    return {};
   }
   const client = await createServerClient();
   return await lookupEntityWithClient({
@@ -65,7 +65,7 @@ export const lookupEntityWithClient = async ({
   prefix?: string;
   xmlId?: string;
   searchParams?: URLSearchParams;
-}): Promise<LookupEntityReturnType | undefined> => {
+}): Promise<LookupEntityReturnType> => {
   let path: string | undefined;
   let workUuid: string | undefined;
   let uuid: string | undefined;
@@ -77,7 +77,7 @@ export const lookupEntityWithClient = async ({
       {
         const item = await getBibliographyEntry({ client, uuid: entity });
         if (!item?.workUuid || !item.uuid) {
-          return;
+          return {};
         }
 
         workUuid = item.workUuid;
@@ -90,7 +90,7 @@ export const lookupEntityWithClient = async ({
       {
         const item = await getGlossaryInstance({ client, uuid: entity });
         if (!item?.workUuid || !item.uuid) {
-          return;
+          return {};
         }
 
         workUuid = item.workUuid;
@@ -103,7 +103,7 @@ export const lookupEntityWithClient = async ({
       {
         const item = await getPassage({ client, uuid: entity });
         if (!item?.workUuid || !item.uuid) {
-          return;
+          return {};
         }
 
         workUuid = item.workUuid;
@@ -145,7 +145,7 @@ export const lookupEntityWithClient = async ({
         const item = await getTranslationMetadataByToh({ client, toh });
 
         if (!item?.uuid) {
-          return;
+          return {};
         }
 
         uuid = item.uuid;
@@ -160,7 +160,7 @@ export const lookupEntityWithClient = async ({
           uuid: entity,
         });
         if (!item?.uuid) {
-          return;
+          return {};
         }
 
         uuid = item.uuid;
@@ -169,12 +169,8 @@ export const lookupEntityWithClient = async ({
       }
       break;
     default: {
-      return;
+      return {};
     }
-  }
-
-  if (!path || !uuid || !workUuid) {
-    return;
   }
 
   return { path, uuid, workUuid, query };

--- a/libs/data-access/src/lib/lookup-entity.ts
+++ b/libs/data-access/src/lib/lookup-entity.ts
@@ -17,6 +17,13 @@ const ALLOWED_TYPES = [
   'work',
 ];
 
+export interface LookupEntityReturnType {
+  path: string;
+  uuid: string;
+  workUuid: string;
+  query: URLSearchParams;
+}
+
 export const lookupEntity = async ({
   type,
   entity,
@@ -29,7 +36,7 @@ export const lookupEntity = async ({
   prefix?: string;
   xmlId?: string;
   searchParams?: URLSearchParams;
-}) => {
+}): Promise<LookupEntityReturnType | undefined> => {
   if (!ALLOWED_TYPES.includes(type)) {
     return;
   }
@@ -58,8 +65,11 @@ export const lookupEntityWithClient = async ({
   prefix?: string;
   xmlId?: string;
   searchParams?: URLSearchParams;
-}) => {
-  let path = '';
+}): Promise<LookupEntityReturnType | undefined> => {
+  let path: string | undefined;
+  let workUuid: string | undefined;
+  let uuid: string | undefined;
+
   const query = searchParams || new URLSearchParams();
 
   switch (type) {
@@ -70,8 +80,10 @@ export const lookupEntityWithClient = async ({
           return;
         }
 
-        query.set('right', `open:bibliography:${item.uuid}`);
-        path = `${prefix}/${item.workUuid}?${query.toString()}`;
+        workUuid = item.workUuid;
+        uuid = item.uuid;
+        query.set('right', `open:bibliography:${uuid}`);
+        path = `${prefix}/${workUuid}?${query.toString()}`;
       }
       break;
     case 'glossary':
@@ -81,8 +93,10 @@ export const lookupEntityWithClient = async ({
           return;
         }
 
-        query.set('right', `open:glossary:${item.uuid}`);
-        path = `${prefix}/${item.workUuid}?${query.toString()}`;
+        workUuid = item.workUuid;
+        uuid = item.uuid;
+        query.set('right', `open:glossary:${uuid}`);
+        path = `${prefix}/${workUuid}?${query.toString()}`;
       }
       break;
     case 'passage':
@@ -96,12 +110,12 @@ export const lookupEntityWithClient = async ({
         const { panel, tab } = panelAndTabForContentType(item.type, queryTab);
 
         query.delete('tab');
-        query.set(panel, `open:${tab}:${item.uuid}`);
+        query.set(panel, `open:${tab}:${uuid}`);
         if (item.toh) {
           query.set('toh', item.toh);
         }
 
-        path = `${prefix}/${item.workUuid}?${query.toString()}`;
+        path = `${prefix}/${workUuid}?${query.toString()}`;
       }
       break;
     case 'translation':
@@ -114,22 +128,27 @@ export const lookupEntityWithClient = async ({
           const queryTab = query.get('tab') || undefined;
           const { panel, tab } = panelAndTabForContentType(item.type, queryTab);
 
-          if (item?.uuid && item?.workUuid) {
-            const { uuid, workUuid } = item;
+          uuid = item?.uuid;
+          workUuid = item?.workUuid;
+
+          if (uuid && workUuid) {
             query.delete('tab');
             query.set(panel, `open:${tab}:${uuid}`);
 
             path = `${prefix}/${workUuid}?${query.toString()}`;
-            return path;
+            return { path, uuid, workUuid, query };
           }
         }
 
         const item = await getTranslationMetadataByToh({ client, toh });
+
         if (!item?.uuid) {
           return;
         }
 
-        path = `${prefix}/${item.uuid}?${query.toString()}`;
+        uuid = item.uuid;
+        workUuid = item.uuid;
+        path = `${prefix}/${uuid}?${query.toString()}`;
       }
       break;
     case 'work':
@@ -142,6 +161,8 @@ export const lookupEntityWithClient = async ({
           return;
         }
 
+        uuid = item.uuid;
+        workUuid = item.uuid;
         path = `${prefix}/${item.uuid}?${query.toString()}`;
       }
       break;
@@ -150,5 +171,9 @@ export const lookupEntityWithClient = async ({
     }
   }
 
-  return path;
+  if (!path || !uuid || !workUuid) {
+    return;
+  }
+
+  return { path, uuid, workUuid, query };
 };

--- a/libs/data-access/src/lib/lookup-entity.ts
+++ b/libs/data-access/src/lib/lookup-entity.ts
@@ -106,6 +106,8 @@ export const lookupEntityWithClient = async ({
           return;
         }
 
+        workUuid = item.workUuid;
+        uuid = item.uuid;
         const queryTab = query.get('tab') || undefined;
         const { panel, tab } = panelAndTabForContentType(item.type, queryTab);
 


### PR DESCRIPTION
### Summary

To make it easier for client applications to route to the right page using the `/entity` endpoint, return an object with the shape

```ts
{
  path?: string;
  uuid?: string;
  workUuid?: string;
  query?: URLSearchParams;
}
```

The path matches the previous result. And the reading room, for example, can use the `workUuid`  to resolve to `toh`