### PR TITLE
Initial Toh

### DIFF
--- a/libs/lib-editing/src/lib/components/reader/ReaderLayout.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderLayout.tsx
@@ -9,6 +9,7 @@ import {
   RightPanel,
 } from '@eightyfourthousand/design-system';
 import { EditorHeader } from '../editor/EditorHeader';
+import type { TohokuCatalogEntry } from '@eightyfourthousand/data-access';
 
 export const ReaderLayout = ({
   withHeader = false,
@@ -16,6 +17,7 @@ export const ReaderLayout = ({
   main,
   right,
   params,
+  initialToh,
   initialHasTranslationContent,
 }: {
   withHeader?: boolean;
@@ -23,12 +25,14 @@ export const ReaderLayout = ({
   main: ReactNode;
   right: ReactNode;
   params: Promise<{ slug: string }>;
+  initialToh?: TohokuCatalogEntry;
   initialHasTranslationContent?: boolean;
 }) => {
   const { slug } = use(params);
   return (
     <NavigationProvider
       uuid={slug}
+      initialToh={initialToh}
       initialHasTranslationContent={initialHasTranslationContent}
     >
       <ThreeColumnRenderer withHeader={withHeader} withFocusToggle>

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -78,10 +78,12 @@ const parsePanelParams = (
 
 export const NavigationProvider = ({
   uuid,
+  initialToh,
   initialHasTranslationContent = true,
   children,
 }: {
   uuid: string;
+  initialToh?: TohokuCatalogEntry;
   initialHasTranslationContent?: boolean;
   children: ReactNode;
 }) => {
@@ -92,7 +94,9 @@ export const NavigationProvider = ({
     parsePanelParams(query).panels || DEFAULT_PANELS,
   );
   const isPanelTransitioning = useRef(false);
-  const [toh, setToh] = useState<TohokuCatalogEntry | undefined>();
+  const [toh, setToh] = useState<TohokuCatalogEntry | undefined>(
+    parsePanelParams(query).toh || initialToh,
+  );
   const [showOuterContent, setShowOuterContent] = useState(true);
   const [focusMode, setFocusMode] = useState(false);
   const [hasTranslationContent, setHasTranslationContent] = useState(


### PR DESCRIPTION
### Summary

Support passing an initial Tohoku number to the `NavigationProvider` instead of relying solely on the `toh` query parameter.

### Linear

- part of [ED-1284](https://linear.app/84000/issue/ED-1284)