### PR TITLE
Default foreign value

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/Foreign/Foreign.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Foreign/Foreign.ts
@@ -31,7 +31,7 @@ export const ForeignMark = Mark.create<ForeignOptions>({
         default: 'foreign',
       },
       lang: {
-        default: undefined,
+        default: 'foreign',
       },
     };
   },


### PR DESCRIPTION
### Summary

In `foreign` marks, also use `foreign` as the default value for the `lang` attribute.

### Linear

- [ED-1285](https://linear.app/84000/issue/ED-1285)
