### PR TITLE
Use bibliography entry label if present

### DIFF
--- a/libs/data-access/src/lib/types/bibliography.ts
+++ b/libs/data-access/src/lib/types/bibliography.ts
@@ -34,21 +34,25 @@ export type BibliographyEntryItemDTO = {
   uuid: string;
   bibl_html: string;
   work_uuid?: string;
+  label?: string;
 };
 
 export type BibliographyEntryItem = {
   uuid: string;
   html: string;
   workUuid?: string;
+  label?: string;
 };
 
 export type BlibliographyEntryDTO = {
   heading?: string;
+  label?: string;
   entries: BibliographyEntryItemDTO[];
 };
 
 export type BibliographyEntry = {
   heading?: string;
+  label?: string;
   entries: BibliographyEntryItem[];
 };
 
@@ -61,6 +65,7 @@ export const bibliographyEntryItemFromDTO = (
 ): BibliographyEntryItem => {
   return {
     uuid: dto.uuid,
+    label: dto.label,
     html: dto.bibl_html,
     workUuid: dto.work_uuid,
   };
@@ -71,6 +76,7 @@ export const bibliographyEntryFromDTO = (
 ): BibliographyEntry => {
   return {
     heading: dto.heading,
+    label: dto.label,
     entries: dto.entries?.map(bibliographyEntryItemFromDTO) || [],
   };
 };

--- a/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyList.tsx
+++ b/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyList.tsx
@@ -41,7 +41,7 @@ export const BibliographyList = ({
               <LabeledElement
                 className="@c/sidebar:mt-0.5 mt-4"
                 id={`${section.heading}-${i}`}
-                label={`b.${i + 1}`}
+                label={section.label || `b.${i + 1}`}
                 contentType="bibliography"
                 excerpt={section.heading}
               >
@@ -53,7 +53,7 @@ export const BibliographyList = ({
             {section.entries.map((entry, j) => (
               <BibliographyBody
                 entry={entry}
-                label={`b.${i + 1}.${j + 1}`}
+                label={entry.label || `b.${i + 1}.${j + 1}`}
                 key={entry.uuid}
               />
             ))}


### PR DESCRIPTION
### Summary

Bibliography entries will now display a label provided by the backend, if it is available. A locally computed label is still a fallback.

### Linear

- [ED-1111](https://linear.app/84000/issue/ED-1111)

### Notes

The database function that serves bibliography entries now supports hierarchy and provides label. Currently, it hides some top-level headings because the frontend needs this change do correctly display labels. Once it is deployed everywhere, the full hierarchy can be returned.
