### PR TITLE
Packages 2026.6.4

### DIFF
--- a/libs/client-graphql/package.json
+++ b/libs/client-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/client-graphql",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "description": "GraphQL client helpers and typed query functions for 84000 applications.",
   "private": false,
   "repository": {
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/data-access": "^2026.6.3",
+    "@eightyfourthousand/data-access": "^2026.6.4",
     "graphql-request": "^7.1.2",
     "graphql-tag": "^2.12.6",
     "server-only": "^0.0.1"

--- a/libs/data-access/package.json
+++ b/libs/data-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/data-access",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "description": "Shared data access clients, DTO mappers, and domain types for 84000 applications.",
   "private": false,
   "repository": {
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/lib-utils": "^2026.6.3",
+    "@eightyfourthousand/lib-utils": "^2026.6.4",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.106.2",
     "@tiptap/core": "^3.23.6",

--- a/libs/design-system/package.json
+++ b/libs/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/design-system",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "description": "Shared React UI components and theme assets for 84000 applications.",
   "private": false,
   "repository": {
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/lib-utils": "^2026.6.3",
+    "@eightyfourthousand/lib-utils": "^2026.6.4",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-collapsible": "^1.1.8",

--- a/libs/lib-agent/package.json
+++ b/libs/lib-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-agent",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "description": "Shared MCP server factory for 84000 Next.js applications.",
   "private": false,
   "repository": {

--- a/libs/lib-agent/src/lib/server.ts
+++ b/libs/lib-agent/src/lib/server.ts
@@ -5,7 +5,7 @@ import type { McpHandlerOptions } from './types';
 export function createMcpHandler(options: McpHandlerOptions) {
   const {
     name = '84000-mcp',
-    version = '2026.6.3',
+    version = '2026.6.4',
     description,
     instructions,
     tools,

--- a/libs/lib-editing/package.json
+++ b/libs/lib-editing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-editing",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "description": "Shared editing and reader components for 84000 translation workflows.",
   "private": false,
   "repository": {
@@ -17,12 +17,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/client-graphql": "^2026.6.3",
-    "@eightyfourthousand/data-access": "^2026.6.3",
-    "@eightyfourthousand/design-system": "^2026.6.3",
-    "@eightyfourthousand/lib-instr": "^2026.6.3",
-    "@eightyfourthousand/lib-search": "^2026.6.3",
-    "@eightyfourthousand/lib-utils": "^2026.6.3",
+    "@eightyfourthousand/client-graphql": "^2026.6.4",
+    "@eightyfourthousand/data-access": "^2026.6.4",
+    "@eightyfourthousand/design-system": "^2026.6.4",
+    "@eightyfourthousand/lib-instr": "^2026.6.4",
+    "@eightyfourthousand/lib-search": "^2026.6.4",
+    "@eightyfourthousand/lib-utils": "^2026.6.4",
     "@floating-ui/react": "^0.27.19",
     "@tanstack/react-table": "^8.21.2",
     "@tiptap/core": "^3.23.6",

--- a/libs/lib-instr/package.json
+++ b/libs/lib-instr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-instr",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "description": "Feature flag and instrumentation helpers for 84000 applications.",
   "private": false,
   "repository": {

--- a/libs/lib-search/package.json
+++ b/libs/lib-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-search",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "description": "Shared translation search UI and server helpers for 84000 applications.",
   "private": false,
   "repository": {
@@ -17,10 +17,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/client-graphql": "^2026.6.3",
-    "@eightyfourthousand/data-access": "^2026.6.3",
-    "@eightyfourthousand/design-system": "^2026.6.3",
-    "@eightyfourthousand/lib-utils": "^2026.6.3",
+    "@eightyfourthousand/client-graphql": "^2026.6.4",
+    "@eightyfourthousand/data-access": "^2026.6.4",
+    "@eightyfourthousand/design-system": "^2026.6.4",
+    "@eightyfourthousand/lib-utils": "^2026.6.4",
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {

--- a/libs/lib-utils/package.json
+++ b/libs/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-utils",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "description": "Shared utility helpers for 84000 applications.",
   "private": false,
   "repository": {


### PR DESCRIPTION
### Summary

Update published packages to version `2026.6.4`

- Cascade endnote deletion in editor and include referencing annotations
- Resolve glossary uuids to a `translationMain` entry in the `/entity` endpoint
- Add the TipTap typography extension for automatically converting straight quotes to smart quotes (and more) while editing
- Ensure mentions display correctly besides endnote links and in all node types
- Display bibliography entry labels provided by the backend, if present