### PR TITLE
Translation Fallback UI

### DIFF
--- a/libs/data-access/src/lib/types/semver.ts
+++ b/libs/data-access/src/lib/types/semver.ts
@@ -1,1 +1,14 @@
 export type SemVer = `${number}.${number}.${number}`;
+
+/**
+ * Whether a publication version represents a published work. A major version
+ * below 1 (e.g. `0.x.x`) is considered in-progress / not yet published.
+ * An undefined or unparseable version is treated as published (don't gate).
+ */
+export const isPublishedVersion = (version?: SemVer): boolean => {
+  if (!version) {
+    return true;
+  }
+  const major = Number(version.split('.')[0]);
+  return Number.isFinite(major) && major >= 1;
+};

--- a/libs/lib-editing/src/lib/components/reader/ReaderBodyPage.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBodyPage.tsx
@@ -3,6 +3,7 @@ import {
   createBuildGraphQLClient,
   FRONT_MATTER_FILTER,
   getTranslationBlocks,
+  getTranslationMetadataByUuid,
   getTranslationTitles,
 } from '@eightyfourthousand/client-graphql/ssr';
 import { ReaderBodyPanel } from './ReaderBodyPanel';
@@ -43,6 +44,8 @@ export const ReaderBodyPage = async ({
 
   const titles = await getTranslationTitles({ client, uuid: slug });
 
+  const work = await getTranslationMetadataByUuid({ client, uuid: slug });
+
   return (
     <ReaderBodyPanel
       titles={titles}
@@ -50,6 +53,7 @@ export const ReaderBodyPage = async ({
       body={body}
       frontMatterHasMore={frontMatterHasMore}
       bodyHasMore={bodyHasMore}
+      publicationVersion={work?.publicationVersion}
     />
   );
 };

--- a/libs/lib-editing/src/lib/components/reader/ReaderBodyPanel.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBodyPanel.tsx
@@ -1,14 +1,23 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   BODY_MATTER_FILTER,
+  createBrowserClient,
   FRONT_MATTER_FILTER,
+  getSession,
+  isPublishedVersion,
+  SemVer,
   Titles as TitlesData,
+  UserRole,
 } from '@eightyfourthousand/data-access';
 import { BodyPanel } from '../shared/BodyPanel';
 import { Titles, TitlesVariant } from '../shared/titles';
-import { TitlesRenderer, TranslationRenderer } from '../shared/types';
+import {
+  TitlesRenderer,
+  TranslationRenderer,
+  TranslationState,
+} from '../shared/types';
 import { TranslationEditorContent } from '../editor';
 import { TranslationReader } from './TranslationReader';
 
@@ -25,6 +34,7 @@ export const ReaderBodyPanel = ({
   body,
   frontMatterHasMore,
   bodyHasMore,
+  publicationVersion,
 }: {
   titles: TitlesData;
   frontMatter: TranslationEditorContent;
@@ -32,15 +42,36 @@ export const ReaderBodyPanel = ({
   frontMatterHasMore?: boolean;
   bodyHasMore?: boolean;
   cursor?: string;
+  publicationVersion?: SemVer;
 }) => {
+  // `undefined` while the role resolves. Gate as a reader until then so
+  // unpublished content never flashes before the role is known.
+  const [role, setRole] = useState<UserRole | undefined>(undefined);
+
+  useEffect(() => {
+    (async () => {
+      const session = await getSession({ client: createBrowserClient() });
+      // Unauthenticated visitors are treated as readers.
+      setRole(session?.claims.role ?? 'reader');
+    })();
+  }, []);
+
+  const translationState = useMemo<TranslationState>(() => {
+    const isReader = role === undefined || role === 'reader';
+    const unpublished = !isPublishedVersion(publicationVersion);
+    if (isReader && unpublished) {
+      return 'unpublished';
+    }
+    const bodyEmpty = Array.isArray(body) ? body.length === 0 : !body;
+    return bodyEmpty ? 'empty' : 'content';
+  }, [role, publicationVersion, body]);
+
   const renderTitles = useCallback(
     ({ titles, imprint, name }: TitlesRenderer) => (
       <Titles
         titles={titles}
         imprint={imprint}
-        variant={
-          (TITLE_VARIANTS_FOR_TABS[name] || 'english') as TitlesVariant
-        }
+        variant={(TITLE_VARIANTS_FOR_TABS[name] || 'english') as TitlesVariant}
       />
     ),
     [],
@@ -69,7 +100,7 @@ export const ReaderBodyPanel = ({
       bodyHasMore={bodyHasMore}
       renderTitles={renderTitles}
       renderTranslation={renderTranslation}
-      limitWhenNoTranslation={true}
+      translationState={translationState}
     />
   );
 };

--- a/libs/lib-editing/src/lib/components/shared/BodyPanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/BodyPanel.tsx
@@ -11,12 +11,13 @@ import {
   TranslationEditorContentItem,
 } from '../editor';
 import { Title } from '@eightyfourthousand/data-access';
-import { TitlesRenderer, TranslationRenderer } from './types';
+import { TitlesRenderer, TranslationRenderer, TranslationState } from './types';
 import { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { useNavigation } from './NavigationProvider';
 import { SourceReader } from './SourceReader';
 import { Imprint } from './Imprint';
+import { TranslationPlaceholder } from './TranslationPlaceholder';
 import { TitleDetails } from './titles';
 import {
   capturePassageAnchor,
@@ -33,7 +34,7 @@ export const BodyPanel = ({
   bodyHasMore,
   renderTitles,
   renderTranslation,
-  limitWhenNoTranslation = false,
+  translationState = 'content',
 }: {
   titles: Title[];
   frontMatter: TranslationEditorContent;
@@ -44,7 +45,7 @@ export const BodyPanel = ({
   renderTranslation: (
     params: TranslationRenderer,
   ) => ReactElement<TranslationRenderer>;
-  limitWhenNoTranslation?: boolean;
+  translationState?: TranslationState;
 }) => {
   const {
     panels,
@@ -55,39 +56,27 @@ export const BodyPanel = ({
   } = useNavigation();
   const tabsRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLElement | null>(null);
-  const hasTranslationContent = useMemo(() => {
-    if (!limitWhenNoTranslation) {
-      return true;
-    }
-    if (Array.isArray(body)) {
-      return body.length > 0;
-    }
-    return Boolean(body);
-  }, [body, limitWhenNoTranslation]);
-  const activeTab =
-    panels.main.tab || (hasTranslationContent ? 'translation' : 'source');
+  const hasContent = translationState === 'content';
+  const activeTab = panels.main.tab || 'translation';
+  // The translation tab is always available (it shows a placeholder message
+  // when there's no content); only redirect away from the compare tab when
+  // there's nothing to compare against.
   const safeTab =
-    !hasTranslationContent &&
-    (activeTab === 'translation' || activeTab === 'compare')
-      ? 'source'
-      : activeTab;
+    !hasContent && activeTab === 'compare' ? 'translation' : activeTab;
 
   const hasAlignments = useMemo(() => {
-    if (!hasTranslationContent) {
+    if (!hasContent) {
       return false;
     }
     const passages = body as TranslationEditorContentItem[];
     return passages.some(
       (item) => Object.keys(item.attrs?.alignments || {}).length > 0,
     );
-  }, [body, hasTranslationContent]);
+  }, [body, hasContent]);
 
   useEffect(() => {
-    if (!limitWhenNoTranslation) {
-      return;
-    }
-    setHasTranslationContent(hasTranslationContent);
-  }, [hasTranslationContent, limitWhenNoTranslation, setHasTranslationContent]);
+    setHasTranslationContent(hasContent);
+  }, [hasContent, setHasTranslationContent]);
 
   const tabsRefCallback = useCallback((node: HTMLDivElement | null) => {
     tabsRef.current = node;
@@ -139,16 +128,14 @@ export const BodyPanel = ({
         }
         updatePanel({ name: 'main', state: { open: true, tab } });
       }}
-      defaultValue={hasTranslationContent ? 'translation' : 'source'}
+      defaultValue="translation"
       className="px-12 w-full"
     >
       <div className="sticky top-0.75 -mt-28 z-10 overflow-x-auto text-center pointer-events-none me-12 sm:me-0 md:w-full">
         <TabsList className="w-fit inline-flex pointer-events-auto">
           <TabsTrigger value="front">Front</TabsTrigger>
-          {hasTranslationContent && (
-            <TabsTrigger value="translation">Translation</TabsTrigger>
-          )}
-          {hasTranslationContent && hasAlignments && (
+          <TabsTrigger value="translation">Translation</TabsTrigger>
+          {hasAlignments && (
             <TabsTrigger value="compare">Compare</TabsTrigger>
           )}
           <TabsTrigger value="source">Source</TabsTrigger>
@@ -179,14 +166,14 @@ export const BodyPanel = ({
       {/* Single editor instance shared between Translation and Compare tabs.
          Passage node views reactively show/hide the Tibetan source column
          based on the active tab from NavigationContext. */}
-      {hasTranslationContent && (
-        <TabsContent
-          value="translation"
-          forceMount
-          className={cn(
-            safeTab !== 'translation' && safeTab !== 'compare' && 'hidden',
-          )}
-        >
+      <TabsContent
+        value="translation"
+        forceMount
+        className={cn(
+          safeTab !== 'translation' && safeTab !== 'compare' && 'hidden',
+        )}
+      >
+        {hasContent ? (
           <div
             className={cn(
               'w-full mx-auto mt-8',
@@ -203,8 +190,10 @@ export const BodyPanel = ({
               hasMoreAfter: bodyHasMore,
             })}
           </div>
-        </TabsContent>
-      )}
+        ) : (
+          <TranslationPlaceholder state={translationState} />
+        )}
+      </TabsContent>
       <TabsContent
         value="source"
         forceMount

--- a/libs/lib-editing/src/lib/components/shared/SourceReader.tsx
+++ b/libs/lib-editing/src/lib/components/shared/SourceReader.tsx
@@ -61,9 +61,10 @@ export const SourceReader = () => {
   // When prepending, the scroll position must be anchored so the viewport
   // doesn't jump. We capture the pre-prepend metrics here and restore in a
   // layout effect once the new folios have rendered.
-  const pendingAnchorRef = useRef<{ prevHeight: number; prevTop: number } | null>(
-    null,
-  );
+  const pendingAnchorRef = useRef<{
+    prevHeight: number;
+    prevTop: number;
+  } | null>(null);
 
   // Only react to a source-tab hash (the deep-link target folio uuid).
   const panelHash =
@@ -325,7 +326,6 @@ export const SourceReader = () => {
     // `panels` is intentionally excluded: we only read its current value when
     // clearing the hash. Including it would loop, since updatePanel() creates a
     // new panels object on every call.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panelHash, toh, uuid, isMobile, client, updatePanel]);
 
   return (

--- a/libs/lib-editing/src/lib/components/shared/TranslationPlaceholder.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationPlaceholder.tsx
@@ -1,0 +1,26 @@
+import { Lead, LotusPond } from '@eightyfourthousand/design-system';
+import { TranslationState } from './types';
+
+const MESSAGES: Record<Exclude<TranslationState, 'content'>, string> = {
+  unpublished: 'This translation is not yet published. Check again soon.',
+  empty: 'No translation content...',
+};
+
+export const TranslationPlaceholder = ({
+  state,
+}: {
+  state: TranslationState;
+}) => {
+  if (state === 'content') {
+    return null;
+  }
+
+  return (
+    <div className="w-full max-w-readable mx-auto mt-24 text-center">
+      <Lead className="italic">{MESSAGES[state]}</Lead>
+      <div className="w-full pt-16 pb-6">
+        <LotusPond className="mx-auto w-96" />
+      </div>
+    </div>
+  );
+};

--- a/libs/lib-editing/src/lib/components/shared/types.ts
+++ b/libs/lib-editing/src/lib/components/shared/types.ts
@@ -20,6 +20,14 @@ export type TabName =
   | 'glossary'
   | 'abbreviations';
 
+/**
+ * Display state for the translation tab body:
+ * - `content`: render the translation passages
+ * - `unpublished`: work is pre-1.0 and the viewer (a reader) may not view it yet
+ * - `empty`: viewer may see content, but there are no body passages
+ */
+export type TranslationState = 'content' | 'unpublished' | 'empty';
+
 export interface TitlesRenderer {
   titles: Titles;
   imprint?: Imprint;


### PR DESCRIPTION
### Summary

Currently, reader can view unpublished translations or untranslated works if they have the direct link. This is partly by design, but the UI needed refinement.

Now, if a user has a role of `reader`, they can see a message that the work is unpublished but still have access to the imprint and Tibetan source. This is the behavior regardless of whether there is any translation content.

Users with a higher degree of access will see in-progress translations or a message that there is no translation content.

### Linear

- part of [DEV-554](https://linear.app/84000/issue/DEV-554)

### Notes

Once deployed, this allows us to migrate internal links to mentions. Internal links to unpublished content (such as pending links) will be allowed to point to the gated UI.