### PR TITLE
Endnote Duplication, part 2

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.spec.ts
@@ -109,6 +109,91 @@ describe('EndNoteLink dedup plugin', () => {
     expect(last.marks.find((m) => m.type === endNoteLink)).toBeDefined();
   });
 
+  it('removes the endNoteLink mark from a non-adjacent earlier text node when the same mark appears later in the same block', () => {
+    // Two text nodes carrying the SAME endNoteLink mark, separated by an
+    // unmarked text node — the layout produced when paste plain-text into a
+    // position inside an existing endNote span, splitting it.
+    const notes = [{ uuid: 'n1', endNote: 'e1', location: 'end' }];
+    const endMark = endNoteLink.create({ notes });
+    const initialDoc = schema.node('doc', null, [
+      schema.node('paragraph', null, [
+        schema.text('abc', [endMark]),
+        schema.text(' between '),
+        schema.text('def', [endMark]),
+      ]),
+    ]);
+
+    const plugin = getPlugin();
+    const state = EditorState.create({
+      schema,
+      doc: initialDoc,
+      plugins: [plugin],
+    });
+
+    // Any docChanged transaction within the block triggers the dedup pass.
+    const tr = state.tr.addMark(5, 6, other.create()).removeMark(5, 6, other);
+    const nextState = state.apply(tr);
+
+    const paragraph = nextState.doc.firstChild!;
+    // After dedup the leading "abc" loses its endNoteLink mark and is
+    // auto-merged with the unmarked " between " by ProseMirror's text
+    // normalization.
+    expect(paragraph.childCount).toBe(2);
+
+    expect(paragraph.child(0).text).toBe('abc between ');
+    expect(
+      paragraph.child(0).marks.find((m) => m.type === endNoteLink),
+    ).toBeUndefined();
+
+    expect(paragraph.child(1).text).toBe('def');
+    expect(
+      paragraph.child(1).marks.find((m) => m.type === endNoteLink),
+    ).toBeDefined();
+  });
+
+  it('simulated paste inside an endnote-linked word dedupes the split mark', () => {
+    // Reproduces the DEV-661 paste-inside-marked-text case: a single
+    // endNoteLink-marked word is split by inserting unmarked text in the
+    // middle, leaving two non-adjacent text nodes with the same mark.
+    const notes = [{ uuid: 'n1', endNote: 'e1', location: 'end' }];
+    const endMark = endNoteLink.create({ notes });
+    const initialDoc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('wordWithEndNote', [endMark])]),
+    ]);
+
+    const plugin = getPlugin();
+    const state = EditorState.create({
+      schema,
+      doc: initialDoc,
+      plugins: [plugin],
+    });
+
+    // Insert "PASTED" (no marks) at position 5 — inside "wordWithEndNote",
+    // right after "word". Use a Slice with no marks via `tr.replaceWith`.
+    const insertPos = 5;
+    const pastedNode = schema.text('PASTED');
+    const tr = state.tr.replaceWith(insertPos, insertPos, pastedNode);
+    const nextState = state.apply(tr);
+
+    const paragraph = nextState.doc.firstChild!;
+    // Expect the dedup to have removed the mark from the leading fragment
+    // ("word") and left it only on the trailing fragment ("WithEndNote").
+    // ProseMirror then auto-merges the now-unmarked "word" with the unmarked
+    // pasted text into a single text node.
+    let bearers = 0;
+    let lastBearerText: string | undefined;
+    for (let i = 0; i < paragraph.childCount; i++) {
+      const child = paragraph.child(i);
+      const m = child.marks.find((mk) => mk.type === endNoteLink);
+      if (m) {
+        bearers += 1;
+        lastBearerText = child.text ?? undefined;
+      }
+    }
+    expect(bearers).toBe(1);
+    expect(lastBearerText).toBe('WithEndNote');
+  });
+
   it('preserves distinct endNoteLink marks on adjacent text nodes (different notes)', () => {
     // Build a paragraph already containing two adjacent text nodes carrying
     // DIFFERENT endNoteLink marks (different notes). The plugin should leave

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
@@ -172,8 +172,7 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
             }
           });
 
-          const toIsInMark =
-            existingMark && to > markFrom && to <= markTo;
+          const toIsInMark = existingMark && to > markFrom && to <= markTo;
 
           if (!toIsInMark) {
             // No existing mark at the end of the selection: create new
@@ -193,11 +192,7 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
             // (up to `to`) gets only the new note, right side keeps
             // the original mark unchanged.
             tr.removeMark(markFrom, markTo, markType);
-            tr.addMark(
-              markFrom,
-              to,
-              markType.create({ notes: [newNote] }),
-            );
+            tr.addMark(markFrom, to, markType.create({ notes: [newNote] }));
             tr.addMark(to, markTo, existingMark);
           }
 
@@ -231,7 +226,8 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
             return null;
           }
 
-          const markType: MarkType | undefined = newState.schema.marks[markName];
+          const markType: MarkType | undefined =
+            newState.schema.marks[markName];
           if (!markType) return null;
 
           // Collect textblock start positions impacted by any transaction.
@@ -255,7 +251,11 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
               e = originMaps[j].map(e, 1);
             }
             // Map through subsequent transactions.
-            for (let later = startTrIdx + 1; later < transactions.length; later++) {
+            for (
+              let later = startTrIdx + 1;
+              later < transactions.length;
+              later++
+            ) {
               s = transactions[later].mapping.map(s, -1);
               e = transactions[later].mapping.map(e, 1);
             }
@@ -315,50 +315,43 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
             const block = newState.doc.nodeAt(blockPos);
             if (!block || !block.isTextblock) return;
 
-            // Walk direct children, grouping consecutive text nodes that share
-            // an .eq() endNoteLink mark. For each run of length > 1, remove the
-            // mark from all but the last fragment.
-            let runStart = -1;
-            let runEnd = -1;
-            let runMark: PMMark | null = null;
-
-            const flushRun = () => {
-              if (runStart === -1 || runMark === null) return;
-              if (runEnd <= runStart) return;
-              let offset = blockPos + 1;
-              for (let i = 0; i < runStart; i++) {
-                offset += block.child(i).nodeSize;
-              }
-              for (let i = runStart; i < runEnd; i++) {
-                const child = block.child(i);
-                tr.removeMark(offset, offset + child.nodeSize, markType);
-                offset += child.nodeSize;
-                changed = true;
-              }
-            };
+            // Walk all direct text children of the block and group them by
+            // `endNoteLink` mark equality. For each group, the mark stays on
+            // the LAST occurrence in document order and is stripped from every
+            // earlier occurrence — even when those occurrences are separated
+            // by other inline content.
+            const groups: Array<{
+              mark: PMMark;
+              indices: number[];
+            }> = [];
 
             for (let i = 0; i < block.childCount; i++) {
               const child = block.child(i);
-              const mark = child.isText
-                ? child.marks.find((m) => m.type === markType) ?? null
-                : null;
-
-              if (mark && runMark && mark.eq(runMark)) {
-                runEnd = i;
+              if (!child.isText) continue;
+              const mark = child.marks.find((m) => m.type === markType);
+              if (!mark) continue;
+              const existing = groups.find((g) => g.mark.eq(mark));
+              if (existing) {
+                existing.indices.push(i);
               } else {
-                flushRun();
-                if (mark) {
-                  runStart = i;
-                  runEnd = i;
-                  runMark = mark;
-                } else {
-                  runStart = -1;
-                  runEnd = -1;
-                  runMark = null;
-                }
+                groups.push({ mark, indices: [i] });
               }
             }
-            flushRun();
+
+            for (const group of groups) {
+              if (group.indices.length <= 1) continue;
+              // Keep the mark on the last occurrence; remove from the rest.
+              const earlier = group.indices.slice(0, -1);
+              for (const idx of earlier) {
+                let offset = blockPos + 1;
+                for (let j = 0; j < idx; j++) {
+                  offset += block.child(j).nodeSize;
+                }
+                const child = block.child(idx);
+                tr.removeMark(offset, offset + child.nodeSize, markType);
+                changed = true;
+              }
+            }
           });
 
           return changed ? tr : null;


### PR DESCRIPTION
### Summary

The previous PR (#376) addressed duplicating endnote link marks when splitting text blocks. This fixes the related but slightly different issue of handling duplication when text is inserted into a text block.

### Linear

- [DEV-661](https://linear.app/84000/issue/DEV-661)
