### PR TITLE
Mention Refinements

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.spec.ts
@@ -1,0 +1,78 @@
+import { Schema } from '@tiptap/pm/model';
+import { EditorState, Plugin } from '@tiptap/pm/state';
+import { EnsureUniqueUuids } from './EnsureUniqueUuids';
+
+// Minimal schema mirroring the editor's relevant shape: block nodes and an
+// inline leaf (atom) all carry a `uuid` attr, just as TranslationMetadata adds
+// a global `uuid` to every node type except text/doc.
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { uuid: { default: null } },
+      parseDOM: [{ tag: 'p' }],
+      toDOM: () => ['p', 0],
+    },
+    // Inline atom leaf with no marks allowed — the same shape as `mention`.
+    mention: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      marks: '',
+      attrs: { uuid: { default: null } },
+      toDOM: () => ['span'],
+    },
+    text: { group: 'inline' },
+  },
+});
+
+const getPlugin = (): Plugin => {
+  const plugins = EnsureUniqueUuids.config.addProseMirrorPlugins?.call({});
+  if (!plugins?.length) {
+    throw new Error('EnsureUniqueUuids did not register a plugin');
+  }
+  return plugins[0] as Plugin;
+};
+
+const collectUuids = (state: EditorState) => {
+  const uuids: string[] = [];
+  state.doc.descendants((node) => {
+    if (node.type.spec.attrs && 'uuid' in node.type.spec.attrs) {
+      uuids.push(node.attrs.uuid);
+    }
+    return true;
+  });
+  return uuids;
+};
+
+describe('EnsureUniqueUuids plugin', () => {
+  it('assigns unique uuids without throwing when adjacent leaf nodes collide', () => {
+    const plugin = getPlugin();
+
+    // Paragraph containing two adjacent mention atoms that share a uuid — the
+    // collision branch the plugin must reconcile. Rebuilding a leaf can shift
+    // later positions, which previously crashed the apply loop.
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', { uuid: 'dup' }, [
+        schema.node('mention', { uuid: 'shared' }),
+        schema.node('mention', { uuid: 'shared' }),
+      ]),
+      schema.node('paragraph', { uuid: 'dup' }, [schema.text('tail')]),
+    ]);
+
+    let state = EditorState.create({ schema, doc, plugins: [plugin] });
+
+    // A docChanged transaction triggers appendTransaction.
+    const tr = state.tr.insertText('x', doc.content.size - 1);
+    expect(() => {
+      state = state.apply(tr);
+    }).not.toThrow();
+
+    const uuids = collectUuids(state);
+    // All uuid-bearing nodes end up with distinct, non-null uuids.
+    expect(uuids.every((u) => !!u)).toBe(true);
+    expect(new Set(uuids).size).toBe(uuids.length);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.ts
@@ -75,10 +75,21 @@ export const EnsureUniqueUuids = Extension.create({
           }
 
           const tr = newState.tr;
-          for (const { pos, attrs } of updates) {
+          // Apply in reverse document order so an earlier (lower) position is
+          // never invalidated by a later edit that changes document size — e.g.
+          // rebuilding a leaf node (an inline atom such as a mention) whose new
+          // markup does not "fit trivially" and shifts subsequent positions.
+          // Re-resolve each node at apply time and skip it if the position no
+          // longer points at a uuid-bearing, non-text node; the plugin must
+          // never throw, and a skipped node is reconciled on the next cycle.
+          for (const { pos, attrs } of [...updates].reverse()) {
+            const node = tr.doc.nodeAt(pos);
+            if (!node || node.isText || !hasUuidAttr(node)) {
+              continue;
+            }
             tr.setNodeMarkup(pos, undefined, attrs);
           }
-          return tr;
+          return tr.docChanged ? tr : null;
         },
       }),
     ];

--- a/libs/lib-editing/src/lib/components/editor/extensions/Line/LineNode.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Line/LineNode.ssr.ts
@@ -9,7 +9,7 @@ export const LineNodeSSR = Node.create({
     };
   },
 
-  content: 'text*',
+  content: 'inline*',
 
   defining: true,
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -26,6 +26,12 @@ export const MentionSSR = Node.create<MentionSSROptions>({
   group: 'inline',
   inline: true,
   atom: true,
+  // Mentions never carry marks. Without this, an inline mark whose range
+  // coincides with the mention's position (e.g. an end-location endNoteLink,
+  // which is a zero-length annotation at the same start/end) gets stored on
+  // the mention node, producing a duplicate <sup>. Disallowing marks here
+  // keeps the endnote on the adjacent text, so the mention renders after it.
+  marks: '',
 
   addOptions() {
     return {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -67,12 +67,12 @@ export const MentionSSR = Node.create<MentionSSROptions>({
       : [];
 
     const children = items.map((item) => {
-      const label = item.text || item.displayText || item.entity || '';
+      const label = item.text || item.displayText || '';
       const tohAttr: Record<string, string> = item.toh
         ? { 'data-toh': item.toh }
         : {};
 
-      if (!item.entity || !item.linkType) {
+      if (!label || !item.entity || !item.linkType) {
         return [
           'span',
           { class: cn('mention-link px-1'), ...tohAttr },

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -28,7 +28,10 @@ export const Mention = MentionSSR.extend({
         }
 
         // Display priority: text (custom override) > displayText (dynamic) > entity UUID (fallback)
-        anchor.textContent = item.text || item.displayText || item.entity;
+        const displayText = item.text || item.displayText;
+        anchor.textContent =
+          displayText ||
+          (props.editor.isEditable ? `[${item.entity || 'Unknown'}]` : '');
 
         // Compute href from linkType + entity
         let href = `/entity/${item.linkType}/${item.entity}`;

--- a/libs/lib-editing/src/lib/transformers/mention.spec.ts
+++ b/libs/lib-editing/src/lib/transformers/mention.spec.ts
@@ -1,0 +1,122 @@
+import {
+  annotationsFromDTO,
+  PassageDTO,
+  passageFromDTO,
+} from '@eightyfourthousand/data-access';
+import { blockFromPassage } from '../block';
+import { findTextNodeWithMarks, recurseForType } from './recurse';
+import { TranslationEditorContentItem } from '../components/editor';
+
+const countMentions = (
+  node: TranslationEditorContentItem,
+): TranslationEditorContentItem[] => {
+  const found: TranslationEditorContentItem[] = [];
+  if (node.type === 'mention') {
+    found.push(node);
+  }
+  for (const child of node.content || []) {
+    found.push(...countMentions(child));
+  }
+  return found;
+};
+
+describe('mention transformer', () => {
+  it('batches multiple mentions at the same location into a single node', () => {
+    const dto: PassageDTO = {
+      sort: 1,
+      type: 'root',
+      uuid: 'passage-uuid-1234',
+      label: '',
+      xmlId: 'test-passage',
+      parent: 'test-parent',
+      content: 'Some text',
+      work_uuid: 'work-uuid-5678',
+      annotations: [
+        {
+          start: 4,
+          end: 4,
+          type: 'mention',
+          uuid: 'mention-uuid-1',
+          content: [{ uuid: 'entity-1' }, { type: 'glossary' }],
+          passage_uuid: 'passage-uuid-1234',
+        },
+        {
+          start: 4,
+          end: 4,
+          type: 'mention',
+          uuid: 'mention-uuid-2',
+          content: [{ uuid: 'entity-2' }, { type: 'bibliography' }],
+          passage_uuid: 'passage-uuid-1234',
+        },
+      ],
+    };
+
+    const passage = passageFromDTO(
+      dto,
+      annotationsFromDTO(dto.annotations || [], dto.content.length),
+    );
+    const block = blockFromPassage(passage);
+    if (!block?.content) {
+      throw new Error('Block conversion failed');
+    }
+
+    const mentions = countMentions(block);
+    // Both annotations collapse into one mention node — no phantom empty node.
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].attrs?.items?.length).toBe(2);
+    expect(mentions[0].marks).toEqual([]);
+  });
+
+  it('keeps the endNoteLink mark on adjacent text, not the mention, at a shared location', () => {
+    const dto: PassageDTO = {
+      sort: 1,
+      type: 'root',
+      uuid: 'passage-uuid-1234',
+      label: '',
+      xmlId: 'test-passage',
+      parent: 'test-parent',
+      content: 'Some text',
+      work_uuid: 'work-uuid-5678',
+      annotations: [
+        {
+          start: 4,
+          end: 4,
+          type: 'mention',
+          uuid: 'mention-uuid-1',
+          content: [{ uuid: 'entity-1' }, { type: 'glossary' }],
+          passage_uuid: 'passage-uuid-1234',
+        },
+        {
+          start: 4,
+          end: 4,
+          type: 'end-note-link',
+          uuid: 'endnote-link-uuid-1',
+          content: [{ uuid: 'endnote-uuid-1' }],
+          passage_uuid: 'passage-uuid-1234',
+        },
+      ],
+    };
+
+    const passage = passageFromDTO(
+      dto,
+      annotationsFromDTO(dto.annotations || [], dto.content.length),
+    );
+    const block = blockFromPassage(passage);
+    if (!block?.content) {
+      throw new Error('Block conversion failed');
+    }
+
+    const mention = recurseForType({ block, until: 'mention' });
+    expect(mention).toBeDefined();
+    // The mention never carries marks.
+    expect(mention?.marks).toEqual([]);
+
+    // The endNoteLink mark lives on a text node, not on the mention.
+    const textNode = findTextNodeWithMarks(block);
+    expect(textNode?.type).toBe('text');
+    const endnoteMark = textNode?.marks?.find(
+      (m: { type: string }) => m.type === 'endNoteLink',
+    );
+    expect(endnoteMark).toBeDefined();
+  });
+});

--- a/libs/lib-editing/src/lib/transformers/mention.ts
+++ b/libs/lib-editing/src/lib/transformers/mention.ts
@@ -59,7 +59,9 @@ export const mention: Transformer = (ctx) => {
             const items = mention.attrs?.items || [];
             items.push(item);
             mention.attrs = { ...mention.attrs, items };
-            return;
+            // Item was batched into the existing mention; signal that no new
+            // mention block should be inserted for this annotation.
+            return true;
           }
 
           block.type = 'mention';
@@ -68,6 +70,7 @@ export const mention: Transformer = (ctx) => {
             end,
             items: [item],
           };
+          block.marks = [];
         },
       });
     },

--- a/libs/lib-editing/src/lib/transformers/split-at.ts
+++ b/libs/lib-editing/src/lib/transformers/split-at.ts
@@ -37,21 +37,52 @@ export const splitContentAt: Transformer = (ctx) => {
   const currentContent = parent.content || [];
   const newContent = [];
 
+  let anchored = false;
+  // Whether any node ended exactly at this position, even one we skipped
+  // because it wasn't text (e.g. a mention). Distinguishes "nothing was here"
+  // from "the only thing here was a non-text node".
+  let boundaryNonTextOnly = false;
+
   for (const item of currentContent) {
     const { prefix, middle, suffix } = splitNode(item, start, end);
 
     const lastPrefix = prefix.at(-1);
     const firstSuffix = suffix[0];
 
+    // An end-location insertion point (e.g. an endNoteLink) attaches to the
+    // text node that ends at this position. Atomic inline nodes such as
+    // mentions are also zero-length and can share the boundary, but they must
+    // not receive the mark — the adjacent text carries it, so the marker
+    // renders before the mention rather than duplicating onto it.
     if (annotationEnd === lastPrefix?.attrs?.end) {
-      transform?.({ root, parent, block: lastPrefix, annotation });
+      if (typeof lastPrefix?.text === 'string') {
+        transform?.({ root, parent, block: lastPrefix, annotation });
+        anchored = true;
+      } else {
+        boundaryNonTextOnly = true;
+      }
     } else if (annotationEnd === firstSuffix?.attrs?.end) {
-      transform?.({ root, parent, block: firstSuffix, annotation });
+      if (typeof firstSuffix?.text === 'string') {
+        transform?.({ root, parent, block: firstSuffix, annotation });
+        anchored = true;
+      } else {
+        boundaryNonTextOnly = true;
+      }
     }
 
     newContent.push(...prefix);
     newContent.push(...middle);
     newContent.push(...suffix);
+  }
+
+  // An end-location insertion point that only ever lined up with non-text
+  // nodes (and no text node) has nowhere valid to attach. This is malformed
+  // data — an end marker with no preceding text in the passage — so the
+  // annotation is dropped rather than rendered onto a mention.
+  if (transform && !anchored && boundaryNonTextOnly) {
+    console.warn(
+      `splitContentAt: insertion point ${annotation.uuid} (${annotation.type}) at position ${annotationEnd} found no text node to attach to; annotation dropped.`,
+    );
   }
 
   parent.content = newContent;

--- a/libs/lib-editing/src/lib/transformers/split-insert.ts
+++ b/libs/lib-editing/src/lib/transformers/split-insert.ts
@@ -42,7 +42,12 @@ export const splitAndInsert: Transformer = (ctx) => {
       end,
     },
   };
-  transform?.({ root, parent, block: newBlock, annotation });
+  // A transform may batch into an existing node and signal that it handled the
+  // context, in which case the freshly created `newBlock` must not be inserted.
+  const handled = transform?.({ root, parent, block: newBlock, annotation });
+  if (handled) {
+    return;
+  }
 
   if (start <= block.attrs?.start || start >= block.attrs?.end) {
     parent.content = insert(newBlock, parent.content || []);

--- a/libs/lib-editing/src/lib/transformers/transformer.ts
+++ b/libs/lib-editing/src/lib/transformers/transformer.ts
@@ -15,7 +15,9 @@ export type TransformationContext = {
 };
 
 export type TransformationContextWithCallback = TransformationContext & {
-  transform?: (ctx: TransformationContext) => void;
+  // A callback may return `true` to signal it fully handled the context and the
+  // caller should not perform its default insertion (e.g. mention batching).
+  transform?: (ctx: TransformationContext) => void | boolean;
 };
 
 export type Transformer = (ctx: TransformationContextWithCallback) => void;


### PR DESCRIPTION
### Summary

- Display unresolved mentions as uuids in the editor but not in the reader
- Allow mentions and other inline content in line nodes
- Fix collisions between mentions and other zero-length annotation
- Fix unnecessary splits of batched annotations like endnote links and mentions
- Ensure unique uuids in reverse document order because mentions, despite being zero-length annotations, affect the document size and can invalidate other in-flight transactions
- Add additional logging for invalid annotations (visible in GraphQL logs)

### Linear

- [DEV-554](https://linear.app/84000/issue/DEV-554)