### PR TITLE
Handle Splitting Text With Endnote Links

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.spec.ts
@@ -1,0 +1,148 @@
+import { Schema } from '@tiptap/pm/model';
+import { EditorState, Plugin } from '@tiptap/pm/state';
+import { EndNoteLinkMark } from './EndNoteLinkMark';
+
+// Minimal schema containing just what we need to exercise the dedup plugin.
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: { content: 'text*', group: 'block' },
+    text: { group: 'inline' },
+  },
+  marks: {
+    endNoteLink: {
+      attrs: { notes: { default: undefined } },
+      parseDOM: [],
+      toDOM: () => ['span', 0],
+    },
+    other: {
+      parseDOM: [],
+      toDOM: () => ['em', 0],
+    },
+  },
+});
+
+const endNoteLink = schema.marks['endNoteLink'];
+const other = schema.marks['other'];
+
+const getPlugin = (): Plugin => {
+  const ext = EndNoteLinkMark as unknown as {
+    config: { addProseMirrorPlugins?: (this: { name: string }) => Plugin[] };
+  };
+  const plugins =
+    ext.config.addProseMirrorPlugins?.call({ name: 'endNoteLink' }) ?? [];
+  return plugins[0];
+};
+
+describe('EndNoteLink dedup plugin', () => {
+  it('removes the endNoteLink mark from all but the last fragment after a sub-range mark splits the text node', () => {
+    // Initial doc: paragraph containing a single text node "abcdef" with an
+    // endNoteLink mark spanning the whole thing.
+    const notes = [{ uuid: 'n1', endNote: 'e1', location: 'end' }];
+    const endMark = endNoteLink.create({ notes });
+    const initialDoc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('abcdef', [endMark])]),
+    ]);
+
+    const plugin = getPlugin();
+    const state = EditorState.create({ schema, doc: initialDoc, plugins: [plugin] });
+
+    // Apply "other" mark to "def" (positions 4..7 inside the paragraph; doc
+    // positions 4..7 because paragraph open tag is at 0). This splits the
+    // text node into "abc" (endNoteLink only) and "def" (endNoteLink + other),
+    // mimicking the glossaryInstance application in the bug report.
+    const userTr = state.tr.addMark(4, 7, other.create());
+    const nextState = state.apply(userTr);
+
+    const paragraph = nextState.doc.firstChild!;
+    expect(paragraph.childCount).toBe(2);
+
+    const first = paragraph.child(0);
+    const second = paragraph.child(1);
+
+    expect(first.text).toBe('abc');
+    expect(first.marks.find((m) => m.type === endNoteLink)).toBeUndefined();
+
+    expect(second.text).toBe('def');
+    expect(second.marks.find((m) => m.type === endNoteLink)).toBeDefined();
+    expect(second.marks.find((m) => m.type === other)).toBeDefined();
+  });
+
+  it('keeps the endNoteLink only on the final fragment when a sub-range mark splits the middle of the text', () => {
+    // Initial doc: paragraph containing "abcdef" with a single endNoteLink mark
+    // across the full range.
+    const notes = [{ uuid: 'n1', endNote: 'e1', location: 'end' }];
+    const endMark = endNoteLink.create({ notes });
+    const initialDoc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('abcdef', [endMark])]),
+    ]);
+
+    const plugin = getPlugin();
+    const state = EditorState.create({
+      schema,
+      doc: initialDoc,
+      plugins: [plugin],
+    });
+
+    // Apply "other" mark to "de" (doc positions 4..6) — i.e. the middle of the
+    // text. This splits the text node into three fragments: "abc", "de", "f".
+    const userTr = state.tr.addMark(4, 6, other.create());
+    const nextState = state.apply(userTr);
+
+    const paragraph = nextState.doc.firstChild!;
+    expect(paragraph.childCount).toBe(3);
+
+    const [first, middle, last] = [
+      paragraph.child(0),
+      paragraph.child(1),
+      paragraph.child(2),
+    ];
+
+    expect(first.text).toBe('abc');
+    expect(first.marks.find((m) => m.type === endNoteLink)).toBeUndefined();
+
+    expect(middle.text).toBe('de');
+    expect(middle.marks.find((m) => m.type === endNoteLink)).toBeUndefined();
+    expect(middle.marks.find((m) => m.type === other)).toBeDefined();
+
+    expect(last.text).toBe('f');
+    expect(last.marks.find((m) => m.type === endNoteLink)).toBeDefined();
+  });
+
+  it('preserves distinct endNoteLink marks on adjacent text nodes (different notes)', () => {
+    // Build a paragraph already containing two adjacent text nodes carrying
+    // DIFFERENT endNoteLink marks (different notes). The plugin should leave
+    // them alone since they are not .eq().
+    const m1 = endNoteLink.create({
+      notes: [{ uuid: 'n1', endNote: 'e1', location: 'end' }],
+    });
+    const m2 = endNoteLink.create({
+      notes: [{ uuid: 'n2', endNote: 'e2', location: 'end' }],
+    });
+    const initialDoc = schema.node('doc', null, [
+      schema.node('paragraph', null, [
+        schema.text('abc', [m1]),
+        schema.text('def', [m2]),
+      ]),
+    ]);
+
+    const plugin = getPlugin();
+    const state = EditorState.create({ schema, doc: initialDoc, plugins: [plugin] });
+
+    // Trigger an appendTransaction by dispatching a no-content-changing edit:
+    // insert and then remove a marker. We use addMark/removeMark on `other`
+    // over a single character to force docChanged + impacted-range coverage.
+    const tr = state.tr.addMark(1, 2, other.create()).removeMark(1, 2, other);
+    const nextState = state.apply(tr);
+
+    const paragraph = nextState.doc.firstChild!;
+    // The two adjacent text fragments should still each have their own
+    // endNoteLink mark.
+    expect(
+      paragraph.child(0).marks.find((m) => m.type === endNoteLink),
+    ).toBeDefined();
+    expect(
+      paragraph.child(1).marks.find((m) => m.type === endNoteLink),
+    ).toBeDefined();
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
@@ -1,4 +1,6 @@
 import { mergeAttributes } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { Mark as PMMark, MarkType } from '@tiptap/pm/model';
 import { v4 as uuidv4 } from 'uuid';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { createUpdateAttributes, registerEditorElement } from '../../util';
@@ -211,5 +213,157 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
             .run();
         },
     };
+  },
+
+  // When another inline mark (e.g. glossaryInstance) is applied to a sub-range
+  // of an existing endNoteLink span, ProseMirror splits the text node and
+  // preserves the endNoteLink mark on every resulting fragment. That causes
+  // duplicate <sup> renders and duplicate exported annotations on save. This
+  // plugin normalizes adjacent text fragments that carry the same endNoteLink
+  // mark by keeping the mark only on the last fragment in each contiguous run.
+  addProseMirrorPlugins() {
+    const markName = this.name;
+    return [
+      new Plugin({
+        key: new PluginKey('endNoteLinkDedup'),
+        appendTransaction(transactions, _oldState, newState) {
+          if (!transactions.some((tr) => tr.docChanged)) {
+            return null;
+          }
+
+          const markType: MarkType | undefined = newState.schema.marks[markName];
+          if (!markType) return null;
+
+          // Collect textblock start positions impacted by any transaction.
+          // Map each step's new range through the rest of the transaction chain
+          // so the coords land in the final new-state doc.
+          const impactedBlockPositions = new Set<number>();
+          const docSize = newState.doc.content.size;
+
+          const recordRange = (
+            rawFrom: number,
+            rawTo: number,
+            startTrIdx: number,
+            startStepIdx: number,
+          ) => {
+            let s = rawFrom;
+            let e = rawTo;
+            // Map through remaining steps in the originating transaction.
+            const originMaps = transactions[startTrIdx].mapping.maps;
+            for (let j = startStepIdx + 1; j < originMaps.length; j++) {
+              s = originMaps[j].map(s, -1);
+              e = originMaps[j].map(e, 1);
+            }
+            // Map through subsequent transactions.
+            for (let later = startTrIdx + 1; later < transactions.length; later++) {
+              s = transactions[later].mapping.map(s, -1);
+              e = transactions[later].mapping.map(e, 1);
+            }
+            const from = Math.max(0, Math.min(s, docSize));
+            const to = Math.max(from, Math.min(e, docSize));
+            newState.doc.nodesBetween(from, to, (node, pos) => {
+              if (node.isTextblock) {
+                impactedBlockPositions.add(pos);
+                return false;
+              }
+              return true;
+            });
+          };
+
+          for (let tIdx = 0; tIdx < transactions.length; tIdx++) {
+            const tr = transactions[tIdx];
+            if (!tr.docChanged) continue;
+
+            for (let i = 0; i < tr.steps.length; i++) {
+              const step = tr.steps[i] as unknown as {
+                from?: number;
+                to?: number;
+                pos?: number;
+              };
+              const stepMap = tr.mapping.maps[i];
+              let recorded = false;
+
+              // ReplaceStep / ReplaceAroundStep produce non-empty step maps;
+              // use their newStart/newEnd.
+              stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+                recordRange(newStart, newEnd, tIdx, i);
+                recorded = true;
+              });
+
+              if (recorded) continue;
+
+              // Mark steps (AddMarkStep / RemoveMarkStep) leave positions
+              // unchanged so their step map is empty. Read the affected range
+              // directly off the step.
+              if (
+                typeof step.from === 'number' &&
+                typeof step.to === 'number'
+              ) {
+                recordRange(step.from, step.to, tIdx, i);
+              } else if (typeof step.pos === 'number') {
+                recordRange(step.pos, step.pos + 1, tIdx, i);
+              }
+            }
+          }
+
+          if (impactedBlockPositions.size === 0) return null;
+
+          const tr = newState.tr;
+          let changed = false;
+
+          impactedBlockPositions.forEach((blockPos) => {
+            const block = newState.doc.nodeAt(blockPos);
+            if (!block || !block.isTextblock) return;
+
+            // Walk direct children, grouping consecutive text nodes that share
+            // an .eq() endNoteLink mark. For each run of length > 1, remove the
+            // mark from all but the last fragment.
+            let runStart = -1;
+            let runEnd = -1;
+            let runMark: PMMark | null = null;
+
+            const flushRun = () => {
+              if (runStart === -1 || runMark === null) return;
+              if (runEnd <= runStart) return;
+              let offset = blockPos + 1;
+              for (let i = 0; i < runStart; i++) {
+                offset += block.child(i).nodeSize;
+              }
+              for (let i = runStart; i < runEnd; i++) {
+                const child = block.child(i);
+                tr.removeMark(offset, offset + child.nodeSize, markType);
+                offset += child.nodeSize;
+                changed = true;
+              }
+            };
+
+            for (let i = 0; i < block.childCount; i++) {
+              const child = block.child(i);
+              const mark = child.isText
+                ? child.marks.find((m) => m.type === markType) ?? null
+                : null;
+
+              if (mark && runMark && mark.eq(runMark)) {
+                runEnd = i;
+              } else {
+                flushRun();
+                if (mark) {
+                  runStart = i;
+                  runEnd = i;
+                  runMark = mark;
+                } else {
+                  runStart = -1;
+                  runEnd = -1;
+                  runMark = null;
+                }
+              }
+            }
+            flushRun();
+          });
+
+          return changed ? tr : null;
+        },
+      }),
+    ];
   },
 });


### PR DESCRIPTION
### Summary

When a block of text containing an `endNoteLink` mark is split, only the the last block of text after the split should retain the original mark. Previously, they all text blocks were preserving them, leading to two issues:

- A visual bug where the same endnote link appeared multiple times
- Duplicate uuids, preventing save actions from succeeding

### Linear

- [DEV-675](https://linear.app/84000/issue/DEV-675)