### PR TITLE
No italic pipes

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic.ts
@@ -1,6 +1,39 @@
 import { Extension } from '@tiptap/core';
+import type { Node, Mark } from '@tiptap/pm/model';
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
+
+const pluginKey = new PluginKey('pipeNotItalic');
+
+/**
+ * Scans a region of the document for italic text nodes containing `|`
+ * and returns an array of inline Decorations for each match.
+ */
+function findPipeDecorations(doc: Node, from: number, to: number) {
+  const decorations: Decoration[] = [];
+
+  doc.nodesBetween(from, to, (node, pos) => {
+    if (!node.isText) return;
+
+    const isItalic = node.marks.some(
+      (mark: Mark) => mark.type.name === 'italic' || mark.type.name === 'em',
+    );
+    if (!isItalic) return;
+
+    const text = node.text ?? '';
+    let index = text.indexOf('|');
+    while (index !== -1) {
+      decorations.push(
+        Decoration.inline(pos + index, pos + index + 1, {
+          class: 'not-italic',
+        }),
+      );
+      index = text.indexOf('|', index + 1);
+    }
+  });
+
+  return decorations;
+}
 
 export const PipeNotItalic = Extension.create({
   name: 'pipeNotItalic',
@@ -8,36 +41,65 @@ export const PipeNotItalic = Extension.create({
   addProseMirrorPlugins() {
     return [
       new Plugin({
-        key: new PluginKey('pipeNotItalic'),
-        props: {
-          decorations(state) {
-            const decorations: Decoration[] = [];
-            const { doc } = state;
+        key: pluginKey,
 
-            doc.descendants((node, pos) => {
-              if (!node.isText) return;
-              // Only act on text nodes that have the em/italic mark
-              const isItalic = node.marks.some(
-                (mark) =>
-                  mark.type.name === 'italic' || mark.type.name === 'em',
-              );
-              if (!isItalic) return;
+        state: {
+          /**
+           * On initialisation, scan the entire document once to build
+           * the initial DecorationSet.
+           */
+          init(_, { doc }) {
+            const decorations = findPipeDecorations(doc, 0, doc.content.size);
+            return DecorationSet.create(doc, decorations);
+          },
 
-              const text = node.text ?? '';
-              let index = text.indexOf('|');
-              while (index !== -1) {
-                const from = pos + index;
-                const to = from + 1;
-                decorations.push(
-                  Decoration.inline(from, to, {
-                    class: 'not-italic',
-                  }),
-                );
-                index = text.indexOf('|', index + 1);
-              }
+          /**
+           * On every transaction:
+           *   1. If nothing changed, return the existing set unchanged.
+           *   2. Remap existing decoration positions through the transaction.
+           *   3. For each changed step range, remove stale decorations and
+           *      re-scan only that region for new ones.
+           */
+          apply(tr, oldDecorationSet) {
+            if (!tr.docChanged) return oldDecorationSet;
+
+            // Remap all existing decoration positions to account for
+            // insertions/deletions elsewhere in the document.
+            let decorationSet = oldDecorationSet.map(tr.mapping, tr.doc);
+
+            // Re-scan only the ranges touched by this transaction.
+            tr.steps.forEach((step) => {
+              // stepMap gives us the affected ranges after the step.
+              const stepMap = step.getMap();
+
+              stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+                // Clamp to document bounds.
+                const from = Math.max(0, newStart);
+                const to = Math.min(tr.doc.content.size, newEnd);
+
+                // Remove any decorations that fall within this range —
+                // they may now be stale (e.g. the `|` was deleted, or
+                // italic was removed).
+                const stale = decorationSet.find(from, to);
+                if (stale.length > 0) {
+                  decorationSet = decorationSet.remove(stale);
+                }
+
+                // Re-scan the changed range and add fresh decorations.
+                const fresh = findPipeDecorations(tr.doc, from, to);
+                if (fresh.length > 0) {
+                  decorationSet = decorationSet.add(tr.doc, fresh);
+                }
+              });
             });
 
-            return DecorationSet.create(doc, decorations);
+            return decorationSet;
+          },
+        },
+
+        props: {
+          decorations(state) {
+            return pluginKey.getState(state);
           },
         },
       }),

--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic.ts
@@ -1,0 +1,46 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+
+export const PipeNotItalic = Extension.create({
+  name: 'pipeNotItalic',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('pipeNotItalic'),
+        props: {
+          decorations(state) {
+            const decorations: Decoration[] = [];
+            const { doc } = state;
+
+            doc.descendants((node, pos) => {
+              if (!node.isText) return;
+              // Only act on text nodes that have the em/italic mark
+              const isItalic = node.marks.some(
+                (mark) =>
+                  mark.type.name === 'italic' || mark.type.name === 'em',
+              );
+              if (!isItalic) return;
+
+              const text = node.text ?? '';
+              let index = text.indexOf('|');
+              while (index !== -1) {
+                const from = pos + index;
+                const to = from + 1;
+                decorations.push(
+                  Decoration.inline(from, to, {
+                    class: 'not-italic',
+                  }),
+                );
+                index = text.indexOf('|', index + 1);
+              }
+            });
+
+            return DecorationSet.create(doc, decorations);
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/translationSSRExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/translationSSRExtensions.ts
@@ -22,6 +22,7 @@ import { MentionSSR } from './Mention/Mention.ssr';
 import Paragraph from './Paragraph/Paragraph';
 import { ParagraphIndent } from './ParagraphIndent';
 import { PassageNodeSSR } from './Passage/PassageNode.ssr';
+import { PipeNotItalic } from './PipeNotItalic';
 import { SmallCaps } from './SmallCaps';
 import { STARTER_KIT_CONFIG, StarterKit } from './StarterKit';
 import { Subscript } from './Subscript';
@@ -55,6 +56,7 @@ export const translationSSRExtensions: Extensions = [
   Paragraph,
   ParagraphIndent,
   PassageNodeSSR,
+  PipeNotItalic,
   SmallCaps,
   StarterKit.configure({
     ...STARTER_KIT_CONFIG,

--- a/libs/lib-editing/src/lib/components/editor/hooks/useTranslationExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/hooks/useTranslationExtensions.ts
@@ -50,6 +50,7 @@ import {
   HasAbbreviation,
 } from '../extensions/Abbreviation/Abbreviation';
 import { ParagraphIndent } from '../extensions/ParagraphIndent';
+import { PipeNotItalic } from '../extensions/PipeNotItalic';
 import { Bold } from '../extensions/Bold';
 import { List, ListItem } from '../extensions/List';
 import { Underline } from '../extensions/Underline';
@@ -116,6 +117,7 @@ export const useTranslationExtensions = ({
     Paragraph,
     ParagraphIndent,
     PassageNode,
+    PipeNotItalic,
     Placeholder,
     SlashCommand.configure({
       suggestion: getSuggestion(suggestions),


### PR DESCRIPTION
### Summary

Adds a ProseMirror decorator plugin to never render `|` characters in italics.

### Linear

- [ED-1277](https://linear.app/84000/issue/ED-1277)
