### PR TITLE
Fix Mantra Saving

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/Mantra/Mantra.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mantra/Mantra.ts
@@ -20,6 +20,9 @@ export const MantraMark = Mark.create<MantraOptions>({
   name: 'mantra',
   addAttributes() {
     return {
+      uuid: {
+        default: undefined,
+      },
       type: {
         default: 'mantra',
       },
@@ -55,33 +58,25 @@ export const MantraMark = Mark.create<MantraOptions>({
   },
 
   addCommands() {
+    const name = this.name;
     return {
       setMantra:
         (lang?: TranslationLanguage) =>
-        ({ chain }) => {
-          return chain()
-            .setMark(this.name)
-            .updateAttributes(this.name, {
-              lang,
-              uuid: uuidv4(),
-            })
-            .run();
+        ({ commands }) => {
+          return commands.setMark(name, { lang, uuid: uuidv4() });
         },
       toggleMantra:
         (lang?: TranslationLanguage) =>
-        ({ commands }) => {
-          if (this.editor.isActive(this.name, { lang })) {
-            return commands.unsetMantra();
+        ({ commands, editor }) => {
+          if (editor.isActive(name, { lang })) {
+            return commands.unsetMark(name);
           }
-          return commands.setMantra(lang);
+          return commands.setMark(name, { lang, uuid: uuidv4() });
         },
       unsetMantra:
         () =>
-        ({ chain }) => {
-          return chain()
-            .unsetMark(this.name)
-            .resetAttributes(this.name, 'lang')
-            .run();
+        ({ commands }) => {
+          return commands.unsetMark(name);
         },
     };
   },

--- a/libs/lib-editing/src/lib/exporters/mantra.spec.ts
+++ b/libs/lib-editing/src/lib/exporters/mantra.spec.ts
@@ -1,17 +1,22 @@
-import type { Node } from '@tiptap/pm/model';
+import type { Mark, Node } from '@tiptap/pm/model';
 import { mantra } from './mantra';
 
 describe('mantra exporter', () => {
   it('should export mantra annotation correctly', () => {
     const node = {
+      attrs: {},
+      textContent: 'oṃ maṇi padme hūṃ',
+    } as unknown as Node;
+
+    const mark = {
       attrs: {
         uuid: 'mantra-uuid-1234',
         lang: 'sa-Latn',
       },
-      textContent: 'oṃ maṇi padme hūṃ',
-    } as unknown as Node;
+    } as unknown as Mark;
 
     const result = mantra({
+      mark,
       node,
       parent: node,
       root: node,
@@ -31,14 +36,19 @@ describe('mantra exporter', () => {
 
   it('should return undefined when textContent is empty', () => {
     const node = {
+      attrs: {},
+      textContent: '',
+    } as unknown as Node;
+
+    const mark = {
       attrs: {
         uuid: 'mantra-uuid-empty',
         lang: 'sa-Latn',
       },
-      textContent: '',
-    } as unknown as Node;
+    } as unknown as Mark;
 
     const result = mantra({
+      mark,
       node,
       parent: node,
       root: node,

--- a/libs/lib-editing/src/lib/exporters/mantra.ts
+++ b/libs/lib-editing/src/lib/exporters/mantra.ts
@@ -2,11 +2,17 @@ import { MantraAnnotation } from '@eightyfourthousand/data-access';
 import { Exporter } from './export';
 
 export const mantra: Exporter<MantraAnnotation> = ({
+  mark,
   node,
   start,
   passageUuid,
 }): MantraAnnotation | undefined => {
-  const { uuid, lang } = node.attrs;
+  if (!mark) {
+    console.warn('Mantra exporter called without mark');
+    return undefined;
+  }
+
+  const { uuid, lang } = mark.attrs;
 
   const textContent = node.textContent || '';
   if (!textContent) {


### PR DESCRIPTION
### Summary

There were two issue with saving mantras:

1. The a new uuid was not reliably generated when required.
2. The exporter used old logic, treating it like a node, but it is a mark now.

This fixes both issue.

### Linear

- [ED-1267](https://linear.app/84000/issue/ED-1267)
