### PR TITLE
Folio data loader

### DIFF
--- a/apps/api-graphql/src/graphql/loaders.ts
+++ b/apps/api-graphql/src/graphql/loaders.ts
@@ -3,6 +3,7 @@ import { createPassageLoaders } from './schema/passage/passage.loader';
 import { createGlossaryNameLoader } from './schema/glossary/glossary-name.loader';
 import { createPassageReferencesLoader } from './schema/passage/passage-references.loader';
 import { createWorkTitleLoader } from './schema/work/work-title.loader';
+import { createFolioLoader } from './schema/folio/folio.loader';
 
 export interface Loaders {
   /**
@@ -47,6 +48,12 @@ export interface Loaders {
    * Used to enrich mention annotations with display text from target glossary entries.
    */
   glossaryNamesByUuid: ReturnType<typeof createGlossaryNameLoader>;
+
+  /**
+   * Load folios by UUID.
+   * Used to enrich mention annotations with display text from target folios.
+   */
+  foliosByUuid: ReturnType<typeof createFolioLoader>;
 }
 
 export function createLoaders(supabase: DataClient): Loaders {
@@ -55,5 +62,6 @@ export function createLoaders(supabase: DataClient): Loaders {
     passageReferencesByPassageUuid: createPassageReferencesLoader(supabase),
     workTitlesByUuid: createWorkTitleLoader(supabase),
     glossaryNamesByUuid: createGlossaryNameLoader(supabase),
+    foliosByUuid: createFolioLoader(supabase),
   };
 }

--- a/apps/api-graphql/src/graphql/schema/folio/folio.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/folio/folio.loader.ts
@@ -1,0 +1,16 @@
+import DataLoader from 'dataloader';
+import {
+  getFoliosByUuids,
+  type DataClient,
+  type Folio,
+} from '@eightyfourthousand/data-access';
+
+export function createFolioLoader(supabase: DataClient) {
+  return new DataLoader<string, Folio | null>(async (folioUuids) => {
+    const foliosByUuid = await getFoliosByUuids({
+      client: supabase,
+      uuids: folioUuids,
+    });
+    return folioUuids.map((uuid) => foliosByUuid.get(uuid) ?? null);
+  });
+}

--- a/apps/api-graphql/src/graphql/schema/passage/passage.field-resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.field-resolver.ts
@@ -124,6 +124,25 @@ async function resolveMentionTexts(
     );
   }
 
+  const folioMentions = byType.get('folio');
+  if (folioMentions) {
+    fetchPromises.push(
+      ctx.loaders.foliosByUuid
+        .loadMany(folioMentions.map((m) => m.entityUuid))
+        .then((folios) => {
+          folioMentions.forEach((m, i) => {
+            const folio = folios[i];
+            if (folio && typeof folio === 'object' && 'side' in folio) {
+              mentionTexts.set(
+                m.annotationUuid,
+                `[F.${folio.folio}.${folio.side}]`,
+              );
+            }
+          });
+        }),
+    );
+  }
+
   // Bibliography gets a static label
   const bibMentions = byType.get('bibliography');
   if (bibMentions) {

--- a/libs/data-access/src/lib/folio.ts
+++ b/libs/data-access/src/lib/folio.ts
@@ -2,7 +2,7 @@
 
 import { createServerClient } from './client-ssr';
 import { DataClient, TohokuCatalogEntry } from './types';
-import { FolioDTO, FoliosAround, folioFromDTO } from './types/folio';
+import { Folio, FolioDTO, FoliosAround, folioFromDTO } from './types/folio';
 
 type GetWorkFoliosArgs = {
   client: DataClient;
@@ -148,6 +148,48 @@ export const getFolioLocation = async ({
     folioUuid: data.folio_uuid as string,
     toh: data.toh as TohokuCatalogEntry,
   };
+};
+
+/**
+ * Batch-fetch folios by their UUIDs, returning a map keyed by folio UUID.
+ * Used by the GraphQL folio DataLoader to resolve folio mention display text.
+ */
+export const getFoliosByUuids = async ({
+  client,
+  uuids,
+}: {
+  client: DataClient;
+  uuids: readonly string[];
+}): Promise<Map<string, Folio>> => {
+  const foliosByUuid = new Map<string, Folio>();
+
+  if (uuids.length === 0) {
+    return foliosByUuid;
+  }
+
+  const { data, error } = await client
+    .from('tibetan_works_folios')
+    .select(
+      `
+      folio_uuid,
+      content::text,
+      volume_number::int4,
+      folio_number::int4,
+      side::text`,
+    )
+    .in('folio_uuid', uuids);
+
+  if (error) {
+    console.error('Error fetching folios by uuids:', error);
+    return foliosByUuid;
+  }
+
+  for (const dto of data) {
+    const folio = folioFromDTO(dto as FolioDTO);
+    foliosByUuid.set(folio.uuid, folio);
+  }
+
+  return foliosByUuid;
 };
 
 export const getFolios = async ({

--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -41,6 +41,10 @@
     @apply text-foreground no-underline cursor-auto;
   }
 
+  .focus-mode .mention-link[entity-type='folio'] {
+    @apply hidden;
+  }
+
   .focus-mode .mention-link {
     @apply text-foreground no-underline cursor-auto;
   }

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -55,17 +55,19 @@ export const MentionSSR = Node.create<MentionSSROptions>({
 
   renderHTML({ node, HTMLAttributes }) {
     const raw = node.attrs.items;
-    const items: MentionItem[] = Array.isArray(raw) ? raw.filter(isMentionItem) : [];
+    const items: MentionItem[] = Array.isArray(raw)
+      ? raw.filter(isMentionItem)
+      : [];
 
     const children = items.map((item) => {
       const label = item.text || item.displayText || item.entity || '';
 
       if (!item.entity || !item.linkType) {
-        return ['span', { class: 'mention-link pe-1' }, label] as unknown;
+        return ['span', { class: 'mention-link px-1' }, label] as unknown;
       }
 
       const href = safeHref(`/entity/${item.linkType}/${item.entity}`);
-      const attrs: Record<string, string> = { class: 'mention-link pe-1' };
+      const attrs: Record<string, string> = { class: 'mention-link px-1' };
       if (item.uuid) attrs['uuid'] = item.uuid;
       if (item.entity) attrs['entity'] = item.entity;
       if (item.linkType) attrs['entity-type'] = item.linkType;
@@ -80,7 +82,7 @@ export const MentionSSR = Node.create<MentionSSROptions>({
         attrs['target'] = '_blank';
         attrs['rel'] = 'noreferrer noopener';
       } else {
-        return ['span', { class: 'mention-link pe-1' }, label] as unknown;
+        return ['span', { class: 'mention-link px-1' }, label] as unknown;
       }
 
       return ['a', attrs, label] as unknown;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -33,7 +33,7 @@ export const Mention = MentionSSR.extend({
 
       items.forEach((item) => {
         const anchor = document.createElement('a');
-        anchor.classList.add('mention-link', 'pe-1');
+        anchor.classList.add('mention-link', 'px-1');
 
         // Display priority: text (custom override) > displayText (dynamic) > entity UUID (fallback)
         anchor.textContent = item.text || item.displayText || item.entity;
@@ -73,11 +73,14 @@ export const Mention = MentionSSR.extend({
                   query.set('right', `open:glossary:${item.entity}`);
                   break;
                 case 'passage': {
-                  const panel =
-                    PANEL_FOR_SECTION[item.subtype || ''] || 'main';
+                  const panel = PANEL_FOR_SECTION[item.subtype || ''] || 'main';
                   const tab =
                     TAB_FOR_SECTION[item.subtype || ''] || 'translation';
                   query.set(panel, `open:${tab}:${item.entity}`);
+                  break;
+                }
+                case 'folio': {
+                  query.set('main', `open:source:${item.entity}`);
                   break;
                 }
                 default:
@@ -121,20 +124,20 @@ export const Mention = MentionSSR.extend({
     return {
       setMention:
         (entity: string, linkType: string) =>
-          ({ commands }) => {
-            return commands.insertContent({
-              type: this.name,
-              attrs: {
-                items: [
-                  {
-                    uuid: uuidv4(),
-                    entity,
-                    linkType,
-                  },
-                ],
-              },
-            });
-          },
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: {
+              items: [
+                {
+                  uuid: uuidv4(),
+                  entity,
+                  linkType,
+                },
+              ],
+            },
+          });
+        },
     };
   },
 });


### PR DESCRIPTION
### Summary

- Adds a data access method to fetch multiple folios by uuid
- Adds a data loader folios in GraphQL
- Adds label lookup for folio mentions
- Improves rendering support for folio mentions in the frontent
- Hide folio mentions in focus mode

### Linear

- part of [DEV-554](https://linear.app/84000/issue/DEV-554)