### PR TITLE
Tohoku visibility improvement

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
@@ -56,10 +56,11 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
           const endnoteDOM = document.createElement('sup');
           const updateAttributes = createUpdateAttributes(endnoteDOM);
           const attributes = mergeAttributes(this.options.HTMLAttributes, {
-            class: cn(className, toh, isStart ? 'me-0.75' : ''),
+            class: cn(className, isStart ? 'me-0.75' : ''),
             type: this.name,
             endNote,
             uuid,
+            ...(toh ? { 'data-toh': toh } : {}),
           });
 
           updateAttributes(attributes);

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
@@ -38,7 +38,7 @@ export const GlossaryInstanceNodeSSR = Mark.create<GlossaryInstanceSSROptions>({
   },
 
   renderHTML({ mark, HTMLAttributes }) {
-    const { authority, glossary, uuid } = mark.attrs as Record<
+    const { authority, glossary, uuid, toh } = mark.attrs as Record<
       string,
       string | undefined
     >;
@@ -47,6 +47,7 @@ export const GlossaryInstanceNodeSSR = Mark.create<GlossaryInstanceSSROptions>({
       class: 'glossary-instance',
       type: 'glossaryInstance',
     };
+    if (toh) attrs['data-toh'] = toh;
     if (authority) attrs['authority'] = authority;
     if (glossary) attrs['glossary'] = glossary;
     if (uuid) attrs['uuid'] = uuid;

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ts
@@ -22,8 +22,12 @@ export const GlossaryInstanceNode = GlossaryInstanceNodeSSR.extend({
       const { dom } = createMarkViewDom({
         ...props,
         element: 'span',
-        className: cn('glossary-instance', props.mark.attrs.toh),
+        className: cn('glossary-instance'),
       });
+
+      if (props.mark.attrs.toh) {
+        dom.setAttribute('data-toh', props.mark.attrs.toh);
+      }
 
       // Set attributes for HoverCardProvider identification
       if (props.mark.attrs.uuid) {

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ssr.ts
@@ -62,12 +62,14 @@ export const InternalLinkSSR = Mark.create<InternalLinkSSROptions>({
       isSameWork,
       subtype,
       linkToh,
+      toh,
     } = mark.attrs as Record<string, string | boolean | undefined>;
 
     const attrs: Record<string, string> = {
       class: cn(LINK_STYLE),
       type: 'internalLink',
     };
+    if (toh) attrs['data-toh'] = String(toh);
     if (entity) attrs['entity'] = String(entity);
     if (entityType) attrs['entity-type'] = String(entityType);
     if (uuid) attrs['uuid'] = String(uuid);

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ts
@@ -21,8 +21,12 @@ export const InternalLink = InternalLinkSSR.extend({
       const { dom } = createMarkViewDom({
         ...props,
         element: 'span',
-        className: cn(LINK_STYLE, props.mark.attrs.toh),
+        className: cn(LINK_STYLE),
       });
+
+      if (props.mark.attrs.toh) {
+        dom.setAttribute('data-toh', props.mark.attrs.toh);
+      }
 
       const {
         isSameWork,

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -62,7 +62,9 @@ export const MentionSSR = Node.create<MentionSSROptions>({
 
     const children = items.map((item) => {
       const label = item.text || item.displayText || item.entity || '';
-      const tohAttr = item.toh ? { 'data-toh': item.toh } : {};
+      const tohAttr: Record<string, string> = item.toh
+        ? { 'data-toh': item.toh }
+        : {};
 
       if (!item.entity || !item.linkType) {
         return [

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -62,17 +62,21 @@ export const MentionSSR = Node.create<MentionSSROptions>({
 
     const children = items.map((item) => {
       const label = item.text || item.displayText || item.entity || '';
+      const tohAttr = item.toh ? { 'data-toh': item.toh } : {};
 
       if (!item.entity || !item.linkType) {
         return [
           'span',
-          { class: cn('mention-link px-1', item.toh) },
+          { class: cn('mention-link px-1'), ...tohAttr },
           label,
         ] as unknown;
       }
 
       const href = safeHref(`/entity/${item.linkType}/${item.entity}`);
-      const attrs: Record<string, string> = { class: 'mention-link px-1' };
+      const attrs: Record<string, string> = {
+        class: 'mention-link px-1',
+        ...tohAttr,
+      };
       if (item.uuid) attrs['uuid'] = item.uuid;
       if (item.entity) attrs['entity'] = item.entity;
       if (item.linkType) attrs['entity-type'] = item.linkType;
@@ -87,7 +91,11 @@ export const MentionSSR = Node.create<MentionSSROptions>({
         attrs['target'] = '_blank';
         attrs['rel'] = 'noreferrer noopener';
       } else {
-        return ['span', { class: 'mention-link px-1' }, label] as unknown;
+        return [
+          'span',
+          { class: 'mention-link px-1', ...tohAttr },
+          label,
+        ] as unknown;
       }
 
       return ['a', attrs, label] as unknown;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -24,7 +24,7 @@ export const Mention = MentionSSR.extend({
         const anchor = document.createElement('a');
         anchor.classList.add('mention-link', 'px-1');
         if (item.toh) {
-          anchor.classList.add(item.toh);
+          anchor.setAttribute('data-toh', item.toh);
         }
 
         // Display priority: text (custom override) > displayText (dynamic) > entity UUID (fallback)

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/Passage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/Passage.tsx
@@ -122,7 +122,8 @@ const PassageComponent = (props: NodeViewProps) => {
     <NodeViewWrapper
       id={node.attrs.uuid}
       as="div"
-      className={cn(PASSAGE_WRAPPER_CLASS, node.attrs.toh)}
+      className={cn(PASSAGE_WRAPPER_CLASS)}
+      data-toh={node.attrs.toh || undefined}
     >
       <div className="w-full">
         <div

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ssr.ts
@@ -53,7 +53,8 @@ export const PassageNodeSSR = Node.create({
     const references = (node.attrs.references ?? []) as PassageReference[];
 
     const wrapperAttrs = mergeAttributes(HTMLAttributes, {
-      class: [PASSAGE_WRAPPER_CLASS, toh].filter(Boolean).join(' '),
+      class: PASSAGE_WRAPPER_CLASS,
+      ...(toh ? { 'data-toh': toh } : {}),
       ...(uuid ? { id: uuid } : {}),
     });
 

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -168,6 +168,10 @@ describe('TranslationSSRContent', () => {
       /<sup[^>]*me-0\.75[^>]*endNote="en-1"[^>]*>a⁠<\/sup>marked/,
     );
     expect(html).toMatch(/marked<sup[^>]*endNote="en-2"[^>]*>⁠b<\/sup>/);
+    // Toh-scoped sups carry a data-toh attribute so the reader's visibility
+    // rule can hide markers belonging to inactive toh variants.
+    expect(html).toMatch(/<sup[^>]*data-toh="toh1"[^>]*endNote="en-1"/);
+    expect(html).toMatch(/<sup[^>]*data-toh="toh1"[^>]*endNote="en-2"/);
   });
 
   it('renders endNoteLink marks with only end-positioned sups', () => {

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
@@ -36,7 +36,8 @@ const renderEndNoteLinkMark = ({
   notes.sort((a, b) => (a.label || '').localeCompare(b.label || ''));
 
   const supHtml = (n: EndNoteItem, marginClass: string) => {
-    const cls = cn('end-note-link', n.toh, marginClass);
+    const cls = cn('end-note-link', marginClass);
+    const tohAttr = n.toh ? ` data-toh="${escapeHTMLAttribute(n.toh)}"` : '';
     const itemLabel = escapeHTML(n.label?.split('.').pop() || '');
     // Glue the marker to the text it's attached to with a word joiner (U+2060)
     // so it never wraps to a new line away from its content: after the text for
@@ -45,6 +46,7 @@ const renderEndNoteLinkMark = ({
       n.location === 'start' ? `${itemLabel}⁠` : `⁠${itemLabel}`;
     return (
       `<sup class="${escapeHTMLAttribute(cls)}"` +
+      tohAttr +
       ` type="endNoteLink"` +
       ` endNote="${escapeHTMLAttribute(n.endNote)}"` +
       ` uuid="${escapeHTMLAttribute(n.uuid)}">` +

--- a/libs/lib-editing/src/lib/components/shared/LeftPanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/LeftPanel.tsx
@@ -20,7 +20,7 @@ export const LeftPanel = ({
 }) => {
   const { panels, toh, updatePanel, setToh } = useNavigation();
   const isMobile = useIsMobile();
-  useTohToggle({ work, toh });
+  useTohToggle({ toh });
 
   useEffect(() => {
     const currentToh = toh || work.toh[0] || '';

--- a/libs/lib-editing/src/lib/components/shared/hooks/useTohToggle.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/hooks/useTohToggle.spec.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+import { TohokuCatalogEntry } from '@eightyfourthousand/data-access';
+import { useTohToggle } from './useTohToggle';
+
+const getSheet = () => {
+  const styleEl = document.getElementById(
+    'dynamic-visibility-rules',
+  ) as HTMLStyleElement | null;
+  return styleEl?.sheet ?? null;
+};
+
+describe('useTohToggle', () => {
+  afterEach(() => {
+    document.getElementById('dynamic-visibility-rules')?.remove();
+  });
+
+  it('inserts a single rule hiding non-active tohs', () => {
+    renderHook(() => useTohToggle({ toh: 'toh257' }));
+
+    const sheet = getSheet();
+    expect(sheet?.cssRules.length).toBe(1);
+    expect(sheet?.cssRules[0].cssText).toContain(
+      '[data-toh]:not([data-toh="toh257"])',
+    );
+    expect(sheet?.cssRules[0].cssText).toContain('display: none');
+  });
+
+  it('hides all toh-scoped elements when no toh is active', () => {
+    renderHook(() => useTohToggle({ toh: undefined }));
+
+    const sheet = getSheet();
+    expect(sheet?.cssRules.length).toBe(1);
+    expect(sheet?.cssRules[0].cssText).toContain('[data-toh] {');
+  });
+
+  it('replaces rules when the active toh changes', () => {
+    const { rerender } = renderHook(
+      ({ toh }: { toh?: TohokuCatalogEntry }) => useTohToggle({ toh }),
+      { initialProps: { toh: 'toh1' as TohokuCatalogEntry } },
+    );
+    rerender({ toh: 'toh2' as TohokuCatalogEntry });
+
+    const sheet = getSheet();
+    expect(sheet?.cssRules.length).toBe(1);
+    expect(sheet?.cssRules[0].cssText).toContain('[data-toh="toh2"]');
+  });
+
+  it('does not throw on toh values that are not valid CSS identifiers', () => {
+    expect(() =>
+      renderHook(() => useTohToggle({ toh: 'toh4.1' as TohokuCatalogEntry })),
+    ).not.toThrow();
+
+    const sheet = getSheet();
+    expect(sheet?.cssRules.length).toBe(1);
+    expect(sheet?.cssRules[0].cssText).toContain('[data-toh="toh4.1"]');
+  });
+});

--- a/libs/lib-editing/src/lib/components/shared/hooks/useTohToggle.tsx
+++ b/libs/lib-editing/src/lib/components/shared/hooks/useTohToggle.tsx
@@ -1,52 +1,46 @@
 'use client';
 
-import { TohokuCatalogEntry, Work } from '@eightyfourthousand/data-access';
+import { TohokuCatalogEntry } from '@eightyfourthousand/data-access';
 import { useEffect } from 'react';
 
-export const useTohToggle = ({
-  toh,
-  work,
-}: {
-  toh?: TohokuCatalogEntry;
-  work: Work;
-}) => {
+export const useTohToggle = ({ toh }: { toh?: TohokuCatalogEntry }) => {
   useEffect(() => {
-    (async () => {
-      const sheets = Array.from(document.styleSheets);
-      let sheet: CSSStyleSheet | null | undefined = [...sheets].find((s) => {
-        const node = s.ownerNode as HTMLElement | null;
-        return node?.id === 'dynamic-visibility-rules';
-      });
+    let styleEl = document.getElementById(
+      'dynamic-visibility-rules',
+    ) as HTMLStyleElement | null;
 
-      if (!sheet) {
-        const styleEl = document.createElement('style');
-        styleEl.id = 'dynamic-visibility-rules';
-        document.head.appendChild(styleEl);
-        sheet = styleEl.sheet;
-      }
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = 'dynamic-visibility-rules';
+      document.head.appendChild(styleEl);
+    }
 
-      if (!sheet) {
-        console.warn(
-          'Could not find or create stylesheet for dynamic class toggling.',
-        );
-        return;
-      }
+    const sheet = styleEl.sheet;
 
-      // Clear existing rules
-      while (sheet.cssRules.length > 0) {
-        sheet.deleteRule(0);
-      }
+    if (!sheet) {
+      console.warn(
+        'Could not find or create stylesheet for dynamic class toggling.',
+      );
+      return;
+    }
 
-      // Add new rules
-      const tohs = work.toh;
-      tohs
-        .filter((cls) => cls !== toh)
-        .forEach((cls) => {
-          sheet.insertRule(
-            `.${cls} { display: none !important; }`,
-            sheet.cssRules.length,
-          );
-        });
-    })();
-  }, [toh, work.toh]);
+    // Clear existing rules
+    while (sheet.cssRules.length > 0) {
+      sheet.deleteRule(0);
+    }
+
+    // A single rule hides every toh-scoped element that doesn't match the
+    // active toh. Attribute selectors take a quoted string, so any toh value
+    // is safe — unlike class selectors, which require valid CSS identifiers.
+    // Only quotes and backslashes need escaping inside the quoted value.
+    const escaped = toh?.replace(/["\\]/g, '\\$&');
+    const selector = escaped
+      ? `[data-toh]:not([data-toh="${escaped}"])`
+      : '[data-toh]';
+    try {
+      sheet.insertRule(`${selector} { display: none; }`, 0);
+    } catch (e) {
+      console.error('Failed to insert toh visibility rule:', e);
+    }
+  }, [toh]);
 };


### PR DESCRIPTION
### Summary

Annotations and passages that should display depending on the select Tohoku number currently use CSS rules to control visibility. In a text with many conditional entities, the explosion of CSS rules impacts performance. Now, a single rule will control visibility based on a `data-toh` html attribute instead.

### Linear

- part of [DEV-554](https://linear.app/84000/issue/DEV-554)
