### PR TITLE
Cascade Endnote Deletion

### DIFF
--- a/libs/data-access/src/lib/passage/save.spec.ts
+++ b/libs/data-access/src/lib/passage/save.spec.ts
@@ -16,6 +16,8 @@ class FakeQueryBuilder {
   private action?: 'select' | 'delete';
   private inColumn?: string;
   private inValues: string[] = [];
+  private eqType?: string;
+  private filterContentUuid?: string;
 
   constructor(
     private readonly state: FakeState,
@@ -51,7 +53,22 @@ class FakeQueryBuilder {
     return this;
   }
 
-  eq() {
+  eq(column: string, value: string) {
+    if (column === 'type') {
+      this.eqType = value;
+    }
+    return this;
+  }
+
+  filter(column: string, op: string, value: string) {
+    if (column === 'content' && op === 'cs') {
+      try {
+        const parsed = JSON.parse(value) as Array<{ uuid?: string }>;
+        this.filterContentUuid = parsed[0]?.uuid;
+      } catch {
+        // ignore malformed filter values in the fake client
+      }
+    }
     return this;
   }
 
@@ -100,6 +117,20 @@ class FakeQueryBuilder {
     }
 
     if (this.table === 'passage_annotations') {
+      if (this.filterContentUuid) {
+        return {
+          data: this.state.annotations.filter(
+            (annotation) =>
+              (!this.eqType || annotation.type === this.eqType) &&
+              Array.isArray(annotation.content) &&
+              annotation.content.some(
+                (entry) =>
+                  (entry as { uuid?: string })?.uuid === this.filterContentUuid,
+              ),
+          ),
+          error: null,
+        };
+      }
       return {
         data: this.state.annotations.filter((annotation) =>
           this.inValues.includes(annotation.passage_uuid ?? ''),
@@ -248,5 +279,43 @@ describe('savePassagesWithDeletions', () => {
     expect(state.annotationUpserts).toEqual([]);
     expect(state.deletedAnnotationUuids).toEqual(['annotation-1']);
     expect(state.deletedPassageUuids).toEqual(['passage-1']);
+  });
+
+  it('cascades deletion of endnote-link references on other passages', async () => {
+    const referencingAnnotation: AnnotationDTO = {
+      uuid: 'ref-1',
+      passage_uuid: 'passage-translation',
+      start: 9,
+      end: 9,
+      type: 'end-note-link',
+      content: [{ uuid: 'endnote-1' }],
+    };
+
+    const endnoteRow: PassageRowDTO = {
+      uuid: 'endnote-1',
+      work_uuid: 'work-1',
+      content: 'Note text',
+      label: '1',
+      sort: 5,
+      type: 'endnotes',
+    };
+
+    const state = createState({
+      annotations: [referencingAnnotation],
+      passages: [endnoteRow],
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [],
+      deletedUuids: ['endnote-1'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.deletedCount).toBe(1);
+    expect(state.deletedPassageUuids).toEqual(['endnote-1']);
+    // The reference lives on a different passage, so it is only removed via
+    // the content-containment cascade, not the delete-by-passage_uuid pass.
+    expect(state.deletedAnnotationUuids).toEqual(['ref-1']);
   });
 });

--- a/libs/data-access/src/lib/passage/save.ts
+++ b/libs/data-access/src/lib/passage/save.ts
@@ -328,6 +328,48 @@ export const savePassagesWithDeletions = async ({
         );
       }
 
+      // Cascade: remove `endNoteLink` annotations on OTHER passages that
+      // reference any deleted endnote passage. These live on the referencing
+      // (translation/front) passages, not on the deleted note itself, so the
+      // delete-by-passage_uuid above never reaches them. Left behind, they
+      // become orphaned references that render as a stray "*". Doing this
+      // server-side fixes the case where the referencing passage is not loaded
+      // in the editor (so client-side cleanup can't reach it).
+      for (const deletedUuid of deletedUuids) {
+        const { data: referencingAnnotations, error: findReferencesError } =
+          await client
+            .from('passage_annotations')
+            .select('uuid')
+            .eq('type', 'end-note-link')
+            .filter('content', 'cs', JSON.stringify([{ uuid: deletedUuid }]));
+
+        if (findReferencesError) {
+          console.error(
+            'Error finding endnote-link references to deleted passage:',
+            findReferencesError,
+          );
+          continue;
+        }
+
+        const referenceUuids = (referencingAnnotations ?? []).map(
+          (annotation) => annotation.uuid,
+        );
+
+        if (referenceUuids.length > 0) {
+          const { error: deleteReferencesError } = await client
+            .from('passage_annotations')
+            .delete()
+            .in('uuid', referenceUuids);
+
+          if (deleteReferencesError) {
+            console.error(
+              'Error deleting endnote-link references to deleted passage:',
+              deleteReferencesError,
+            );
+          }
+        }
+      }
+
       const { error: deletePassagesError } = await client
         .from('passages')
         .delete()

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkHoverContent.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkHoverContent.tsx
@@ -13,7 +13,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigation } from '../../../shared/NavigationContext';
 import { findEndnoteMarkByUuid, findPassageNode } from '../../util';
 import { useEditorState } from '../../EditorProvider';
-import { deleteEndnotePassageNode } from './endnote-utils';
+import {
+  deleteEndnotePassageNode,
+  removeAllEndnoteLinksForPassage,
+} from './endnote-utils';
 
 const EDITOR_UPDATE_DELAY_MS = 100;
 
@@ -99,6 +102,19 @@ export const EndNoteLinkHoverContent = ({
       const endnotesEditor = getEditor('endnotes');
       if (endnotesEditor) {
         deleteEndnotePassageNode(endnotesEditor, endNote);
+      }
+
+      // Remove the referencing links directly rather than relying solely on
+      // the debounced observer in TranslationBuilder, which can miss the
+      // deletion if it races a save/navigation. The observer still backstops
+      // other deletion paths (backspace, merge) and renumbers labels.
+      const frontEditor = getEditor('front');
+      const translationEditor = getEditor('translation');
+      if (frontEditor) {
+        removeAllEndnoteLinksForPassage(frontEditor, endNote);
+      }
+      if (translationEditor) {
+        removeAllEndnoteLinksForPassage(translationEditor, endNote);
       }
     }, EDITOR_UPDATE_DELAY_MS);
   }, [endNote, getEditor, close, setHoverCardEditing]);

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -215,6 +215,48 @@ describe('TranslationSSRContent', () => {
     expect(html).toMatch(/marked<sup[^>]*endNote="en-only"[^>]*>⁠c<\/sup>/);
   });
 
+  it('omits orphaned endNoteLink notes with no resolvable label', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'marked',
+                  marks: [
+                    {
+                      type: 'endNoteLink',
+                      attrs: {
+                        notes: [
+                          // Orphaned: target endnote deleted, no label resolved.
+                          { uuid: 'n-orphan', endNote: 'en-gone' },
+                          { uuid: 'n-ok', endNote: 'en-2', label: '1.b' },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const el = TranslationSSRContent({ content: doc }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    expect(html).toContain('marked');
+    // The valid note still renders; the orphaned one is dropped entirely.
+    expect(html).toMatch(/endNote="en-2"[^>]*>⁠b<\/sup>/);
+    expect(html).not.toContain('en-gone');
+  });
+
   it('exposes the default SSR extension set including passage and bold', () => {
     const names = translationSSRExtensions.map((e) => e.name);
     expect(names).toEqual(expect.arrayContaining(['passage', 'bold']));

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
@@ -32,7 +32,12 @@ const renderEndNoteLinkMark = ({
   children?: string | string[];
 }): string => {
   const raw = mark.attrs.notes;
-  const notes: EndNoteItem[] = Array.isArray(raw) ? raw.filter(isEndNoteItem) : [];
+  const notes: EndNoteItem[] = Array.isArray(raw)
+    ? // Skip orphaned references: an endnote-link whose target passage no
+      // longer exists has no resolvable label. Rendering it would leave a
+      // stray marker in the reader, so drop it. The editor keeps showing "*".
+      raw.filter(isEndNoteItem).filter((note) => note.label)
+    : [];
   notes.sort((a, b) => (a.label || '').localeCompare(b.label || ''));
 
   const supHtml = (n: EndNoteItem, marginClass: string) => {


### PR DESCRIPTION
### Summary

When deleting an endnote, delete any endnote link annotations that reference it. Previously, this only happened client-side. If a passage was not present in memory, it would later be displayed as `*` since the uuid could not be resolved.

### Linear

<!-- A link to related Linear issues. -->
<!-- Remove if not applicable. -->

- [DEV-695](https://linear.app/84000/issue/DEV-695)
