### PR TITLE
Glossary Lookup Fallback

### DIFF
--- a/libs/data-access/src/lib/glossary/instance.spec.ts
+++ b/libs/data-access/src/lib/glossary/instance.spec.ts
@@ -1,0 +1,129 @@
+import { getGlossaryInstance } from './instance';
+import { DataClient } from '../types';
+
+type QueryResult = { data: unknown; error: unknown };
+
+/**
+ * Builds a chainable Supabase-like query builder where `.from('table')`
+ * resolves (via `maybeSingle()`) to the result registered for that table.
+ * `eq` calls are recorded so tests can assert which column/value was queried.
+ */
+const createMockClient = (resultsByTable: Record<string, QueryResult>) => {
+  const fromCalls: string[] = [];
+  const eqCalls: Array<{ table: string; column: string; value: unknown }> = [];
+
+  const client = {
+    from: jest.fn((table: string) => {
+      fromCalls.push(table);
+      const builder = {
+        select: jest.fn(() => builder),
+        eq: jest.fn((column: string, value: unknown) => {
+          eqCalls.push({ table, column, value });
+          return builder;
+        }),
+        limit: jest.fn(() => builder),
+        maybeSingle: jest.fn(() =>
+          Promise.resolve(
+            resultsByTable[table] ?? { data: null, error: null },
+          ),
+        ),
+      };
+      return builder;
+    }),
+  };
+
+  return { client: client as unknown as DataClient, fromCalls, eqCalls };
+};
+
+const indexRow = {
+  glossary_uuid: 'parent-uuid',
+  authority_uuid: 'authority-uuid',
+  work_uuid: 'work-uuid',
+  definition: 'a definition',
+  english: 'English',
+  wylie: 'wylie',
+  tibetan: 'tibetan',
+  sanskrit_plain: 'sanskrit',
+  chinese: 'chinese',
+  pali: 'pali',
+  alternatives: 'alt',
+};
+
+describe('getGlossaryInstance', () => {
+  it('returns the mapped instance on a direct index hit without touching glossary_edges', async () => {
+    const { client, fromCalls, eqCalls } = createMockClient({
+      glossary_term_index: { data: indexRow, error: null },
+    });
+
+    const result = await getGlossaryInstance({ client, uuid: 'parent-uuid' });
+
+    expect(result).toEqual({
+      uuid: 'parent-uuid',
+      authority: 'authority-uuid',
+      workUuid: 'work-uuid',
+      definition: 'a definition',
+      termNumber: 0,
+      names: {
+        english: 'English',
+        tibetan: 'tibetan',
+        sanskrit: 'sanskrit',
+        pali: 'pali',
+        chinese: 'chinese',
+        wylie: 'wylie',
+        alternatives: 'alt',
+      },
+    });
+
+    expect(fromCalls).toEqual(['glossary_term_index']);
+    expect(eqCalls).toContainEqual({
+      table: 'glossary_term_index',
+      column: 'glossary_uuid',
+      value: 'parent-uuid',
+    });
+  });
+
+  it('falls back to glossary_edges and retries the index with the parent uuid', async () => {
+    const indexResults: QueryResult[] = [
+      { data: null, error: null }, // first index lookup misses
+      { data: indexRow, error: null }, // retry with parent hits
+    ];
+
+    const client = {
+      from: jest.fn((table: string) => {
+        const builder = {
+          select: jest.fn(() => builder),
+          eq: jest.fn(() => builder),
+          limit: jest.fn(() => builder),
+          maybeSingle: jest.fn(() => {
+            if (table === 'glossary_edges') {
+              return Promise.resolve({
+                data: { parent_uuid: 'parent-uuid' },
+                error: null,
+              });
+            }
+            return Promise.resolve(
+              indexResults.shift() ?? { data: null, error: null },
+            );
+          }),
+        };
+        return builder;
+      }),
+    } as unknown as DataClient;
+
+    const result = await getGlossaryInstance({ client, uuid: 'child-uuid' });
+
+    expect(result?.uuid).toBe('parent-uuid');
+    expect(result?.workUuid).toBe('work-uuid');
+  });
+
+  it('returns undefined when neither the index nor an edge resolves', async () => {
+    const { client } = createMockClient({
+      glossary_term_index: { data: null, error: null },
+      glossary_edges: { data: null, error: null },
+    });
+
+    const result = await getGlossaryInstance({ client, uuid: 'missing-uuid' });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/libs/data-access/src/lib/glossary/instance.ts
+++ b/libs/data-access/src/lib/glossary/instance.ts
@@ -34,6 +34,55 @@ export const getGlossaryInstances = async ({
   });
 };
 
+const GLOSSARY_INDEX_COLUMNS =
+  'glossary_uuid, authority_uuid, work_uuid, definition, english, wylie, tibetan, sanskrit_plain, chinese, pali, alternatives';
+
+type GlossaryTermIndexInstanceRow = {
+  glossary_uuid: string;
+  authority_uuid: string;
+  work_uuid: string;
+  definition: string | null;
+  english: string | null;
+  wylie: string | null;
+  tibetan: string | null;
+  sanskrit_plain: string | null;
+  chinese: string | null;
+  pali: string | null;
+  alternatives: string | null;
+};
+
+const indexRowToDTO = (
+  row: GlossaryTermIndexInstanceRow,
+): GlossaryTermInstanceDTO => ({
+  uuid: row.glossary_uuid,
+  authority_uuid: row.authority_uuid,
+  work_uuid: row.work_uuid,
+  definition: row.definition ?? undefined,
+  names: {
+    english: row.english ?? undefined,
+    tibetan: row.tibetan ?? undefined,
+    sanskrit: row.sanskrit_plain ?? undefined,
+    pali: row.pali ?? undefined,
+    chinese: row.chinese ?? undefined,
+    wylie: row.wylie ?? undefined,
+    alternatives: row.alternatives ?? undefined,
+  },
+});
+
+const fetchIndexRow = async (client: DataClient, uuid: string) => {
+  const { data, error } = await client
+    .from('glossary_term_index')
+    .select(GLOSSARY_INDEX_COLUMNS)
+    .eq('glossary_uuid', uuid)
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    console.error(`Error fetching glossary instance: ${uuid} `, error);
+    return null;
+  }
+  return data as GlossaryTermIndexInstanceRow | null;
+};
+
 export const getGlossaryInstance = async ({
   client,
   uuid,
@@ -41,14 +90,29 @@ export const getGlossaryInstance = async ({
   client: DataClient;
   uuid: string;
 }) => {
-  const { data, error } = await client.rpc('show_glossary_entry', {
-    v_glossary_uuid: uuid,
-  });
+  // 1) Direct lookup in the glossary_term_index view.
+  let row = await fetchIndexRow(client, uuid);
 
-  if (error) {
-    console.error(`Error fetching glossary instance: ${uuid} `, error);
+  // 2) Fallback: the uuid may be a non-translationMain child that isn't
+  //    represented in the index. Resolve its parent via glossary_edges and
+  //    retry the index lookup with the parent uuid.
+  if (!row) {
+    const { data: edge, error: edgeError } = await client
+      .from('glossary_edges')
+      .select('parent_uuid')
+      .eq('child_uuid', uuid)
+      .limit(1)
+      .maybeSingle();
+    if (edgeError) {
+      console.error(`Error fetching glossary edge: ${uuid} `, edgeError);
+    } else if (edge?.parent_uuid) {
+      row = await fetchIndexRow(client, edge.parent_uuid);
+    }
+  }
+
+  if (!row) {
     return undefined;
   }
 
-  return glossaryTermInstanceFromDTO(data as GlossaryTermInstanceDTO);
+  return glossaryTermInstanceFromDTO(indexRowToDTO(row));
 };


### PR DESCRIPTION
### Summary

In the reader, links to glossary terms will only succeed if the provided uuid is present in the `glossary_term_index` view, which correspond to `translationMain` rows in the `glossaries` table. Previously, the `/entity/glossary` endpoint relied on the old `show_glossary_entry` rpc function to look up terms, and that function does will look up any row from the `glossaries` table. Now, the endpoint will read from the `glossary_term_index`. As a fallback, if the uuid is not found in the index, it will also try to find the uuid of the parent `glossaries` entry.

### Linear

- [DEV-698](https://linear.app/84000/issue/DEV-698)
