### PR TITLE
add a no-break between endnotes and the word they are attached to

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
@@ -76,7 +76,11 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
           }
 
           const itemLabel = label?.split('.').pop() || defaultLabel;
-          endnoteDOM.textContent = itemLabel || defaultLabel;
+          const text = itemLabel || defaultLabel;
+          // Glue the marker to the text it's attached to with a word joiner
+          // (U+2060) so it never wraps to a new line away from its content:
+          // after the text for start notes, before it for end notes.
+          endnoteDOM.textContent = isStart ? `${text}⁠` : `⁠${text}`;
 
           endnoteDOM.addEventListener('click', () => {
             if (!endNote) {

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -162,8 +162,12 @@ describe('TranslationSSRContent', () => {
     const el = TranslationSSRContent({ content: doc }) as ReactElement<DangerousProps>;
     const html = renderedHtml(el);
     expect(html).toContain('marked');
-    expect(html).toMatch(/<sup[^>]*me-0\.75[^>]*endNote="en-1"[^>]*>a<\/sup>marked/);
-    expect(html).toMatch(/marked<sup[^>]*endNote="en-2"[^>]*>b<\/sup>/);
+    // Start sup carries a trailing word joiner (U+2060); end sup a leading one,
+    // gluing each marker to the content it's attached to.
+    expect(html).toMatch(
+      /<sup[^>]*me-0\.75[^>]*endNote="en-1"[^>]*>a⁠<\/sup>marked/,
+    );
+    expect(html).toMatch(/marked<sup[^>]*endNote="en-2"[^>]*>⁠b<\/sup>/);
   });
 
   it('renders endNoteLink marks with only end-positioned sups', () => {
@@ -204,7 +208,7 @@ describe('TranslationSSRContent', () => {
 
     const el = TranslationSSRContent({ content: doc }) as ReactElement<DangerousProps>;
     const html = renderedHtml(el);
-    expect(html).toMatch(/marked<sup[^>]*endNote="en-only"[^>]*>c<\/sup>/);
+    expect(html).toMatch(/marked<sup[^>]*endNote="en-only"[^>]*>⁠c<\/sup>/);
   });
 
   it('exposes the default SSR extension set including passage and bold', () => {

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
@@ -37,13 +37,18 @@ const renderEndNoteLinkMark = ({
 
   const supHtml = (n: EndNoteItem, marginClass: string) => {
     const cls = cn('end-note-link', n.toh, marginClass);
-    const itemLabel = n.label?.split('.').pop() || '';
+    const itemLabel = escapeHTML(n.label?.split('.').pop() || '');
+    // Glue the marker to the text it's attached to with a word joiner (U+2060)
+    // so it never wraps to a new line away from its content: after the text for
+    // start notes, before it for end notes.
+    const joined =
+      n.location === 'start' ? `${itemLabel}⁠` : `⁠${itemLabel}`;
     return (
       `<sup class="${escapeHTMLAttribute(cls)}"` +
       ` type="endNoteLink"` +
       ` endNote="${escapeHTMLAttribute(n.endNote)}"` +
       ` uuid="${escapeHTMLAttribute(n.uuid)}">` +
-      `${escapeHTML(itemLabel)}</sup>`
+      `${joined}</sup>`
     );
   };
 


### PR DESCRIPTION
### Summary

Add a `&NoBreak;` character between endnote link mark instances and the text they are attached to.

### Linear

- [ED-1270](https://linear.app/84000/issue/ED-1270)

### Notes

The `&NoBreak;` addition is the key to this PR, but it is not visible in the web view 🤷🏻 
