### PR TITLE
Fix: Support Multiple Tohoku Values for Visibility

### DIFF
--- a/apps/api-graphql/src/graphql/schema/annotation/annotation.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/annotation/annotation.resolver.ts
@@ -210,7 +210,9 @@ export function transformAnnotation(
     type: annotation.type,
     start: annotation.start,
     end: annotation.end,
-    toh: annotation.toh ?? null,
+    // GraphQL exposes the raw DB shape (a single toh or comma-separated list);
+    // the domain model parses it into an array, so read from the DTO here.
+    toh: dto.toh ?? null,
     metadata: extractMetadata(annotation, enrichment),
   };
 }

--- a/libs/data-access/src/lib/types/annotation/annotation-type.ts
+++ b/libs/data-access/src/lib/types/annotation/annotation-type.ts
@@ -190,7 +190,8 @@ export type AnnotationDTO = {
   uuid: string;
   passage_uuid?: string;
   passageUuid?: string;
-  toh?: TohokuCatalogEntry;
+  // DB shape: a single toh or a comma-separated list, e.g. "toh417,toh418".
+  toh?: string;
 };
 
 export type AnnotationsDTO = AnnotationDTO[];
@@ -217,5 +218,7 @@ export type AnnotationBase = {
   uuid: string;
   passageUuid: string;
   validated?: boolean;
-  toh?: TohokuCatalogEntry;
+  // Tohs this annotation is scoped to; parsed from the DB's comma-separated
+  // `toh` column. Empty when the annotation applies to every toh.
+  toh?: TohokuCatalogEntry[];
 };

--- a/libs/data-access/src/lib/types/annotation/annotation.spec.ts
+++ b/libs/data-access/src/lib/types/annotation/annotation.spec.ts
@@ -1,0 +1,59 @@
+import { parseTohList, serializeTohList } from '../toh';
+import { baseAnnotationFromDTO, baseAnnotationToDto } from './annotation';
+import type { AnnotationDTO } from './annotation-type';
+
+describe('toh list helpers', () => {
+  it('parses a comma-separated toh value into entries', () => {
+    expect(parseTohList('toh417,toh418')).toEqual(['toh417', 'toh418']);
+  });
+
+  it('parses a single toh value into a one-element array', () => {
+    expect(parseTohList('toh417')).toEqual(['toh417']);
+  });
+
+  it('trims whitespace and drops empty entries', () => {
+    expect(parseTohList('toh417, toh418, ')).toEqual(['toh417', 'toh418']);
+  });
+
+  it('returns an empty array for empty/undefined input', () => {
+    expect(parseTohList(undefined)).toEqual([]);
+    expect(parseTohList('')).toEqual([]);
+    expect(parseTohList(null)).toEqual([]);
+  });
+
+  it('serializes entries back to a comma-separated string', () => {
+    expect(serializeTohList(['toh417', 'toh418'])).toBe('toh417,toh418');
+  });
+
+  it('serializes empty/undefined to undefined', () => {
+    expect(serializeTohList([])).toBeUndefined();
+    expect(serializeTohList(undefined)).toBeUndefined();
+  });
+});
+
+describe('baseAnnotation toh round-trip', () => {
+  const dto: AnnotationDTO = {
+    uuid: 'a',
+    start: 0,
+    end: 5,
+    type: 'glossary-instance',
+    passage_uuid: 'p',
+    toh: 'toh417,toh418',
+    content: [],
+  };
+
+  it('parses the DB comma-string into an array on the domain type', () => {
+    expect(baseAnnotationFromDTO(dto).toh).toEqual(['toh417', 'toh418']);
+  });
+
+  it('round-trips the toh list back to the DB comma-string', () => {
+    const domain = baseAnnotationFromDTO(dto);
+    expect(baseAnnotationToDto(domain).toh).toBe('toh417,toh418');
+  });
+
+  it('produces an empty array (and undefined DTO) when no toh is set', () => {
+    const domain = baseAnnotationFromDTO({ ...dto, toh: undefined });
+    expect(domain.toh).toEqual([]);
+    expect(baseAnnotationToDto(domain).toh).toBeUndefined();
+  });
+});

--- a/libs/data-access/src/lib/types/annotation/annotation.ts
+++ b/libs/data-access/src/lib/types/annotation/annotation.ts
@@ -1,4 +1,5 @@
 import { ExtendedTranslationLanguage } from '../language';
+import { parseTohList, serializeTohList } from '../toh';
 import {
   AnnotationBase,
   AnnotationDTO,
@@ -259,7 +260,7 @@ export const baseAnnotationFromDTO = (dto: AnnotationDTO): AnnotationBase => {
     start: dto.start,
     end: dto.end,
     type: annotationTypeFromDTO(dto.type),
-    toh: dto.toh,
+    toh: parseTohList(dto.toh),
     passageUuid,
     validated: true,
   };
@@ -275,6 +276,6 @@ export const baseAnnotationToDto = (
   type: annotationTypeToDTO(annotation.type),
   uuid: annotation.uuid,
   passage_uuid: annotation.passageUuid,
-  toh: annotation.toh,
+  toh: serializeTohList(annotation.toh),
   content: [],
 });

--- a/libs/data-access/src/lib/types/toh.ts
+++ b/libs/data-access/src/lib/types/toh.ts
@@ -1,1 +1,15 @@
 export type TohokuCatalogEntry = `toh${number}`;
+
+/** Split a comma-separated DB toh value (e.g. "toh417,toh418") into entries. */
+export const parseTohList = (value?: string | null): TohokuCatalogEntry[] =>
+  value
+    ? (value
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean) as TohokuCatalogEntry[])
+    : [];
+
+/** Join entries back into the DB comma-string form (undefined when empty). */
+export const serializeTohList = (
+  list?: TohokuCatalogEntry[],
+): string | undefined => (list && list.length ? list.join(',') : undefined);

--- a/libs/lib-editing/src/lib/components/shared/hooks/useTohToggle.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/hooks/useTohToggle.spec.tsx
@@ -45,6 +45,41 @@ describe('useTohToggle', () => {
     expect(sheet?.cssRules[0].cssText).toContain('[data-toh="toh2"]');
   });
 
+  it('matches the active toh as a member of a comma-separated list', () => {
+    renderHook(() => useTohToggle({ toh: 'toh417' }));
+
+    const cssText = getSheet()?.cssRules[0].cssText ?? '';
+    // Keeps elements whose data-toh equals, starts with, contains, or ends
+    // with the active toh as a comma-delimited token.
+    expect(cssText).toContain(':not([data-toh="toh417"])');
+    expect(cssText).toContain(':not([data-toh^="toh417,"])');
+    expect(cssText).toContain(':not([data-toh*=",toh417,"])');
+    expect(cssText).toContain(':not([data-toh$=",toh417"])');
+  });
+
+  it('hides only non-member tohs for multi-toh elements', () => {
+    renderHook(() => useTohToggle({ toh: 'toh417' }));
+
+    // Extract the selector (everything before the declaration block).
+    const cssText = getSheet()?.cssRules[0].cssText ?? '';
+    const selector = cssText.slice(0, cssText.indexOf('{')).trim();
+
+    document.body.innerHTML = `
+      <span id="multi" data-toh="toh417,toh418">visible</span>
+      <span id="other" data-toh="toh418">hidden</span>
+      <span id="prefix" data-toh="toh4170">hidden</span>
+      <span id="plain">always visible</span>
+    `;
+
+    // The injected rule hides anything the selector matches.
+    expect(document.getElementById('multi')?.matches(selector)).toBe(false);
+    expect(document.getElementById('other')?.matches(selector)).toBe(true);
+    expect(document.getElementById('prefix')?.matches(selector)).toBe(true);
+    expect(document.getElementById('plain')?.matches(selector)).toBe(false);
+
+    document.body.innerHTML = '';
+  });
+
   it('does not throw on toh values that are not valid CSS identifiers', () => {
     expect(() =>
       renderHook(() => useTohToggle({ toh: 'toh4.1' as TohokuCatalogEntry })),

--- a/libs/lib-editing/src/lib/components/shared/hooks/useTohToggle.tsx
+++ b/libs/lib-editing/src/lib/components/shared/hooks/useTohToggle.tsx
@@ -30,12 +30,20 @@ export const useTohToggle = ({ toh }: { toh?: TohokuCatalogEntry }) => {
     }
 
     // A single rule hides every toh-scoped element that doesn't match the
-    // active toh. Attribute selectors take a quoted string, so any toh value
-    // is safe — unlike class selectors, which require valid CSS identifiers.
-    // Only quotes and backslashes need escaping inside the quoted value.
+    // active toh. `data-toh` may hold a comma-separated list (e.g.
+    // "toh417,toh418") when content belongs to several tohs, so the active toh
+    // is treated as list membership: keep the element visible if its list
+    // equals the active toh or contains it as a comma-delimited token (first,
+    // middle, or last). The comma boundaries avoid prefix collisions such as
+    // "toh41" matching "toh417". Attribute selectors take a quoted string, so
+    // any toh value is safe — only quotes and backslashes need escaping.
     const escaped = toh?.replace(/["\\]/g, '\\$&');
     const selector = escaped
-      ? `[data-toh]:not([data-toh="${escaped}"])`
+      ? `[data-toh]` +
+        `:not([data-toh="${escaped}"])` +
+        `:not([data-toh^="${escaped},"])` +
+        `:not([data-toh*=",${escaped},"])` +
+        `:not([data-toh$=",${escaped}"])`
       : '[data-toh]';
     try {
       sheet.insertRule(`${selector} { display: none; }`, 0);

--- a/libs/lib-editing/src/lib/transformers/end-note-link.ts
+++ b/libs/lib-editing/src/lib/transformers/end-note-link.ts
@@ -1,4 +1,7 @@
-import { EndNoteLinkAnnotation } from '@eightyfourthousand/data-access';
+import {
+  EndNoteLinkAnnotation,
+  serializeTohList,
+} from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
 import { recurse } from './recurse';
 import { splitContentAt } from './split-at';
@@ -17,7 +20,7 @@ const innerTransform: Transformer = ({ block, annotation }) => {
     start,
     end,
     location: end === 0 ? 'start' : 'end',
-    toh,
+    toh: serializeTohList(toh),
   });
 
   if (endnoteMark) {

--- a/libs/lib-editing/src/lib/transformers/glossary-instance.ts
+++ b/libs/lib-editing/src/lib/transformers/glossary-instance.ts
@@ -1,4 +1,7 @@
-import { GlossaryInstanceAnnotation } from '@eightyfourthousand/data-access';
+import {
+  GlossaryInstanceAnnotation,
+  serializeTohList,
+} from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
 import { recurse } from './recurse';
 import { splitContent } from './split-content';
@@ -29,7 +32,7 @@ export const glossaryInstance: Transformer = (ctx) => {
                 authority,
                 glossary,
                 uuid,
-                toh,
+                toh: serializeTohList(toh),
               },
             },
           ];

--- a/libs/lib-editing/src/lib/transformers/internal-link.ts
+++ b/libs/lib-editing/src/lib/transformers/internal-link.ts
@@ -1,4 +1,7 @@
-import { InternalLinkAnnotation } from '@eightyfourthousand/data-access';
+import {
+  InternalLinkAnnotation,
+  serializeTohList,
+} from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
 import { splitContent } from './split-content';
 import { recurse } from './recurse';
@@ -52,7 +55,7 @@ export const internalLink: Transformer = (ctx) => {
                 href: path,
                 entity,
                 type,
-                toh,
+                toh: serializeTohList(toh),
                 isSameWork,
                 subtype,
                 linkToh,

--- a/libs/lib-editing/src/lib/transformers/mention.ts
+++ b/libs/lib-editing/src/lib/transformers/mention.ts
@@ -1,4 +1,7 @@
-import { MentionAnnotation } from '@eightyfourthousand/data-access';
+import {
+  MentionAnnotation,
+  serializeTohList,
+} from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
 import { recurse } from './recurse';
 import { splitAndInsert } from './split-insert';
@@ -28,7 +31,7 @@ export const mention: Transformer = (ctx) => {
     isSameWork,
     subtype,
     linkToh,
-    toh,
+    toh: serializeTohList(toh),
   };
   recurse({
     ...ctx,


### PR DESCRIPTION
### Summary

Fixes a regression that resulted in content disappearing when annotations have a comma separated list of `toh` column values.

### Linear

- [ED-1332](https://linear.app/84000/issue/ED-1332)
