### PR TITLE
Non distracted view

### DIFF
--- a/libs/design-system/src/lib/ThreeColumns/ThreeColumns.tsx
+++ b/libs/design-system/src/lib/ThreeColumns/ThreeColumns.tsx
@@ -41,7 +41,7 @@ export type ImperativePanelHandle = RRImperativePanelHandle;
 const pct = (size: MinPanelSizes) => `${size}%`;
 
 export const LeftPanel = ({ children }: { children: ReactNode }) => {
-  return <div className='size-full'>{children}</div>;
+  return <div className="size-full">{children}</div>;
 };
 
 export const MainPanel = ({ children }: { children: ReactNode }) => {
@@ -49,12 +49,14 @@ export const MainPanel = ({ children }: { children: ReactNode }) => {
 };
 
 export const RightPanel = ({ children }: { children: ReactNode }) => {
-  return <div className='size-full'>{children}</div>;
+  return <div className="size-full">{children}</div>;
 };
 
 export const MainPanelHeader = ({ children }: { children?: ReactNode }) => {
   return (
-    <div className="sticky top-16 flex justify-end z-10 pointer-events-none">{children}</div>
+    <div className="sticky top-16 flex justify-end z-10 pointer-events-none">
+      {children}
+    </div>
   );
 };
 
@@ -205,7 +207,7 @@ export const ThreeColumns = ({
               )}
             </div>
           </div>
-          <div className='bg-surface flex-1'>
+          <div className="bg-surface flex-1">
             {mainHeaderChildren}
             {mainPanelChildren}
           </div>
@@ -221,7 +223,9 @@ export const ThreeColumns = ({
             >
               <SheetHeader className="sr-only">
                 <SheetTitle>Left Panel</SheetTitle>
-                <SheetDescription>Navigation and content panel</SheetDescription>
+                <SheetDescription>
+                  Navigation and content panel
+                </SheetDescription>
               </SheetHeader>
               {leftPanelChildren}
             </SheetContent>
@@ -293,7 +297,7 @@ export const ThreeColumns = ({
                 <PanelLeftIcon />
                 <span className="sr-only">Toggle Left Panel</span>
               </Button>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-2">
                 {mainPanelActions}
                 {rightPanelEnabled && (
                   <Button
@@ -308,7 +312,7 @@ export const ThreeColumns = ({
                 )}
               </div>
             </div>
-            <div className='bg-surface flex-1'>
+            <div className="bg-surface flex-1">
               {mainHeaderChildren}
               {mainPanelChildren}
             </div>

--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -31,6 +31,20 @@
     @apply ml-0.75;
   }
 
+  /* Non-distracted view: hide endnote markers, neutralize glossary and
+     mention affordances while keeping their underlying text readable. */
+  .focus-mode .end-note-link {
+    @apply hidden;
+  }
+
+  .focus-mode .glossary-instance {
+    @apply text-foreground no-underline cursor-auto;
+  }
+
+  .focus-mode .mention-link {
+    @apply text-foreground no-underline cursor-auto;
+  }
+
   .glossary-instance-definition {
     p {
       @apply mb-1 mt-2 @c/sidebar:pt-1;

--- a/libs/lib-editing/src/lib/components/reader/ReaderLayout.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderLayout.tsx
@@ -31,7 +31,7 @@ export const ReaderLayout = ({
       uuid={slug}
       initialHasTranslationContent={initialHasTranslationContent}
     >
-      <ThreeColumnRenderer withHeader={withHeader}>
+      <ThreeColumnRenderer withHeader={withHeader} withFocusToggle>
         <LeftPanel>{left}</LeftPanel>
         <MainPanelHeader>
           <EditorHeader />

--- a/libs/lib-editing/src/lib/components/reader/ReaderLayout.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderLayout.tsx
@@ -34,7 +34,7 @@ export const ReaderLayout = ({
       <ThreeColumnRenderer withHeader={withHeader} withFocusToggle>
         <LeftPanel>{left}</LeftPanel>
         <MainPanelHeader>
-          <EditorHeader />
+          <div className="h-12" />
         </MainPanelHeader>
         <MainPanel>{main}</MainPanel>
         <RightPanel>{right}</RightPanel>

--- a/libs/lib-editing/src/lib/components/shared/BodyPanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/BodyPanel.tsx
@@ -138,7 +138,7 @@ export const BodyPanel = ({
       defaultValue={hasTranslationContent ? 'translation' : 'source'}
       className="px-12 w-full"
     >
-      <div className="sticky top-0.75 -mt-28 z-10 overflow-x-auto text-center pointer-events-none me-8 sm:me-0 md:w-full">
+      <div className="sticky top-0.75 -mt-28 z-10 overflow-x-auto text-center pointer-events-none me-12 sm:me-0 md:w-full">
         <TabsList className="w-fit inline-flex pointer-events-auto">
           <TabsTrigger value="front">Front</TabsTrigger>
           {hasTranslationContent && (

--- a/libs/lib-editing/src/lib/components/shared/FocusToggleButton.tsx
+++ b/libs/lib-editing/src/lib/components/shared/FocusToggleButton.tsx
@@ -10,14 +10,14 @@ export const FocusToggleButton = () => {
 
   return (
     <Button
-      variant="link"
+      variant="ghost"
       size="icon"
       aria-pressed={focusMode}
       className={cn(
-        'cursor-pointer rounded-full [&_svg]:size-5 [&_svg]:stroke-1 transition-all',
+        'cursor-pointer [&_svg]:size-5 md:[&_svg]:size-7 size-6 md:size-9 [&_svg]:stroke-1 transition-all',
         focusMode
           ? 'bg-accent text-accent-foreground hover:bg-accent/90'
-          : 'text-accent/60 hover:text-accent hover:bg-muted',
+          : 'text-accent hover:text-accent hover:bg-muted',
       )}
       onClick={() => setFocusMode(!focusMode)}
     >

--- a/libs/lib-editing/src/lib/components/shared/FocusToggleButton.tsx
+++ b/libs/lib-editing/src/lib/components/shared/FocusToggleButton.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Button } from '@eightyfourthousand/design-system';
+import { cn } from '@eightyfourthousand/lib-utils';
+import { Glasses } from 'lucide-react';
+import { useNavigation } from './NavigationProvider';
+
+export const FocusToggleButton = () => {
+  const { focusMode, setFocusMode } = useNavigation();
+
+  return (
+    <Button
+      variant="link"
+      size="icon"
+      aria-pressed={focusMode}
+      className={cn(
+        'cursor-pointer [&_svg]:size-5 [&_svg]:stroke-1 transition-all',
+        focusMode ? 'text-accent' : 'text-accent/60 hover:text-accent',
+      )}
+      onClick={() => setFocusMode(!focusMode)}
+    >
+      <Glasses />
+      <span className="sr-only">Toggle non-distracted view</span>
+    </Button>
+  );
+};

--- a/libs/lib-editing/src/lib/components/shared/FocusToggleButton.tsx
+++ b/libs/lib-editing/src/lib/components/shared/FocusToggleButton.tsx
@@ -14,8 +14,10 @@ export const FocusToggleButton = () => {
       size="icon"
       aria-pressed={focusMode}
       className={cn(
-        'cursor-pointer [&_svg]:size-5 [&_svg]:stroke-1 transition-all',
-        focusMode ? 'text-accent' : 'text-accent/60 hover:text-accent',
+        'cursor-pointer rounded-full [&_svg]:size-5 [&_svg]:stroke-1 transition-all',
+        focusMode
+          ? 'bg-accent text-accent-foreground hover:bg-accent/90'
+          : 'text-accent/60 hover:text-accent hover:bg-muted',
       )}
       onClick={() => setFocusMode(!focusMode)}
     >

--- a/libs/lib-editing/src/lib/components/shared/NavigationContext.ts
+++ b/libs/lib-editing/src/lib/components/shared/NavigationContext.ts
@@ -18,9 +18,11 @@ export interface NavigationState {
   toh?: TohokuCatalogEntry;
   showOuterContent: boolean;
   hasTranslationContent: boolean;
+  focusMode: boolean;
   setToh: (toh: TohokuCatalogEntry) => void;
   setShowOuterContent: (withTitles: boolean) => void;
   setHasTranslationContent: (hasTranslationContent: boolean) => void;
+  setFocusMode: (focusMode: boolean) => void;
   updatePanel: (params: { name: PanelName; state: PanelState }) => void;
   fetchBibliographyEntry: (
     uuid: string,
@@ -44,10 +46,12 @@ export const NavigationContext = createContext<NavigationState>({
   panels: DEFAULT_PANELS,
   showOuterContent: true,
   hasTranslationContent: true,
+  focusMode: false,
   updatePanel: () => { throw new Error('Not implemented'); },
   setToh: () => { throw new Error('Not implemented'); },
   setShowOuterContent: () => { throw new Error('Not implemented'); },
   setHasTranslationContent: () => { throw new Error('Not implemented'); },
+  setFocusMode: () => { throw new Error('Not implemented'); },
   fetchBibliographyEntry: async () => { throw new Error('Not implemented'); },
   fetchEndNote: async () => { throw new Error('Not implemented'); },
   fetchGlossaryTerm: async () => { throw new Error('Not implemented'); },

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -94,6 +94,7 @@ export const NavigationProvider = ({
   const isPanelTransitioning = useRef(false);
   const [toh, setToh] = useState<TohokuCatalogEntry | undefined>();
   const [showOuterContent, setShowOuterContent] = useState(true);
+  const [focusMode, setFocusMode] = useState(false);
   const [hasTranslationContent, setHasTranslationContent] = useState(
     initialHasTranslationContent,
   );
@@ -387,9 +388,11 @@ export const NavigationProvider = ({
       toh,
       showOuterContent,
       hasTranslationContent,
+      focusMode,
       setToh,
       setShowOuterContent,
       setHasTranslationContent,
+      setFocusMode,
       updatePanel,
       fetchBibliographyEntry,
       fetchEndNote,
@@ -404,9 +407,11 @@ export const NavigationProvider = ({
       toh,
       showOuterContent,
       hasTranslationContent,
+      focusMode,
       setToh,
       setShowOuterContent,
       setHasTranslationContent,
+      setFocusMode,
       updatePanel,
       fetchBibliographyEntry,
       fetchEndNote,

--- a/libs/lib-editing/src/lib/components/shared/ThreeColumnRenderer.tsx
+++ b/libs/lib-editing/src/lib/components/shared/ThreeColumnRenderer.tsx
@@ -6,25 +6,38 @@ import { useNavigation } from './NavigationProvider';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { TranslationHeader } from './TranslationHeader';
 import { ReaderSearchButton } from './ReaderSearchButton';
+import { FocusToggleButton } from './FocusToggleButton';
 import { GatedFeature } from '@eightyfourthousand/lib-instr';
 
 export const ThreeColumnRenderer = ({
   withHeader = false,
+  withFocusToggle = false,
   children,
 }: {
   withHeader?: boolean;
+  withFocusToggle?: boolean;
   children: ReactNode;
 }) => {
-  const { panels, updatePanel, hasTranslationContent } = useNavigation();
+  const { panels, updatePanel, hasTranslationContent, focusMode } =
+    useNavigation();
   const rightPanelEnabled = hasTranslationContent;
 
-  const searchButton = useMemo(() => <ReaderSearchButton />, []);
+  const mainPanelActions = useMemo(
+    () => (
+      <>
+        {withFocusToggle && <FocusToggleButton />}
+        <ReaderSearchButton />
+      </>
+    ),
+    [withFocusToggle],
+  );
 
   return (
     <div
       className={cn(
         'fixed flex flex-col size-full p-2 bg-canvas',
         withHeader ? 'pb-20' : '',
+        withFocusToggle && focusMode && 'focus-mode',
       )}
     >
       <GatedFeature flag='show-reader-header'>
@@ -36,7 +49,7 @@ export const ThreeColumnRenderer = ({
         leftPanelOpen={panels.left.open}
         rightPanelOpen={rightPanelEnabled ? panels.right.open : false}
         rightPanelEnabled={rightPanelEnabled}
-        mainPanelActions={searchButton}
+        mainPanelActions={mainPanelActions}
         onLeftPanelOpenChange={(open) => {
           updatePanel({
             name: 'left',

--- a/libs/lib-editing/src/lib/components/shared/ThreeColumnRenderer.tsx
+++ b/libs/lib-editing/src/lib/components/shared/ThreeColumnRenderer.tsx
@@ -25,8 +25,8 @@ export const ThreeColumnRenderer = ({
   const mainPanelActions = useMemo(
     () => (
       <>
-        {withFocusToggle && <FocusToggleButton />}
         <ReaderSearchButton />
+        {withFocusToggle && <FocusToggleButton />}
       </>
     ),
     [withFocusToggle],
@@ -40,7 +40,7 @@ export const ThreeColumnRenderer = ({
         withFocusToggle && focusMode && 'focus-mode',
       )}
     >
-      <GatedFeature flag='show-reader-header'>
+      <GatedFeature flag="show-reader-header">
         <div className="pb-2.5">
           <TranslationHeader className="rounded-full shadow-lg" />
         </div>
@@ -59,11 +59,11 @@ export const ThreeColumnRenderer = ({
         onRightPanelOpenChange={
           rightPanelEnabled
             ? (open) => {
-              updatePanel({
-                name: 'right',
-                state: { open, tab: panels.right.tab },
-              });
-            }
+                updatePanel({
+                  name: 'right',
+                  state: { open, tab: panels.right.tab },
+                });
+              }
             : undefined
         }
       >

--- a/libs/lib-editing/src/lib/components/shared/index.ts
+++ b/libs/lib-editing/src/lib/components/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './AiSummarizerPage';
+export * from './FocusToggleButton';
 export * from './NavigationProvider';
 export * from './LabeledElement';
 export * from './SuggestRevisionForm';

--- a/libs/lib-search/src/lib/ui/SearchButton.tsx
+++ b/libs/lib-search/src/lib/ui/SearchButton.tsx
@@ -152,10 +152,10 @@ export const SearchButton = ({
       });
       setHasResults(
         !!nextResults &&
-        (nextResults.passages.length > 0 ||
-          nextResults.alignments.length > 0 ||
-          nextResults.bibliographies.length > 0 ||
-          nextResults.glossaries.length > 0),
+          (nextResults.passages.length > 0 ||
+            nextResults.alignments.length > 0 ||
+            nextResults.bibliographies.length > 0 ||
+            nextResults.glossaries.length > 0),
       );
       setResults(nextResults);
 
@@ -269,11 +269,11 @@ export const SearchButton = ({
       const nextPassageIndex =
         pendingSelection.kind === 'cursor' && currentPassageOrder != null
           ? passageOccurrences.findIndex((occurrence) => {
-            const occurrenceOrder = passageOrder.get(occurrence.passageUuid);
-            return (
-              occurrenceOrder != null && occurrenceOrder > currentPassageOrder
-            );
-          })
+              const occurrenceOrder = passageOrder.get(occurrence.passageUuid);
+              return (
+                occurrenceOrder != null && occurrenceOrder > currentPassageOrder
+              );
+            })
           : -1;
 
       setActiveOccurrenceIndexState(
@@ -362,7 +362,7 @@ export const SearchButton = ({
         <Button
           variant="ghost"
           size="icon"
-          className="bg-background my-auto [&_svg]:size-6 [&_svg]:stroke-1 hover:bg-background cursor-pointer text-base text-accent hover:text-accent/80"
+          className="bg-background my-auto [&_svg]:size-5 md:[&_svg]:size-6 size-6 [&_svg]:stroke-1 hover:bg-muted cursor-pointer text-base text-accent hover:text-accent/80"
         >
           <SearchIcon />
         </Button>
@@ -452,7 +452,7 @@ export const SearchButton = ({
                           <SearchResultsList
                             activeOccurrenceStart={
                               activeOccurrenceStart != null &&
-                                shouldScrollActiveOccurrence
+                              shouldScrollActiveOccurrence
                                 ? activeOccurrenceStart
                                 : undefined
                             }


### PR DESCRIPTION
### Summary

Adds a toggle to the reader (but not editor) that allows users to hide glossary instances, endnote links, and mentions. This can be expanded to include other annotations as well.

### Linear

- [DEV-678](https://linear.app/84000/issue/DEV-678)