### PR TITLE
Display Bibliography Label

### DIFF
--- a/apps/api-graphql/src/graphql/schema/bibliography/bibliography.graphql
+++ b/apps/api-graphql/src/graphql/schema/bibliography/bibliography.graphql
@@ -13,6 +13,11 @@ type BibliographyEntryItem {
   html: String!
 
   """
+  Label of the bibliography entry (e.g., 1.1, 1.2, etc.)
+  """
+  label: String
+
+  """
   UUID of the work this entry belongs to
   """
   workUuid: ID
@@ -26,6 +31,11 @@ type BibliographyEntry {
   Section heading
   """
   heading: String
+
+  """
+  Label of the bibliography entry (e.g., 1, 2, etc.)
+  """
+  label: String
 
   """
   Bibliography entries in this section

--- a/libs/client-graphql/package.json
+++ b/libs/client-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/client-graphql",
-  "version": "2026.6.4",
+  "version": "2026.6.5",
   "description": "GraphQL client helpers and typed query functions for 84000 applications.",
   "private": false,
   "repository": {
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/data-access": "^2026.6.4",
+    "@eightyfourthousand/data-access": "^2026.6.5",
     "graphql-request": "^7.1.2",
     "graphql-tag": "^2.12.6",
     "server-only": "^0.0.1"

--- a/libs/client-graphql/src/lib/functions/get-work-bibliography.ts
+++ b/libs/client-graphql/src/lib/functions/get-work-bibliography.ts
@@ -7,8 +7,10 @@ const GET_WORK_BIBLIOGRAPHY = gql`
     work(uuid: $uuid) {
       bibliography {
         heading
+        label
         entries {
           uuid
+          label
           html
           workUuid
         }

--- a/libs/client-graphql/src/lib/generated/graphql.ts
+++ b/libs/client-graphql/src/lib/generated/graphql.ts
@@ -71,6 +71,8 @@ export type BibliographyEntry = {
   entries: Array<BibliographyEntryItem>;
   /** Section heading */
   heading?: Maybe<Scalars['String']['output']>;
+  /** Label of the bibliography entry (e.g., 1, 2, etc.) */
+  label?: Maybe<Scalars['String']['output']>;
 };
 
 /** A single bibliography entry item */
@@ -78,6 +80,8 @@ export type BibliographyEntryItem = {
   __typename?: 'BibliographyEntryItem';
   /** HTML content of the bibliography entry */
   html: Scalars['String']['output'];
+  /** Label of the bibliography entry (e.g., 1.1, 1.2, etc.) */
+  label?: Maybe<Scalars['String']['output']>;
   /** Unique identifier */
   uuid: Scalars['ID']['output'];
   /** UUID of the work this entry belongs to */

--- a/libs/data-access/package.json
+++ b/libs/data-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/data-access",
-  "version": "2026.6.4",
+  "version": "2026.6.5",
   "description": "Shared data access clients, DTO mappers, and domain types for 84000 applications.",
   "private": false,
   "repository": {
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/lib-utils": "^2026.6.4",
+    "@eightyfourthousand/lib-utils": "^2026.6.5",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.106.2",
     "@tiptap/core": "^3.23.6",

--- a/libs/design-system/package.json
+++ b/libs/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/design-system",
-  "version": "2026.6.4",
+  "version": "2026.6.5",
   "description": "Shared React UI components and theme assets for 84000 applications.",
   "private": false,
   "repository": {
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/lib-utils": "^2026.6.4",
+    "@eightyfourthousand/lib-utils": "^2026.6.5",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-collapsible": "^1.1.8",

--- a/libs/lib-agent/package.json
+++ b/libs/lib-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-agent",
-  "version": "2026.6.4",
+  "version": "2026.6.5",
   "description": "Shared MCP server factory for 84000 Next.js applications.",
   "private": false,
   "repository": {

--- a/libs/lib-agent/src/lib/server.ts
+++ b/libs/lib-agent/src/lib/server.ts
@@ -5,7 +5,7 @@ import type { McpHandlerOptions } from './types';
 export function createMcpHandler(options: McpHandlerOptions) {
   const {
     name = '84000-mcp',
-    version = '2026.6.4',
+    version = '2026.6.5',
     description,
     instructions,
     tools,

--- a/libs/lib-editing/package.json
+++ b/libs/lib-editing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-editing",
-  "version": "2026.6.4",
+  "version": "2026.6.5",
   "description": "Shared editing and reader components for 84000 translation workflows.",
   "private": false,
   "repository": {
@@ -17,12 +17,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/client-graphql": "^2026.6.4",
-    "@eightyfourthousand/data-access": "^2026.6.4",
-    "@eightyfourthousand/design-system": "^2026.6.4",
-    "@eightyfourthousand/lib-instr": "^2026.6.4",
-    "@eightyfourthousand/lib-search": "^2026.6.4",
-    "@eightyfourthousand/lib-utils": "^2026.6.4",
+    "@eightyfourthousand/client-graphql": "^2026.6.5",
+    "@eightyfourthousand/data-access": "^2026.6.5",
+    "@eightyfourthousand/design-system": "^2026.6.5",
+    "@eightyfourthousand/lib-instr": "^2026.6.5",
+    "@eightyfourthousand/lib-search": "^2026.6.5",
+    "@eightyfourthousand/lib-utils": "^2026.6.5",
     "@floating-ui/react": "^0.27.19",
     "@tanstack/react-table": "^8.21.2",
     "@tiptap/core": "^3.23.6",

--- a/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyList.tsx
+++ b/libs/lib-editing/src/lib/components/shared/bibliography/BibliographyList.tsx
@@ -41,7 +41,7 @@ export const BibliographyList = ({
               <LabeledElement
                 className="@c/sidebar:mt-0.5 mt-4"
                 id={`${section.heading}-${i}`}
-                label={section.label || `b.${i + 1}`}
+                label={`b.${section.label || i + 1}`}
                 contentType="bibliography"
                 excerpt={section.heading}
               >
@@ -53,7 +53,7 @@ export const BibliographyList = ({
             {section.entries.map((entry, j) => (
               <BibliographyBody
                 entry={entry}
-                label={entry.label || `b.${i + 1}.${j + 1}`}
+                label={`b.${entry.label || `${i + 1}.${j + 1}`}`}
                 key={entry.uuid}
               />
             ))}

--- a/libs/lib-instr/package.json
+++ b/libs/lib-instr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-instr",
-  "version": "2026.6.4",
+  "version": "2026.6.5",
   "description": "Feature flag and instrumentation helpers for 84000 applications.",
   "private": false,
   "repository": {

--- a/libs/lib-search/package.json
+++ b/libs/lib-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-search",
-  "version": "2026.6.4",
+  "version": "2026.6.5",
   "description": "Shared translation search UI and server helpers for 84000 applications.",
   "private": false,
   "repository": {
@@ -17,10 +17,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@eightyfourthousand/client-graphql": "^2026.6.4",
-    "@eightyfourthousand/data-access": "^2026.6.4",
-    "@eightyfourthousand/design-system": "^2026.6.4",
-    "@eightyfourthousand/lib-utils": "^2026.6.4",
+    "@eightyfourthousand/client-graphql": "^2026.6.5",
+    "@eightyfourthousand/data-access": "^2026.6.5",
+    "@eightyfourthousand/design-system": "^2026.6.5",
+    "@eightyfourthousand/lib-utils": "^2026.6.5",
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {

--- a/libs/lib-utils/package.json
+++ b/libs/lib-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightyfourthousand/lib-utils",
-  "version": "2026.6.4",
+  "version": "2026.6.5",
   "description": "Shared utility helpers for 84000 applications.",
   "private": false,
   "repository": {


### PR DESCRIPTION
### Summary

GraphQL will now pass generated bibliography labels from the database function. In addition, the frontend will add a `b.` prefix.

This also updates package versions to `2026.6.5`.

### Linear

- [ED-1111](https://linear.app/84000/issue/ED-1111)
