### PR TITLE
Folio Mention Prep

### DIFF
--- a/apps/api-graphql/src/graphql/resolvers.ts
+++ b/apps/api-graphql/src/graphql/resolvers.ts
@@ -3,7 +3,10 @@ import {
   bibliographyEntryResolver,
   workBibliographyResolver,
 } from './schema/bibliography/bibliography.resolver';
-import { workFoliosResolver } from './schema/folio/folio.resolver';
+import {
+  workFoliosResolver,
+  workFoliosAroundResolver,
+} from './schema/folio/folio.resolver';
 import {
   glossaryInstanceResolver,
   workGlossaryResolver,
@@ -61,6 +64,7 @@ export const resolvers = {
     searchGlossaryTerms: searchWorkGlossaryTermsResolver,
     bibliography: workBibliographyResolver,
     folios: workFoliosResolver,
+    foliosAround: workFoliosAroundResolver,
   },
 
   GlossaryTermInstance: {

--- a/apps/api-graphql/src/graphql/schema/folio/folio.graphql
+++ b/apps/api-graphql/src/graphql/schema/folio/folio.graphql
@@ -36,6 +36,31 @@ type Folio {
   side: FolioSide!
 }
 
+"""
+A window of folios centered on a target folio, with flags for further loading
+"""
+type FoliosAround {
+  """
+  The folios in the window, in reading order
+  """
+  folios: [Folio!]!
+
+  """
+  Absolute 0-indexed position of the first folio in the window
+  """
+  startIndex: Int!
+
+  """
+  Whether folios exist before the window
+  """
+  hasMoreBefore: Boolean!
+
+  """
+  Whether folios exist after the window
+  """
+  hasMoreAfter: Boolean!
+}
+
 extend type Work {
   """
   Folios for this work, filtered by toh and paginated
@@ -55,5 +80,35 @@ extend type Work {
     Number of folios per page
     """
     size: Int
+
+    """
+    Absolute offset into the ordered folio list (takes precedence over page)
+    """
+    offset: Int
   ): [Folio!]!
+
+  """
+  A window of folios centered on a target folio, for deep-linking
+  """
+  foliosAround(
+    """
+    Tohoku catalog entry (e.g., "toh94")
+    """
+    toh: String!
+
+    """
+    UUID of the folio to center the window on
+    """
+    folioUuid: ID!
+
+    """
+    Number of folios to include before the target
+    """
+    before: Int
+
+    """
+    Number of folios to include after the target
+    """
+    after: Int
+  ): FoliosAround
 }

--- a/apps/api-graphql/src/graphql/schema/folio/folio.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/folio/folio.resolver.ts
@@ -2,7 +2,9 @@ import type { GraphQLContext } from '../../context';
 import type { WorkParent } from '../work/work.types';
 import {
   getWorkFolios,
+  getWorkFoliosAround,
   type Folio,
+  type FoliosAround,
   type TohokuCatalogEntry,
 } from '@eightyfourthousand/data-access';
 
@@ -11,7 +13,7 @@ import {
  */
 export const workFoliosResolver = async (
   parent: WorkParent,
-  args: { toh: string; page?: number; size?: number },
+  args: { toh: string; page?: number; size?: number; offset?: number },
   ctx: GraphQLContext,
 ): Promise<Folio[]> => {
   return getWorkFolios({
@@ -20,5 +22,25 @@ export const workFoliosResolver = async (
     toh: args.toh as TohokuCatalogEntry,
     page: args.page,
     size: args.size,
+    offset: args.offset ?? undefined,
+  });
+};
+
+/**
+ * Resolver for Work.foliosAround - fetches a window of folios centered on a
+ * target folio, for deep-linking into the source reader.
+ */
+export const workFoliosAroundResolver = async (
+  parent: WorkParent,
+  args: { toh: string; folioUuid: string; before?: number; after?: number },
+  ctx: GraphQLContext,
+): Promise<FoliosAround | null> => {
+  return getWorkFoliosAround({
+    client: ctx.supabase,
+    uuid: parent.uuid,
+    toh: args.toh as TohokuCatalogEntry,
+    folioUuid: args.folioUuid,
+    before: args.before ?? undefined,
+    after: args.after ?? undefined,
   });
 };

--- a/libs/client-graphql/src/index.ts
+++ b/libs/client-graphql/src/index.ts
@@ -31,6 +31,7 @@ export {
   getBibliographyEntry,
   getWorkBibliography,
   getWorkFolios,
+  getWorkFoliosAround,
   hasPermission,
   replace,
   savePassages,

--- a/libs/client-graphql/src/lib/functions/get-work-folios-around.ts
+++ b/libs/client-graphql/src/lib/functions/get-work-folios-around.ts
@@ -1,0 +1,71 @@
+import type { GraphQLClient } from 'graphql-request';
+import { gql } from 'graphql-request';
+import type { FoliosAround } from '@eightyfourthousand/data-access';
+
+const GET_WORK_FOLIOS_AROUND = gql`
+  query GetWorkFoliosAround(
+    $uuid: ID!
+    $toh: String!
+    $folioUuid: ID!
+    $before: Int
+    $after: Int
+  ) {
+    work(uuid: $uuid) {
+      foliosAround(
+        toh: $toh
+        folioUuid: $folioUuid
+        before: $before
+        after: $after
+      ) {
+        folios {
+          uuid
+          content
+          volume
+          folio
+          side
+        }
+        startIndex
+        hasMoreBefore
+        hasMoreAfter
+      }
+    }
+  }
+`;
+
+type GetWorkFoliosAroundResponse = {
+  work: {
+    foliosAround: FoliosAround | null;
+  } | null;
+};
+
+/**
+ * Get a window of folios centered on a target folio, for deep-linking into
+ * the source reader. Returns `null` when the folio isn't part of the work/toh.
+ */
+export async function getWorkFoliosAround({
+  client,
+  uuid,
+  toh,
+  folioUuid,
+  before,
+  after,
+}: {
+  client: GraphQLClient;
+  uuid: string;
+  toh: string;
+  folioUuid: string;
+  before?: number;
+  after?: number;
+}): Promise<FoliosAround | null> {
+  try {
+    const response = await client.request<GetWorkFoliosAroundResponse>(
+      GET_WORK_FOLIOS_AROUND,
+      { uuid, toh, folioUuid, before, after },
+    );
+
+    return response.work?.foliosAround ?? null;
+  } catch (error) {
+    console.error('Error fetching folios around:', error);
+    return null;
+  }
+}

--- a/libs/client-graphql/src/lib/functions/get-work-folios.ts
+++ b/libs/client-graphql/src/lib/functions/get-work-folios.ts
@@ -3,9 +3,15 @@ import { gql } from 'graphql-request';
 import type { Folio } from '@eightyfourthousand/data-access';
 
 const GET_WORK_FOLIOS = gql`
-  query GetWorkFolios($uuid: ID!, $toh: String!, $page: Int, $size: Int) {
+  query GetWorkFolios(
+    $uuid: ID!
+    $toh: String!
+    $page: Int
+    $size: Int
+    $offset: Int
+  ) {
     work(uuid: $uuid) {
-      folios(toh: $toh, page: $page, size: $size) {
+      folios(toh: $toh, page: $page, size: $size, offset: $offset) {
         uuid
         content
         volume
@@ -31,17 +37,19 @@ export async function getWorkFolios({
   toh,
   page = 0,
   size = 10,
+  offset,
 }: {
   client: GraphQLClient;
   uuid: string;
   toh: string;
   page?: number;
   size?: number;
+  offset?: number;
 }): Promise<Folio[]> {
   try {
     const response = await client.request<GetWorkFoliosResponse>(
       GET_WORK_FOLIOS,
-      { uuid, toh, page, size },
+      { uuid, toh, page, size, offset },
     );
 
     return response.work?.folios ?? [];

--- a/libs/client-graphql/src/lib/functions/index.ts
+++ b/libs/client-graphql/src/lib/functions/index.ts
@@ -31,6 +31,7 @@ export {
 export { getBibliographyEntry } from './get-bibliography-entry';
 export { getWorkBibliography } from './get-work-bibliography';
 export { getWorkFolios } from './get-work-folios';
+export { getWorkFoliosAround } from './get-work-folios-around';
 export { hasPermission, type Permission } from './has-permission';
 export { replace, type ReplaceType, type ReplacedPassage } from './replace';
 export { savePassages } from './save-passages';

--- a/libs/client-graphql/src/lib/generated/graphql.ts
+++ b/libs/client-graphql/src/lib/generated/graphql.ts
@@ -115,6 +115,19 @@ export type FolioSide =
   | 'a'
   | 'b';
 
+/** A window of folios centered on a target folio, with flags for further loading */
+export type FoliosAround = {
+  __typename?: 'FoliosAround';
+  /** The folios in the window, in reading order */
+  folios: Array<Folio>;
+  /** Whether folios exist after the window */
+  hasMoreAfter: Scalars['Boolean']['output'];
+  /** Whether folios exist before the window */
+  hasMoreBefore: Scalars['Boolean']['output'];
+  /** Absolute 0-indexed position of the first folio in the window */
+  startIndex: Scalars['Int']['output'];
+};
+
 /** Paginated passage references for a glossary term */
 export type GlossaryPassagesPage = {
   __typename?: 'GlossaryPassagesPage';
@@ -659,6 +672,8 @@ export type Work = {
   bibliography: Array<BibliographyEntry>;
   /** Folios for this work, filtered by toh and paginated */
   folios: Array<Folio>;
+  /** A window of folios centered on a target folio, for deep-linking */
+  foliosAround?: Maybe<FoliosAround>;
   /**
    * Glossary term instances for this work
    * @deprecated Use glossaryTerms for paginated access
@@ -705,8 +720,18 @@ export type Work = {
 
 /** A published translation work from the 84000 canon */
 export type WorkFoliosArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
   size?: InputMaybe<Scalars['Int']['input']>;
+  toh: Scalars['String']['input'];
+};
+
+
+/** A published translation work from the 84000 canon */
+export type WorkFoliosAroundArgs = {
+  after?: InputMaybe<Scalars['Int']['input']>;
+  before?: InputMaybe<Scalars['Int']['input']>;
+  folioUuid: Scalars['ID']['input'];
   toh: Scalars['String']['input'];
 };
 

--- a/libs/data-access/src/lib/folio.ts
+++ b/libs/data-access/src/lib/folio.ts
@@ -115,6 +115,41 @@ export const getWorkFoliosAround = async ({
   };
 };
 
+type FolioLocation = {
+  workUuid: string;
+  folioUuid: string;
+  toh: TohokuCatalogEntry;
+};
+
+/**
+ * Resolve a single folio by its UUID to its parent work + toh. Used by entity
+ * lookup to build a deep link into the work's source tab.
+ */
+export const getFolioLocation = async ({
+  client,
+  uuid,
+}: {
+  client: DataClient;
+  uuid: string;
+}): Promise<FolioLocation | null> => {
+  const { data, error } = await client
+    .from('tibetan_works_folios')
+    .select('work_uuid, folio_uuid, toh')
+    .eq('folio_uuid', uuid)
+    .single();
+
+  if (error || !data) {
+    console.error('Error fetching folio location:', error);
+    return null;
+  }
+
+  return {
+    workUuid: data.work_uuid as string,
+    folioUuid: data.folio_uuid as string,
+    toh: data.toh as TohokuCatalogEntry,
+  };
+};
+
 export const getFolios = async ({
   uuid,
   toh,

--- a/libs/data-access/src/lib/folio.ts
+++ b/libs/data-access/src/lib/folio.ts
@@ -2,7 +2,7 @@
 
 import { createServerClient } from './client-ssr';
 import { DataClient, TohokuCatalogEntry } from './types';
-import { FolioDTO, folioFromDTO } from './types/folio';
+import { FolioDTO, FoliosAround, folioFromDTO } from './types/folio';
 
 type GetWorkFoliosArgs = {
   client: DataClient;
@@ -10,6 +10,11 @@ type GetWorkFoliosArgs = {
   toh: TohokuCatalogEntry;
   page?: number;
   size?: number;
+  /**
+   * Absolute offset into the ordered folio list. When provided, takes
+   * precedence over `page` (which is otherwise `page * size`).
+   */
+  offset?: number;
 };
 
 export const getWorkFolios = async ({
@@ -18,8 +23,9 @@ export const getWorkFolios = async ({
   toh,
   page = 0,
   size = 10,
+  offset,
 }: GetWorkFoliosArgs) => {
-  const start = page * size;
+  const start = offset ?? page * size;
   const end = start + size - 1;
   const { data, error } = await client
     .from('tibetan_works_folios')
@@ -44,6 +50,69 @@ export const getWorkFolios = async ({
   }
 
   return data.map((dto) => folioFromDTO(dto as FolioDTO));
+};
+
+type GetWorkFoliosAroundArgs = {
+  client: DataClient;
+  uuid: string;
+  toh: TohokuCatalogEntry;
+  folioUuid: string;
+  before?: number;
+  after?: number;
+};
+
+/**
+ * Fetch a window of folios centered on a target folio, plus flags indicating
+ * whether more folios exist before/after the window. Returns `null` when the
+ * folio isn't part of the work/toh.
+ */
+export const getWorkFoliosAround = async ({
+  client,
+  uuid,
+  toh,
+  folioUuid,
+  before = 10,
+  after = 10,
+}: GetWorkFoliosAroundArgs): Promise<FoliosAround | null> => {
+  // Resolve the target folio's position within the ordered list. Selecting
+  // only the uuid keeps this cheap even for works with many folios.
+  const { data, error } = await client
+    .from('tibetan_works_folios')
+    .select('folio_uuid')
+    .eq('work_uuid', uuid)
+    .eq('toh', toh)
+    .order('volume_number', { ascending: true })
+    .order('folio_number', { ascending: true })
+    .order('side', { ascending: true });
+
+  if (error) {
+    console.error('Error fetching folio index:', error);
+    return null;
+  }
+
+  const total = data.length;
+  const index = data.findIndex((row) => row.folio_uuid === folioUuid);
+  if (index === -1) {
+    return null;
+  }
+
+  const startIndex = Math.max(0, index - before);
+  const endIndex = Math.min(total - 1, index + after);
+
+  const folios = await getWorkFolios({
+    client,
+    uuid,
+    toh,
+    offset: startIndex,
+    size: endIndex - startIndex + 1,
+  });
+
+  return {
+    folios,
+    startIndex,
+    hasMoreBefore: startIndex > 0,
+    hasMoreAfter: endIndex < total - 1,
+  };
 };
 
 export const getFolios = async ({

--- a/libs/data-access/src/lib/lookup-entity.spec.ts
+++ b/libs/data-access/src/lib/lookup-entity.spec.ts
@@ -1,5 +1,6 @@
 import { lookupEntity } from './lookup-entity';
 import { getGlossaryInstance } from './glossary';
+import { getFolioLocation } from './folio';
 
 jest.mock('./client-ssr', () => ({
   createServerClient: jest.fn().mockResolvedValue({}),
@@ -7,6 +8,10 @@ jest.mock('./client-ssr', () => ({
 
 jest.mock('./bibliography', () => ({
   getBibliographyEntry: jest.fn(),
+}));
+
+jest.mock('./folio', () => ({
+  getFolioLocation: jest.fn(),
 }));
 
 jest.mock('./passage', () => ({
@@ -24,6 +29,7 @@ jest.mock('./glossary', () => ({
 }));
 
 const mockedGetGlossaryInstance = jest.mocked(getGlossaryInstance);
+const mockedGetFolioLocation = jest.mocked(getFolioLocation);
 
 describe('lookupEntity', () => {
   beforeEach(() => {
@@ -52,6 +58,28 @@ describe('lookupEntity', () => {
     expect(mockedGetGlossaryInstance).toHaveBeenCalledWith({
       client: {},
       uuid: 'glossary-uuid',
+    });
+  });
+
+  it('routes folio entities to the source tab in the main panel', async () => {
+    mockedGetFolioLocation.mockResolvedValue({
+      workUuid: 'work-uuid',
+      folioUuid: 'folio-uuid',
+      toh: 'toh1',
+    });
+
+    const result = await lookupEntity({
+      type: 'folio',
+      entity: 'folio-uuid',
+    });
+
+    expect(result.path).toBe(
+      '/work-uuid?main=open%3Asource%3Afolio-uuid&toh=toh1',
+    );
+
+    expect(mockedGetFolioLocation).toHaveBeenCalledWith({
+      client: {},
+      uuid: 'folio-uuid',
     });
   });
 });

--- a/libs/data-access/src/lib/lookup-entity.ts
+++ b/libs/data-access/src/lib/lookup-entity.ts
@@ -7,10 +7,12 @@ import {
 } from './publications';
 import { panelAndTabForContentType } from './panel-url';
 import { getGlossaryInstance } from './glossary';
+import { getFolioLocation } from './folio';
 import { DataClient } from './types';
 
 const ALLOWED_TYPES = [
   'bibliography',
+  'folio',
   'glossary',
   'passage',
   'translation',
@@ -83,6 +85,25 @@ export const lookupEntityWithClient = async ({
         workUuid = item.workUuid;
         uuid = item.uuid;
         query.set('right', `open:bibliography:${uuid}`);
+        path = `${prefix}/${workUuid}?${query.toString()}`;
+      }
+      break;
+    case 'folio':
+      {
+        const item = await getFolioLocation({ client, uuid: entity });
+        if (!item?.workUuid || !item.folioUuid) {
+          return {};
+        }
+
+        workUuid = item.workUuid;
+        uuid = item.folioUuid;
+        const { panel, tab } = panelAndTabForContentType('source');
+
+        query.set(panel, `open:${tab}:${uuid}`);
+        if (item.toh) {
+          query.set('toh', item.toh);
+        }
+
         path = `${prefix}/${workUuid}?${query.toString()}`;
       }
       break;

--- a/libs/data-access/src/lib/panel-url.ts
+++ b/libs/data-access/src/lib/panel-url.ts
@@ -46,7 +46,10 @@ export const urlForPanelContent = ({
 export const entityTypeForContentType = (
   contentType: PanelContentType,
 ): string => {
-  if (['compare', 'source', ...BODY_ITEM_TYPES].includes(contentType)) {
+  if (contentType === 'source') {
+    return 'folio';
+  }
+  if (['compare', ...BODY_ITEM_TYPES].includes(contentType)) {
     return 'passage';
   }
 
@@ -62,15 +65,6 @@ export const urlForEntity = ({
   uuid: string;
   contentType?: PanelContentType;
 }): string => {
-  // TODO: support folios in the entity endpoint
-  if (contentType === 'source') {
-    return urlForPanelContent({
-      location,
-      hash: uuid,
-      contentType,
-    });
-  }
-
   const { origin, href, search } = location;
   const searchParams = new URLSearchParams(search);
 

--- a/libs/data-access/src/lib/types/folio.ts
+++ b/libs/data-access/src/lib/types/folio.ts
@@ -17,6 +17,13 @@ export type Folio = {
   side: FolioSide;
 };
 
+export type FoliosAround = {
+  folios: Folio[];
+  startIndex: number;
+  hasMoreBefore: boolean;
+  hasMoreAfter: boolean;
+};
+
 export const folioFromDTO = (dto: FolioDTO): Folio => {
   return {
     uuid: dto.folio_uuid,

--- a/libs/lib-editing/src/lib/components/editor/EditorBackMatterPage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorBackMatterPage.tsx
@@ -23,6 +23,8 @@ export const EditorBackMatterPage = () => {
   const [endnotes, setEndnotes] = useState<TranslationEditorContent>();
   const [abbreviations, setAbbreviations] =
     useState<TranslationEditorContent>();
+  const [endnotesHasMore, setEndnotesHasMore] = useState<boolean>();
+  const [abbreviationsHasMore, setAbbreviationsHasMore] = useState<boolean>();
   const [glossary, setGlossary] = useState<GlossaryTermsPage>();
   const [bibliography, setBibliography] = useState<BibliographyEntries>();
 
@@ -32,8 +34,8 @@ export const EditorBackMatterPage = () => {
       const graphqlClient = createGraphQLClient();
 
       const [
-        { blocks: endnoteBlocks },
-        { blocks: abbreviationBlocks },
+        { blocks: endnoteBlocks, hasMoreAfter: endnoteHasMore },
+        { blocks: abbreviationBlocks, hasMoreAfter: abbreviationHasMore },
         glossaryData,
         bibliographyData,
       ] = await Promise.all([
@@ -59,20 +61,23 @@ export const EditorBackMatterPage = () => {
       ]);
 
       setEndnotes(endnoteBlocks);
+      setEndnotesHasMore(endnoteHasMore);
       setAbbreviations(abbreviationBlocks);
+      setAbbreviationsHasMore(abbreviationHasMore);
       setGlossary(glossaryData);
       setBibliography(bibliographyData);
     })();
   }, [work]);
 
   const renderTranslation = useCallback(
-    ({ content, name, className }: TranslationRenderer) => (
+    ({ content, name, className, hasMoreAfter }: TranslationRenderer) => (
       <TranslationBuilder
         content={content}
         name={name}
         className={className}
         filter={name}
         panel="right"
+        hasMoreAfter={hasMoreAfter}
       />
     ),
     [],
@@ -89,6 +94,8 @@ export const EditorBackMatterPage = () => {
       glossary={glossary}
       bibliography={bibliography}
       abbreviations={abbreviations}
+      endnotesHasMore={endnotesHasMore}
+      abbreviationsHasMore={abbreviationsHasMore}
       renderTranslation={renderTranslation}
       withAttestations={withAttestations}
       isEditor={true}

--- a/libs/lib-editing/src/lib/components/editor/EditorBodyPage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorBodyPage.tsx
@@ -22,32 +22,39 @@ export const EditorBodyPage = () => {
   const { work } = useEditorState();
   const [body, setBody] = useState<TranslationEditorContent>();
   const [frontMatter, setFrontMatter] = useState<TranslationEditorContent>();
+  const [frontMatterHasMore, setFrontMatterHasMore] = useState<boolean>();
+  const [bodyHasMore, setBodyHasMore] = useState<boolean>();
   const [titles, setTitles] = useState<Title[]>();
 
   useEffect(() => {
     (async () => {
       const client = createGraphQLClient();
 
-      const [{ blocks: frontBlocks }, { blocks: bodyBlocks }, titlesData] =
-        await Promise.all([
-          getTranslationBlocks({
-            client,
-            uuid: work.uuid,
-            type: FRONT_MATTER_FILTER,
-            maxPassages: INITIAL_PASSAGES,
-          }),
-          getTranslationBlocks({
-            client,
-            uuid: work.uuid,
-            type: BODY_MATTER_FILTER,
-            maxPassages: INITIAL_PASSAGES,
-          }),
-          getTranslationTitles({ client, uuid: work.uuid }),
-        ]);
+      const [
+        { blocks: frontBlocks, hasMoreAfter: frontHasMore },
+        { blocks: bodyBlocks, hasMoreAfter: bodyHasMoreAfter },
+        titlesData,
+      ] = await Promise.all([
+        getTranslationBlocks({
+          client,
+          uuid: work.uuid,
+          type: FRONT_MATTER_FILTER,
+          maxPassages: INITIAL_PASSAGES,
+        }),
+        getTranslationBlocks({
+          client,
+          uuid: work.uuid,
+          type: BODY_MATTER_FILTER,
+          maxPassages: INITIAL_PASSAGES,
+        }),
+        getTranslationTitles({ client, uuid: work.uuid }),
+      ]);
 
       setTitles(titlesData);
       setFrontMatter(frontBlocks);
+      setFrontMatterHasMore(frontHasMore);
       setBody(bodyBlocks);
+      setBodyHasMore(bodyHasMoreAfter);
     })();
   }, [work.uuid]);
 
@@ -59,13 +66,14 @@ export const EditorBodyPage = () => {
   );
 
   const renderTranslation = useCallback(
-    ({ content, name, className }: TranslationRenderer) => (
+    ({ content, name, className, hasMoreAfter }: TranslationRenderer) => (
       <TranslationBuilder
         content={content}
         name={name}
         className={className}
         filter={name === 'front' ? FRONT_MATTER_FILTER : BODY_MATTER_FILTER}
         panel="main"
+        hasMoreAfter={hasMoreAfter}
       />
     ),
     [],
@@ -80,6 +88,8 @@ export const EditorBodyPage = () => {
       titles={titles}
       frontMatter={frontMatter}
       body={body}
+      frontMatterHasMore={frontMatterHasMore}
+      bodyHasMore={bodyHasMore}
       renderTitles={renderTitles}
       renderTranslation={renderTranslation}
     />

--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -222,16 +222,15 @@ export const PaginationProvider = ({
             return;
           }
 
-          // Wait for editor to finish updating
-          await new Promise<void>((resolve) => {
-            const handleUpdate = () => {
-              editor?.off('update', handleUpdate);
-              requestAnimationFrame(() => resolve());
-            };
-
-            editor?.on('update', handleUpdate);
-            editor?.chain().clearContent().setContent(blocks).run();
-          });
+          // Replace the window synchronously. We intentionally do NOT await a
+          // TipTap 'update' event here: under the Collaboration (Yjs) extension
+          // — loaded only in the editor — TipTap v3 does not reliably emit
+          // 'update' for this programmatic clearContent/setContent (core
+          // suppresses it when the change arrives via the y-sync plugin or the
+          // doc compares equal). Awaiting it would hang navigation indefinitely,
+          // leaving isNavigatingRef stuck true and the view locked. The
+          // DOM-stability poll below is an event-independent readiness signal.
+          editor?.chain().clearContent().setContent(blocks).run();
           setStartCursor(hasMoreBefore && prevCursor ? prevCursor : undefined);
           setEndCursor(hasMoreAfter && nextCursor ? nextCursor : undefined);
           if (tab) {
@@ -243,8 +242,18 @@ export const PaginationProvider = ({
           await new Promise<void>((resolve) => {
             let stabilityCount = 0;
             let lastTop = -1;
+            let frames = 0;
+            // Cap the wait so a target that never renders can't hang
+            // navigation; ~2s at 60fps. On timeout we resolve and the
+            // element lookup + `if (!element) return` below bails cleanly.
+            const MAX_FRAMES = 120;
 
             const checkStability = () => {
+              if (frames++ > MAX_FRAMES) {
+                resolve();
+                return;
+              }
+
               const el = div.querySelector<HTMLElement>(
                 `#${CSS.escape(navCursor)}`,
               );

--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -81,6 +81,7 @@ export const PaginationProvider = ({
   content,
   fragment,
   isEditable = true,
+  hasMoreAfter,
   onCreate,
   children,
 }: {
@@ -91,6 +92,7 @@ export const PaginationProvider = ({
   content: TranslationEditorContent;
   fragment?: XmlFragment;
   isEditable?: boolean;
+  hasMoreAfter?: boolean;
   onCreate?: (params: { editor: Editor }) => void;
   children: ReactNode;
 }) => {
@@ -101,8 +103,11 @@ export const PaginationProvider = ({
   const { refreshEditorBaseline, setNavigating } = useEditorState();
 
   const [startCursor, setStartCursor] = useState<string | undefined>();
+  // When the caller knows the initial window already contains everything
+  // (`hasMoreAfter === false`), start with no end cursor so the bottom
+  // skeleton isn't shown. Otherwise fall back to the last passage's UUID.
   const [endCursor, setEndCursor] = useState<string | undefined>(
-    initialEndCursor || undefined,
+    hasMoreAfter === false ? undefined : initialEndCursor || undefined,
   );
   const [navCursor, setNavCursor] = useState<string | undefined>();
   const processedNavCursorRef = useRef<string | undefined>(undefined);
@@ -159,8 +164,16 @@ export const PaginationProvider = ({
   });
 
   useEffect(() => {
+    // `showOuterContent` is a single shared flag but only gates front-matter
+    // outer content (imprint/titles), so only the front provider should drive
+    // it. Otherwise another tab's provider (e.g. the body tab after a deep-link
+    // navigation sets its startCursor) would stomp the flag and hide the
+    // imprint even when the front matter is at its top.
+    if (tab !== 'front') {
+      return;
+    }
     setShowOuterContent(!startCursor);
-  }, [startCursor, setShowOuterContent]);
+  }, [tab, startCursor, setShowOuterContent]);
 
   useEffect(() => {
     const div = childrenDivRef.current;

--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -32,6 +32,7 @@ import {
 } from '@eightyfourthousand/design-system';
 import { useEditorState } from './EditorProvider';
 import { usePaginationLoadTriggers } from '../shared/hooks/usePaginationLoadTriggers';
+import { findScrollParent } from '../shared/hooks/useScrollPositionRestore';
 
 const LOADING_SKELETONS_COUNT = 3;
 const CHUNK_SIZE = 25;
@@ -407,8 +408,13 @@ export const PaginationProvider = ({
 
       if (blocks.length && editor?.view?.dom) {
         const editorEl = editor.view.dom;
-        const scrollContainer =
-          editorEl.closest('[data-panel]') || editorEl.parentElement;
+        // Anchor against the real scrollable ancestor. The main translation
+        // panel has no `[data-panel]` element (only the back-matter panel does),
+        // so the old `closest('[data-panel]') || parentElement` fell back to the
+        // editor's non-scrollable parent — making the scroll adjustment below a
+        // no-op, which left the sentinel in view and the viewport jumping on
+        // prepend. `findScrollParent` is the same lookup BodyPanel/SourceReader use.
+        const scrollContainer = findScrollParent(editorEl);
         const previousScrollHeight = scrollContainer?.scrollHeight || 0;
         const previousScrollTop = scrollContainer?.scrollTop || 0;
 

--- a/libs/lib-editing/src/lib/components/editor/TranslationBuilder.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationBuilder.tsx
@@ -18,6 +18,7 @@ export const TranslationBuilder = ({
   className,
   filter,
   panel,
+  hasMoreAfter,
 }: TranslationRenderer) => {
   const [fragment, setFragment] = useState<XmlFragment>();
   const [isObserving, setIsObserving] = useState(false);
@@ -73,6 +74,7 @@ export const TranslationBuilder = ({
       content={content}
       fragment={fragment}
       isEditable={isEditable}
+      hasMoreAfter={hasMoreAfter}
       onCreate={({ editor }) => {
         editor.commands.setDebug(true);
         setEditor(name, editor);

--- a/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPage.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPage.tsx
@@ -24,8 +24,8 @@ export const ReaderBackMatterPage = async ({
   const withAttestations = isStaticFeatureEnabled('glossary-attestations');
 
   const [
-    { blocks: endnotes },
-    { blocks: abbreviations },
+    { blocks: endnotes, hasMoreAfter: endnotesHasMore },
+    { blocks: abbreviations, hasMoreAfter: abbreviationsHasMore },
     glossary,
     bibliography,
   ] = await Promise.all([
@@ -57,6 +57,8 @@ export const ReaderBackMatterPage = async ({
       bibliography={bibliography}
       endnotes={endnotes}
       glossary={glossary}
+      endnotesHasMore={endnotesHasMore}
+      abbreviationsHasMore={abbreviationsHasMore}
       withAttestations={withAttestations}
     />
   );

--- a/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPanel.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBackMatterPanel.tsx
@@ -14,6 +14,8 @@ export const ReaderBackMatterPanel = ({
   glossary,
   bibliography,
   abbreviations,
+  endnotesHasMore,
+  abbreviationsHasMore,
   withAttestations = false,
 }: {
   workUuid: string;
@@ -21,16 +23,19 @@ export const ReaderBackMatterPanel = ({
   glossary: GlossaryTermsPage;
   bibliography: BibliographyEntries;
   abbreviations: TranslationEditorContent;
+  endnotesHasMore?: boolean;
+  abbreviationsHasMore?: boolean;
   withAttestations?: boolean;
 }) => {
   const renderTranslation = useCallback(
-    ({ content, name, className }: TranslationRenderer) => (
+    ({ content, name, className, hasMoreAfter }: TranslationRenderer) => (
       <TranslationReader
         content={content}
         name={name}
         className={className}
         filter={name}
         panel="right"
+        hasMoreAfter={hasMoreAfter}
       />
     ),
     [],
@@ -43,6 +48,8 @@ export const ReaderBackMatterPanel = ({
       glossary={glossary}
       bibliography={bibliography}
       abbreviations={abbreviations}
+      endnotesHasMore={endnotesHasMore}
+      abbreviationsHasMore={abbreviationsHasMore}
       renderTranslation={renderTranslation}
       withAttestations={withAttestations}
     />

--- a/libs/lib-editing/src/lib/components/reader/ReaderBodyPage.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBodyPage.tsx
@@ -24,23 +24,32 @@ export const ReaderBodyPage = async ({
 
   const client = createBuildGraphQLClient();
 
-  const { blocks: frontMatter } = await getTranslationBlocks({
-    client,
-    uuid: slug,
-    type: FRONT_MATTER_FILTER,
-    maxPassages: INITIAL_PASSAGES,
-  });
+  const { blocks: frontMatter, hasMoreAfter: frontMatterHasMore } =
+    await getTranslationBlocks({
+      client,
+      uuid: slug,
+      type: FRONT_MATTER_FILTER,
+      maxPassages: INITIAL_PASSAGES,
+    });
 
-  const { blocks: body } = await getTranslationBlocks({
-    client,
-    uuid: slug,
-    type: BODY_MATTER_FILTER,
-    maxPassages: INITIAL_PASSAGES,
-  });
+  const { blocks: body, hasMoreAfter: bodyHasMore } = await getTranslationBlocks(
+    {
+      client,
+      uuid: slug,
+      type: BODY_MATTER_FILTER,
+      maxPassages: INITIAL_PASSAGES,
+    },
+  );
 
   const titles = await getTranslationTitles({ client, uuid: slug });
 
   return (
-    <ReaderBodyPanel titles={titles} frontMatter={frontMatter} body={body} />
+    <ReaderBodyPanel
+      titles={titles}
+      frontMatter={frontMatter}
+      body={body}
+      frontMatterHasMore={frontMatterHasMore}
+      bodyHasMore={bodyHasMore}
+    />
   );
 };

--- a/libs/lib-editing/src/lib/components/reader/ReaderBodyPanel.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBodyPanel.tsx
@@ -23,10 +23,14 @@ export const ReaderBodyPanel = ({
   titles,
   frontMatter,
   body,
+  frontMatterHasMore,
+  bodyHasMore,
 }: {
   titles: TitlesData;
   frontMatter: TranslationEditorContent;
   body: TranslationEditorContent;
+  frontMatterHasMore?: boolean;
+  bodyHasMore?: boolean;
   cursor?: string;
 }) => {
   const renderTitles = useCallback(
@@ -43,13 +47,14 @@ export const ReaderBodyPanel = ({
   );
 
   const renderTranslation = useCallback(
-    ({ content, name, className }: TranslationRenderer) => (
+    ({ content, name, className, hasMoreAfter }: TranslationRenderer) => (
       <TranslationReader
         content={content}
         name={name}
         className={className}
         filter={name === 'front' ? FRONT_MATTER_FILTER : BODY_MATTER_FILTER}
         panel="main"
+        hasMoreAfter={hasMoreAfter}
       />
     ),
     [],
@@ -60,6 +65,8 @@ export const ReaderBodyPanel = ({
       titles={titles}
       frontMatter={frontMatter}
       body={body}
+      frontMatterHasMore={frontMatterHasMore}
+      bodyHasMore={bodyHasMore}
       renderTitles={renderTitles}
       renderTranslation={renderTranslation}
       limitWhenNoTranslation={true}

--- a/libs/lib-editing/src/lib/components/reader/TranslationReader.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationReader.tsx
@@ -38,6 +38,7 @@ export const TranslationReader = ({
   filter,
   panel,
   name,
+  hasMoreAfter,
 }: TranslationRenderer) => {
   const { uuid } = useNavigation();
 
@@ -49,6 +50,7 @@ export const TranslationReader = ({
       filter={filter}
       content={content}
       isEditable={false}
+      hasMoreAfter={hasMoreAfter}
     >
       <ReaderBody content={content} className={className} />
     </PaginationProvider>

--- a/libs/lib-editing/src/lib/components/shared/BackMatterPanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/BackMatterPanel.tsx
@@ -23,6 +23,8 @@ export const BackMatterPanel = ({
   glossary,
   bibliography,
   abbreviations,
+  endnotesHasMore,
+  abbreviationsHasMore,
   isEditor = false,
   withAttestations = false,
   renderTranslation,
@@ -32,6 +34,8 @@ export const BackMatterPanel = ({
   glossary: GlossaryTermsPage;
   bibliography: BibliographyEntries;
   abbreviations: TranslationEditorContent;
+  endnotesHasMore?: boolean;
+  abbreviationsHasMore?: boolean;
   isEditor?: boolean;
   withAttestations?: boolean;
   renderTranslation: (
@@ -101,6 +105,7 @@ export const BackMatterPanel = ({
                   className: 'block',
                   name: 'endnotes',
                   panel: 'right',
+                  hasMoreAfter: endnotesHasMore,
                 })}
               </TabsContent>
             )}
@@ -139,6 +144,7 @@ export const BackMatterPanel = ({
                   className: 'block',
                   name: 'abbreviations',
                   panel: 'right',
+                  hasMoreAfter: abbreviationsHasMore,
                 })}
               </TabsContent>
             )}

--- a/libs/lib-editing/src/lib/components/shared/BodyPanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/BodyPanel.tsx
@@ -29,6 +29,8 @@ export const BodyPanel = ({
   titles,
   frontMatter,
   body,
+  frontMatterHasMore,
+  bodyHasMore,
   renderTitles,
   renderTranslation,
   limitWhenNoTranslation = false,
@@ -36,6 +38,8 @@ export const BodyPanel = ({
   titles: Title[];
   frontMatter: TranslationEditorContent;
   body: TranslationEditorContent;
+  frontMatterHasMore?: boolean;
+  bodyHasMore?: boolean;
   renderTitles: (params: TitlesRenderer) => ReactElement<TitlesRenderer>;
   renderTranslation: (
     params: TranslationRenderer,
@@ -168,6 +172,7 @@ export const BodyPanel = ({
             className: 'block',
             name: 'front',
             panel: 'main',
+            hasMoreAfter: frontMatterHasMore,
           })}
         </div>
       </TabsContent>
@@ -195,6 +200,7 @@ export const BodyPanel = ({
               className: 'block',
               name: 'translation',
               panel: 'main',
+              hasMoreAfter: bodyHasMore,
             })}
           </div>
         </TabsContent>

--- a/libs/lib-editing/src/lib/components/shared/SourceReader.tsx
+++ b/libs/lib-editing/src/lib/components/shared/SourceReader.tsx
@@ -1,64 +1,349 @@
 'use client';
 
 import { useInView } from 'motion/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useNavigation } from './NavigationProvider';
 import {
   createGraphQLClient,
   getWorkFolios,
+  getWorkFoliosAround,
 } from '@eightyfourthousand/client-graphql';
 import type { Folio } from '@eightyfourthousand/data-access';
 import { LabeledElement } from './LabeledElement';
 import { PassageSkeleton } from './PassageSkeleton';
-import { LotusPond } from '@eightyfourthousand/design-system';
+import {
+  isUuid,
+  scrollToElement,
+  useIsMobile,
+} from '@eightyfourthousand/lib-utils';
+import {
+  LotusPond,
+  SHEET_ANIMATION_DURATION,
+} from '@eightyfourthousand/design-system';
+import { findScrollParent } from './hooks/useScrollPositionRestore';
 
 const PAGE_SIZE = 10;
 
 export const SourceReader = () => {
-  const [page, setPage] = useState(0);
-  const [hasMore, setHasMore] = useState(true);
+  // Window of loaded folios plus its absolute position within the work's
+  // ordered folio list. `loadedStart` is the absolute index of `folios[0]`,
+  // so the window covers [loadedStart, loadedStart + folios.length).
   const [folios, setFolios] = useState<Folio[]>([]);
+  const [loadedStart, setLoadedStart] = useState(0);
+  const [hasMoreBefore, setHasMoreBefore] = useState(false);
+  const [hasMoreAfter, setHasMoreAfter] = useState(true);
+  const [loadingBefore, setLoadingBefore] = useState(false);
+  const [loadingAfter, setLoadingAfter] = useState(false);
+  const [initialized, setInitialized] = useState(false);
 
-  const { toh, uuid } = useNavigation();
+  const { toh, uuid, panels, updatePanel } = useNavigation();
+  const isMobile = useIsMobile();
+  const client = useMemo(() => createGraphQLClient(), []);
+
+  const containerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
-  const shouldLoadMore = useInView(loadMoreRef);
-  const graphqlClient = createGraphQLClient();
+  const loadMoreBeforeRef = useRef<HTMLDivElement>(null);
+  const scrollParentRef = useRef<HTMLElement | null>(null);
+  const inViewAfter = useInView(loadMoreRef);
+  const inViewBefore = useInView(loadMoreBeforeRef);
 
-  const fetchMore = useCallback(async () => {
-    if (!toh || !uuid) return;
+  // Guards a deep-link navigation so sentinel-driven loads don't prepend/append
+  // (shifting the target) while we're scrolling to it.
+  const navigatingRef = useRef(false);
+  const processedHashRef = useRef<string | undefined>(undefined);
+  // When prepending, the scroll position must be anchored so the viewport
+  // doesn't jump. We capture the pre-prepend metrics here and restore in a
+  // layout effect once the new folios have rendered.
+  const pendingAnchorRef = useRef<{ prevHeight: number; prevTop: number } | null>(
+    null,
+  );
 
-    const folios = await getWorkFolios({
-      client: graphqlClient,
-      uuid,
-      toh,
-      page,
-      size: PAGE_SIZE,
-    });
-    if (folios.length) {
-      setPage((prevPage) => prevPage + 1);
-      setFolios((prevFolios) => [...prevFolios, ...folios]);
-      setHasMore(folios.length >= PAGE_SIZE);
+  // Only react to a source-tab hash (the deep-link target folio uuid).
+  const panelHash =
+    panels.main?.tab === 'source' ? panels.main?.hash : undefined;
+
+  const getScrollParent = useCallback(() => {
+    if (!scrollParentRef.current && containerRef.current) {
+      scrollParentRef.current = findScrollParent(containerRef.current);
     }
-  }, [toh, uuid, page, graphqlClient]);
+    return scrollParentRef.current;
+  }, []);
 
+  // Reset when the work changes; the initialization effect will repopulate.
   useEffect(() => {
-    if (shouldLoadMore && hasMore) {
-      fetchMore();
-    }
-  }, [shouldLoadMore, hasMore, fetchMore]);
-
-  useEffect(() => {
-    // Reset when uuid or toh changes
     setFolios([]);
-    setPage(0);
-    setHasMore(true);
+    setLoadedStart(0);
+    setHasMoreBefore(false);
+    setHasMoreAfter(true);
+    setLoadingBefore(false);
+    setLoadingAfter(false);
+    setInitialized(false);
+    processedHashRef.current = undefined;
+    scrollParentRef.current = null;
   }, [toh, uuid]);
 
+  // Initial load. When there's no deep-link hash, load from the top (folio 0).
+  // When a hash is present, the navigation effect seeds the window around the
+  // target instead, so we skip the top load here.
+  useEffect(() => {
+    if (initialized || !toh || !uuid || panelHash) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const first = await getWorkFolios({
+        client,
+        uuid,
+        toh,
+        offset: 0,
+        size: PAGE_SIZE,
+      });
+      if (cancelled) {
+        return;
+      }
+      setFolios(first);
+      setLoadedStart(0);
+      setHasMoreBefore(false);
+      setHasMoreAfter(first.length >= PAGE_SIZE);
+      setInitialized(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [initialized, toh, uuid, panelHash, client]);
+
+  const loadAfter = useCallback(async () => {
+    if (
+      !initialized ||
+      !toh ||
+      !uuid ||
+      loadingAfter ||
+      !hasMoreAfter ||
+      navigatingRef.current
+    ) {
+      return;
+    }
+    setLoadingAfter(true);
+    const offset = loadedStart + folios.length;
+    const next = await getWorkFolios({
+      client,
+      uuid,
+      toh,
+      offset,
+      size: PAGE_SIZE,
+    });
+    setFolios((prev) => [...prev, ...next]);
+    setHasMoreAfter(next.length >= PAGE_SIZE);
+    setLoadingAfter(false);
+  }, [
+    initialized,
+    toh,
+    uuid,
+    loadingAfter,
+    hasMoreAfter,
+    loadedStart,
+    folios.length,
+    client,
+  ]);
+
+  const loadBefore = useCallback(async () => {
+    if (
+      !initialized ||
+      !toh ||
+      !uuid ||
+      loadingBefore ||
+      !hasMoreBefore ||
+      loadedStart <= 0 ||
+      navigatingRef.current
+    ) {
+      return;
+    }
+    setLoadingBefore(true);
+    const newStart = Math.max(0, loadedStart - PAGE_SIZE);
+    const size = loadedStart - newStart;
+    const before = await getWorkFolios({
+      client,
+      uuid,
+      toh,
+      offset: newStart,
+      size,
+    });
+
+    // Capture scroll metrics immediately before the prepend so the layout
+    // effect can keep the viewport anchored.
+    const scrollEl = getScrollParent();
+    pendingAnchorRef.current = scrollEl
+      ? { prevHeight: scrollEl.scrollHeight, prevTop: scrollEl.scrollTop }
+      : null;
+
+    setFolios((prev) => [...before, ...prev]);
+    setLoadedStart(newStart);
+    setHasMoreBefore(newStart > 0);
+    setLoadingBefore(false);
+  }, [
+    initialized,
+    toh,
+    uuid,
+    loadingBefore,
+    hasMoreBefore,
+    loadedStart,
+    client,
+    getScrollParent,
+  ]);
+
+  // Restore scroll position after a prepend so the viewport stays put.
+  useLayoutEffect(() => {
+    const anchor = pendingAnchorRef.current;
+    const scrollEl = scrollParentRef.current;
+    if (anchor && scrollEl) {
+      scrollEl.scrollTop =
+        anchor.prevTop + (scrollEl.scrollHeight - anchor.prevHeight);
+      pendingAnchorRef.current = null;
+    }
+  }, [folios]);
+
+  useEffect(() => {
+    if (inViewAfter) {
+      loadAfter();
+    }
+  }, [inViewAfter, loadAfter]);
+
+  useEffect(() => {
+    if (inViewBefore) {
+      loadBefore();
+    }
+  }, [inViewBefore, loadBefore]);
+
+  // Deep-link navigation: scroll to a target folio, loading a window around it
+  // first if it isn't already in the DOM.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !panelHash || !toh || !uuid) {
+      return;
+    }
+    if (processedHashRef.current === panelHash) {
+      return;
+    }
+    processedHashRef.current = panelHash;
+
+    const clearHash = () => {
+      updatePanel({
+        name: 'main',
+        state: { ...panels.main, hash: undefined },
+      });
+    };
+
+    (async () => {
+      navigatingRef.current = true;
+      try {
+        // On mobile, wait for the panel Sheet animation before scrolling.
+        if (isMobile) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, SHEET_ANIMATION_DURATION),
+          );
+        }
+
+        let element = container.querySelector<HTMLElement>(
+          `#${CSS.escape(panelHash)}`,
+        );
+
+        if (!element && isUuid(panelHash)) {
+          const around = await getWorkFoliosAround({
+            client,
+            uuid,
+            toh,
+            folioUuid: panelHash,
+          });
+          if (!around) {
+            clearHash();
+            return;
+          }
+
+          setFolios(around.folios);
+          setLoadedStart(around.startIndex);
+          setHasMoreBefore(around.hasMoreBefore);
+          setHasMoreAfter(around.hasMoreAfter);
+          setInitialized(true);
+
+          // Wait for the window to render and the target's position to settle.
+          await new Promise<void>((resolve) => {
+            let stabilityCount = 0;
+            let lastTop = -1;
+
+            const checkStability = () => {
+              const el = container.querySelector<HTMLElement>(
+                `#${CSS.escape(panelHash)}`,
+              );
+              if (!el) {
+                requestAnimationFrame(checkStability);
+                return;
+              }
+
+              const currentTop = el.getBoundingClientRect().top;
+              if (currentTop === lastTop) {
+                stabilityCount++;
+                if (stabilityCount >= 2) {
+                  resolve();
+                  return;
+                }
+              } else {
+                stabilityCount = 0;
+              }
+
+              lastTop = currentTop;
+              requestAnimationFrame(checkStability);
+            };
+
+            requestAnimationFrame(checkStability);
+          });
+
+          element = container.querySelector<HTMLElement>(
+            `#${CSS.escape(panelHash)}`,
+          );
+        }
+
+        if (!element) {
+          clearHash();
+          return;
+        }
+
+        await scrollToElement({ element });
+        clearHash();
+      } catch (error) {
+        console.error('Folio navigation failed:', error);
+      } finally {
+        navigatingRef.current = false;
+      }
+    })();
+    // `panels` is intentionally excluded: we only read its current value when
+    // clearing the hash. Including it would loop, since updatePanel() creates a
+    // new panels object on every call.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelHash, toh, uuid, isMobile, client, updatePanel]);
+
   return (
-    <div className="pt-12 flex flex-col gap-5 mx-auto max-w-readable 2xl:max-w-380">
-      {folios.map((folio, index) => (
+    <div
+      ref={containerRef}
+      className="pt-12 flex flex-col gap-5 mx-auto max-w-readable 2xl:max-w-380"
+    >
+      <div ref={loadMoreBeforeRef} className="h-0" />
+      {hasMoreBefore && (
+        <>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <PassageSkeleton key={`before-${i}`} />
+          ))}
+        </>
+      )}
+      {folios.map((folio) => (
         <LabeledElement
-          key={index}
+          key={folio.uuid}
           id={folio.uuid}
           label={`f.${folio.folio}.${folio.side}\nvol.${folio.volume}`}
           className="mt-0.5"
@@ -77,10 +362,10 @@ export const SourceReader = () => {
         </LabeledElement>
       ))}
       <div ref={loadMoreRef} className="h-0" />
-      {hasMore ? (
+      {hasMoreAfter ? (
         <>
           {Array.from({ length: 3 }).map((_, i) => (
-            <PassageSkeleton key={i} />
+            <PassageSkeleton key={`after-${i}`} />
           ))}
         </>
       ) : (

--- a/libs/lib-editing/src/lib/components/shared/types.ts
+++ b/libs/lib-editing/src/lib/components/shared/types.ts
@@ -32,6 +32,13 @@ export interface TranslationRenderer {
   className?: string;
   filter?: PanelFilter;
   panel: PanelName;
+  /**
+   * Whether more passages exist after the initial `content` window. When
+   * `false`, pagination starts with no end cursor so the bottom loading
+   * skeleton isn't shown for fully-loaded short texts. Omitted/undefined
+   * preserves the legacy behavior (treat as "maybe more").
+   */
+  hasMoreAfter?: boolean;
 }
 
 export const TAB_FOR_SECTION: Record<string, TabName> = {


### PR DESCRIPTION
### Summary

- Add `folio` handling in the `/entity` endpoint
- Support generating urls for `folio` references
- Support deep links to folio uuids
- Add bi-directional pagination in the source tab

In addition, some regressions related to recent dependency updates were fixed

- Passages intermittently load loading after loading via deep link
- The loading skeleton showing for short texts
- The imprint not showing after internal navigation
- Scrolling up getting stuck

### Linear

- part of [DEV-554](https://linear.app/84000/issue/DEV-554)
- fixes [ED-1275](https://linear.app/84000/issue/ED-1275)
- fixes [ED-1276](https://linear.app/84000/issue/ED-1276)
