### PR TITLE
Fix Tibetan Selection in Compare Mode

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/Passage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/Passage.tsx
@@ -237,6 +237,8 @@ const PassageComponent = (props: NodeViewProps) => {
       </div>
       <div
         className={cn('w-full', source ? '' : 'hidden', compareLeadingSpace)}
+        contentEditable={false}
+        data-compare-source
       >
         <LabeledElement className="mt-0.5">
           <div className="leading-7 font-tibetan text-lg whitespace-normal mt-1.5 pb-4 md:pb-2">

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
@@ -1,7 +1,7 @@
 import { Node } from '@tiptap/core';
 import { ReactNodeViewRenderer, mergeAttributes } from '@tiptap/react';
 import { Passage } from './Passage';
-import { Selection, TextSelection } from '@tiptap/pm/state';
+import { Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state';
 import { Fragment, ResolvedPos } from '@tiptap/pm/model';
 import { incrementLabel } from './label';
 
@@ -25,6 +25,23 @@ const currentPassageDepth = ($from: ResolvedPos) => {
 
   return passageDepth;
 };
+
+// True when the current native (browser) selection sits inside the read-only
+// Tibetan compare source, which is rendered outside ProseMirror's content DOM.
+const selectionInCompareSource = () => {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || !selection.focusNode) {
+    return false;
+  }
+  const node = selection.focusNode;
+  const el = node.nodeType === 3 ? node.parentElement : (node as HTMLElement);
+  return !!el?.closest('[data-compare-source]');
+};
+
+// Returning true makes ProseMirror skip its own copy/cut handling (without
+// calling preventDefault), so the browser's native clipboard behavior runs and
+// copies the selected Tibetan text.
+const handleCompareSourceClipboard = () => selectionInCompareSource();
 
 export const PassageNode = Node.create({
   name: 'passage',
@@ -69,135 +86,180 @@ export const PassageNode = Node.create({
     return ['passage', mergeAttributes(HTMLAttributes), 0];
   },
   addNodeView() {
-    return ReactNodeViewRenderer(Passage);
+    return ReactNodeViewRenderer(Passage, {
+      ignoreMutation: ({ mutation }) => {
+        const target = mutation.target;
+        // nodeType 3 === text node; resolve to its parent element so we can
+        // match against the surrounding DOM.
+        const el =
+          target.nodeType === 3
+            ? target.parentElement
+            : (target as HTMLElement);
+
+        // The read-only Tibetan source shown in compare mode lives outside the
+        // content DOM. Let the browser keep its native selection there (and
+        // ignore React-driven DOM updates in that region) so the text can be
+        // selected and copied; ProseMirror otherwise resets the selection back
+        // into the editable content.
+        if (el?.closest('[data-compare-source]')) {
+          return true;
+        }
+
+        // Defer to ProseMirror for everything inside the editable content.
+        return false;
+      },
+    });
+  },
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('passageCompareSourceClipboard'),
+        props: {
+          handleDOMEvents: {
+            // The Tibetan source in compare mode lives outside the document
+            // (it is not part of ProseMirror's content). ProseMirror's built-in
+            // copy/cut handler would otherwise overwrite the clipboard with the
+            // serialized document selection. When the native selection sits
+            // inside the compare source, return true so ProseMirror skips its
+            // handler without preventing default — letting the browser perform
+            // its native copy of the selected Tibetan text.
+            copy: handleCompareSourceClipboard,
+            cut: handleCompareSourceClipboard,
+          },
+        },
+      }),
+    ];
   },
   addCommands() {
     return {
       normalizeLabelsAfter:
         () =>
-          ({ dispatch, tr }) => {
-            if (!dispatch) return true;
+        ({ dispatch, tr }) => {
+          if (!dispatch) return true;
 
-            // Use tr.selection so this works correctly when chained after commands
-            // like joinBackward that have already modified the document.
-            const { $from } = tr.selection;
-            const passageDepth = currentPassageDepth($from);
-            if (passageDepth === null) return false;
+          // Use tr.selection so this works correctly when chained after commands
+          // like joinBackward that have already modified the document.
+          const { $from } = tr.selection;
+          const passageDepth = currentPassageDepth($from);
+          if (passageDepth === null) return false;
 
-            const passagePos = $from.start(passageDepth) - 1;
-            const currentPassage = $from.node(passageDepth);
-            const currentLabel = currentPassage.attrs.label as string;
-            if (!currentLabel) return false;
+          const passagePos = $from.start(passageDepth) - 1;
+          const currentPassage = $from.node(passageDepth);
+          const currentLabel = currentPassage.attrs.label as string;
+          if (!currentLabel) return false;
 
-            const currentParts = currentLabel.split('.');
-            const numParts = currentParts.length;
-            const currentPrefixWithDot =
-              numParts > 1 ? currentParts.slice(0, -1).join('.') + '.' : '';
+          const currentParts = currentLabel.split('.');
+          const numParts = currentParts.length;
+          const currentPrefixWithDot =
+            numParts > 1 ? currentParts.slice(0, -1).join('.') + '.' : '';
 
-            const parentDepth = passageDepth - 1;
-            if (parentDepth < 0) return false;
+          const parentDepth = passageDepth - 1;
+          if (parentDepth < 0) return false;
 
-            const parentNode = $from.node(parentDepth);
-            const startIndex = $from.index(parentDepth);
+          const parentNode = $from.node(parentDepth);
+          const startIndex = $from.index(parentDepth);
 
-            let expectedNext = incrementLabel(currentLabel);
-            let pos = passagePos + currentPassage.nodeSize;
-            let changed = false;
+          let expectedNext = incrementLabel(currentLabel);
+          let pos = passagePos + currentPassage.nodeSize;
+          let changed = false;
 
-            for (let i = startIndex + 1; i < parentNode.childCount; i++) {
-              const child = parentNode.child(i);
+          for (let i = startIndex + 1; i < parentNode.childCount; i++) {
+            const child = parentNode.child(i);
 
-              if (child.type.name !== 'passage') {
-                pos += child.nodeSize;
-                continue;
-              }
-
-              const targetLabel = child.attrs.label as string;
-              if (!targetLabel) {
-                pos += child.nodeSize;
-                continue;
-              }
-
-              const targetParts = targetLabel.split('.');
-              if (targetParts.length < numParts) break; // shallower → out of scope
-              if (targetParts.length > numParts) {
-                // deeper → skip sub-passage
-                pos += child.nodeSize;
-                continue;
-              }
-              if (!targetLabel.startsWith(currentPrefixWithDot)) break; // different prefix
-
-              if (targetLabel === expectedNext) break; // already contiguous
-
-              tr.setNodeMarkup(pos, null, { ...child.attrs, label: expectedNext });
-              expectedNext = incrementLabel(expectedNext);
-              changed = true;
+            if (child.type.name !== 'passage') {
               pos += child.nodeSize;
+              continue;
             }
 
-            if (changed) dispatch(tr);
-            return true;
-          },
+            const targetLabel = child.attrs.label as string;
+            if (!targetLabel) {
+              pos += child.nodeSize;
+              continue;
+            }
+
+            const targetParts = targetLabel.split('.');
+            if (targetParts.length < numParts) break; // shallower → out of scope
+            if (targetParts.length > numParts) {
+              // deeper → skip sub-passage
+              pos += child.nodeSize;
+              continue;
+            }
+            if (!targetLabel.startsWith(currentPrefixWithDot)) break; // different prefix
+
+            if (targetLabel === expectedNext) break; // already contiguous
+
+            tr.setNodeMarkup(pos, null, {
+              ...child.attrs,
+              label: expectedNext,
+            });
+            expectedNext = incrementLabel(expectedNext);
+            changed = true;
+            pos += child.nodeSize;
+          }
+
+          if (changed) dispatch(tr);
+          return true;
+        },
       splitPassage:
         () =>
-          ({ state, dispatch }) => {
-            const { selection } = state;
-            const { $from } = selection;
+        ({ state, dispatch }) => {
+          const { selection } = state;
+          const { $from } = selection;
 
-            // Find the passage node that contains the current selection
-            const passageDepth = currentPassageDepth($from);
-            if (passageDepth === null) {
-              return false;
-            }
+          // Find the passage node that contains the current selection
+          const passageDepth = currentPassageDepth($from);
+          if (passageDepth === null) {
+            return false;
+          }
 
-            const passageNode = $from.node(passageDepth);
-            const passageStart = $from.start(passageDepth) - 1; // -1 to include the passage node itself
-            const passageEnd = $from.end(passageDepth) + 1; // +1 to include the passage node itself
+          const passageNode = $from.node(passageDepth);
+          const passageStart = $from.start(passageDepth) - 1; // -1 to include the passage node itself
+          const passageEnd = $from.end(passageDepth) + 1; // +1 to include the passage node itself
 
-            // Get the position within the passage content
-            const posInPassage = $from.pos - $from.start(passageDepth);
+          // Get the position within the passage content
+          const posInPassage = $from.pos - $from.start(passageDepth);
 
-            // Split the passage content
-            const beforeContent = passageNode.content.cut(0, posInPassage);
-            const afterContent = passageNode.content.cut(posInPassage);
+          // Split the passage content
+          const beforeContent = passageNode.content.cut(0, posInPassage);
+          const afterContent = passageNode.content.cut(posInPassage);
 
-            if (!dispatch) return true;
+          if (!dispatch) return true;
 
-            const tr = state.tr;
+          const tr = state.tr;
 
-            // Replace current passage with first part
-            tr.replaceWith(
-              passageStart,
-              passageEnd,
-              state.schema.nodes.passage.create(passageNode.attrs, beforeContent),
-            );
+          // Replace current passage with first part
+          tr.replaceWith(
+            passageStart,
+            passageEnd,
+            state.schema.nodes.passage.create(passageNode.attrs, beforeContent),
+          );
 
-            // Calculate where to insert the new passage
-            const newPassagePos = passageStart + beforeContent.size + 2; // +2 for passage wrapper
-            const oldAttrs = passageNode.attrs;
-            const attrs = {
-              ...oldAttrs,
-              uuid: crypto.randomUUID(),
-              sort: oldAttrs.sort + 1,
-              label: incrementLabel(oldAttrs.label),
-            };
-            // Insert new passage with remaining content
-            tr.insert(
-              newPassagePos,
-              state.schema.nodes.passage.create(attrs, afterContent),
-            );
+          // Calculate where to insert the new passage
+          const newPassagePos = passageStart + beforeContent.size + 2; // +2 for passage wrapper
+          const oldAttrs = passageNode.attrs;
+          const attrs = {
+            ...oldAttrs,
+            uuid: crypto.randomUUID(),
+            sort: oldAttrs.sort + 1,
+            label: incrementLabel(oldAttrs.label),
+          };
+          // Insert new passage with remaining content
+          tr.insert(
+            newPassagePos,
+            state.schema.nodes.passage.create(attrs, afterContent),
+          );
 
-            // move the cursor to the new paragraph
-            const $pos = tr.doc.resolve(newPassagePos + 1);
-            const newSelection =
-              TextSelection.findFrom($pos, 1, true) || Selection.near($pos, 1);
-            if (newSelection) {
-              tr.setSelection(newSelection);
-            }
+          // move the cursor to the new paragraph
+          const $pos = tr.doc.resolve(newPassagePos + 1);
+          const newSelection =
+            TextSelection.findFrom($pos, 1, true) || Selection.near($pos, 1);
+          if (newSelection) {
+            tr.setSelection(newSelection);
+          }
 
-            dispatch(tr);
-            return true;
-          },
+          dispatch(tr);
+          return true;
+        },
     };
   },
   addKeyboardShortcuts() {


### PR DESCRIPTION
### Summary

The underlying ProseMirror editor blocks text selection outside of the dom element it manages directly, and the Tibetan source in compare mode falls under this condition. Now, a simple plugin and custom `ignoreMutation` function enables this.

A future goal is to render the reader entirely as html without relying on the editor's renderer, but this change is necessary to allow Tibetan selection while actively using the editor as well.

### Linear

- [ED-1286](https://linear.app/84000/issue/ED-1286)
