### PR TITLE
Fix Bubble Menu Extending Offscreen

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/menus/EmptyBubbleMenu.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/EmptyBubbleMenu.tsx
@@ -12,6 +12,7 @@ export const EmptyBubbleMenu = ({ editor }: { editor: Editor | null }) => {
   return (
     <BubbleMenu
       editor={editor}
+      appendTo={() => document.body}
       options={{
         placement: 'top',
         offset: 6,
@@ -31,7 +32,7 @@ export const EmptyBubbleMenu = ({ editor }: { editor: Editor | null }) => {
         return true;
       }}
     >
-      <ScrollArea className="max-w-[90vw] rounded-md border bg-popover shadow-xl">
+      <ScrollArea className="max-w-[90vw] rounded-md border bg-popover shadow-xl z-50">
         <div className="py-2 px-4 text-muted-foreground italic">
           No menu options available
         </div>

--- a/libs/lib-editing/src/lib/components/editor/menus/EmptyBubbleMenu.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/EmptyBubbleMenu.tsx
@@ -3,14 +3,20 @@
 import { Editor } from '@tiptap/core';
 import { BubbleMenu } from '@tiptap/react/menus';
 import { ScrollArea, ScrollBar } from '@eightyfourthousand/design-system';
+import { useRef } from 'react';
+import { useDismissBubbleMenu } from './useDismissBubbleMenu';
 
 export const EmptyBubbleMenu = ({ editor }: { editor: Editor | null }) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useDismissBubbleMenu(editor, menuRef);
+
   if (!editor) {
     return null;
   }
 
   return (
     <BubbleMenu
+      ref={menuRef}
       editor={editor}
       appendTo={() => document.body}
       options={{

--- a/libs/lib-editing/src/lib/components/editor/menus/MainBubbleMenu.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/MainBubbleMenu.tsx
@@ -3,15 +3,21 @@
 import { Editor } from '@tiptap/core';
 import { BubbleMenu } from '@tiptap/react/menus';
 import { ScrollArea, Separator, ScrollBar } from '@eightyfourthousand/design-system';
+import { useRef } from 'react';
 import { NodeSelector, TextAlignSelector, TextButtons } from './selectors';
+import { useDismissBubbleMenu } from './useDismissBubbleMenu';
 
 export const MainBubbleMenu = ({ editor }: { editor: Editor | null }) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useDismissBubbleMenu(editor, menuRef);
+
   if (!editor) {
     return null;
   }
 
   return (
     <BubbleMenu
+      ref={menuRef}
       editor={editor}
       appendTo={() => document.body}
       options={{

--- a/libs/lib-editing/src/lib/components/editor/menus/MainBubbleMenu.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/MainBubbleMenu.tsx
@@ -13,6 +13,7 @@ export const MainBubbleMenu = ({ editor }: { editor: Editor | null }) => {
   return (
     <BubbleMenu
       editor={editor}
+      appendTo={() => document.body}
       options={{
         placement: 'top',
         offset: 6,
@@ -36,7 +37,7 @@ export const MainBubbleMenu = ({ editor }: { editor: Editor | null }) => {
         return true;
       }}
     >
-      <ScrollArea className="max-w-[90vw] rounded-md border bg-popover shadow-xl">
+      <ScrollArea className="max-w-[90vw] rounded-md border bg-popover shadow-xl z-50">
         <div className="flex">
           <NodeSelector editor={editor} />
           <Separator orientation="vertical" className="h-10" />

--- a/libs/lib-editing/src/lib/components/editor/menus/TranslationBubbleMenu.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/TranslationBubbleMenu.tsx
@@ -3,21 +3,27 @@
 import { Editor } from '@tiptap/core';
 import { BubbleMenu } from '@tiptap/react/menus';
 import { ScrollArea, Separator, ScrollBar } from '@eightyfourthousand/design-system';
+import { useRef } from 'react';
 import { TranslationTextButtons } from './selectors/TranslationTextButtons';
 import { ParagraphButtons } from './selectors/ParagraphButtons';
 import { TranslationNodeSelector } from './selectors/TranslationNodeSelector';
+import { useDismissBubbleMenu } from './useDismissBubbleMenu';
 
 export const TranslationBubbleMenu = ({
   editor,
 }: {
   editor: Editor | null;
 }) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useDismissBubbleMenu(editor, menuRef);
+
   if (!editor) {
     return null;
   }
 
   return (
     <BubbleMenu
+      ref={menuRef}
       editor={editor}
       appendTo={() => document.body}
       options={{

--- a/libs/lib-editing/src/lib/components/editor/menus/TranslationBubbleMenu.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/TranslationBubbleMenu.tsx
@@ -19,6 +19,7 @@ export const TranslationBubbleMenu = ({
   return (
     <BubbleMenu
       editor={editor}
+      appendTo={() => document.body}
       options={{
         placement: 'top',
         offset: 6,
@@ -42,7 +43,7 @@ export const TranslationBubbleMenu = ({
         return true;
       }}
     >
-      <ScrollArea className="max-w-[90vw] rounded-md border bg-popover shadow-xl z-10">
+      <ScrollArea className="max-w-[90vw] rounded-md border bg-popover shadow-xl z-50">
         <div className="flex">
           <TranslationNodeSelector editor={editor} />
           <Separator orientation="vertical" className="h-10" />

--- a/libs/lib-editing/src/lib/components/editor/menus/index.ts
+++ b/libs/lib-editing/src/lib/components/editor/menus/index.ts
@@ -1,3 +1,4 @@
 export * from './EmptyBubbleMenu';
 export * from './MainBubbleMenu';
 export * from './TranslationBubbleMenu';
+export * from './useDismissBubbleMenu';

--- a/libs/lib-editing/src/lib/components/editor/menus/useDismissBubbleMenu.ts
+++ b/libs/lib-editing/src/lib/components/editor/menus/useDismissBubbleMenu.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { Editor } from '@tiptap/core';
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Collapses the editor selection (dismissing the bubble menu) when the user
+ * clicks anywhere outside both the menu and the editor itself. Clicks inside
+ * the editor are left alone so native selection handling can run.
+ */
+export const useDismissBubbleMenu = (
+  editor: Editor | null,
+  menuRef: RefObject<HTMLDivElement | null>,
+) => {
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+
+      if (!target) {
+        return;
+      }
+
+      if (menuRef.current?.contains(target)) {
+        return;
+      }
+
+      if (editor.view.dom.contains(target)) {
+        return;
+      }
+
+      if (editor.state.selection.empty) {
+        return;
+      }
+
+      editor.commands.setTextSelection(editor.state.selection.from);
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [editor, menuRef]);
+};


### PR DESCRIPTION
### Summary

Attach the bubble menus to the html body instead of the default. This ensures it renders using the available space in the top-level UI instead of aligning awkwardly and forcing unwanted scrolling behavior. In addition clicking any where will dismiss the bubble menu.

### Linear

- [DEV-662](https://linear.app/84000/issue/DEV-662)
