### PR TITLE
Fix Glossary Deep Links

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -24,6 +24,7 @@ import {
   isUuid,
   scrollToElement,
   useIsMobile,
+  waitForStableElement,
 } from '@eightyfourthousand/lib-utils';
 import { PanelName, TabName, useNavigation } from '../shared';
 import {
@@ -251,52 +252,12 @@ export const PaginationProvider = ({
             refreshEditorBaseline(tab);
           }
 
-          // Wait for React to re-render and update the DOM (remove/add skeletons)
-          // by waiting until the element's position stabilizes
-          await new Promise<void>((resolve) => {
-            let stabilityCount = 0;
-            let lastTop = -1;
-            let frames = 0;
-            // Cap the wait so a target that never renders can't hang
-            // navigation; ~2s at 60fps. On timeout we resolve and the
-            // element lookup + `if (!element) return` below bails cleanly.
-            const MAX_FRAMES = 120;
-
-            const checkStability = () => {
-              if (frames++ > MAX_FRAMES) {
-                resolve();
-                return;
-              }
-
-              const el = div.querySelector<HTMLElement>(
-                `#${CSS.escape(navCursor)}`,
-              );
-              if (!el) {
-                requestAnimationFrame(checkStability);
-                return;
-              }
-
-              const currentTop = el.getBoundingClientRect().top;
-
-              // Check if position has stabilized (same for 2 consecutive frames)
-              if (currentTop === lastTop) {
-                stabilityCount++;
-                if (stabilityCount >= 2) {
-                  resolve();
-                  return;
-                }
-              } else {
-                stabilityCount = 0;
-              }
-
-              lastTop = currentTop;
-              requestAnimationFrame(checkStability);
-            };
-
-            requestAnimationFrame(checkStability);
-          });
-
-          element = div.querySelector<HTMLElement>(`#${CSS.escape(navCursor)}`);
+          // Wait for React to re-render and update the DOM (remove/add
+          // skeletons) by waiting until the element's position stabilizes. The
+          // wait is capped so a target that never renders can't hang
+          // navigation; on timeout the `if (!element) return` below bails
+          // cleanly.
+          element = await waitForStableElement(div, navCursor);
         }
 
         if (!element) {

--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryPaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryPaginationProvider.tsx
@@ -16,7 +16,11 @@ import {
   getWorkGlossaryTerms,
   getWorkGlossaryTermsAround,
 } from '@eightyfourthousand/client-graphql';
-import { isUuid, scrollToElement } from '@eightyfourthousand/lib-utils';
+import {
+  isUuid,
+  scrollToElement,
+  waitForStableElement,
+} from '@eightyfourthousand/lib-utils';
 import { useNavigation } from '../NavigationProvider';
 import { GlossarySkeleton } from './GlossarySkeleton';
 import { usePaginationLoadTriggers } from '../hooks/usePaginationLoadTriggers';
@@ -138,16 +142,10 @@ export const GlossaryPaginationProvider = ({
           setEndCursor(page.nextCursor);
           setTotalCount(page.totalCount);
 
-          // Wait for DOM update
-          await new Promise<void>((resolve) => {
-            requestAnimationFrame(() => {
-              requestAnimationFrame(() => resolve());
-            });
-          });
-
-          element = container.querySelector<HTMLElement>(
-            `#${CSS.escape(navCursor)}`,
-          );
+          // Wait for the freshly-rendered term to settle (skeletons removed,
+          // content hydrated) before scrolling, so we don't land on a
+          // pre-settle position.
+          element = await waitForStableElement(container, navCursor);
         }
 
         if (element) {

--- a/libs/lib-utils/src/lib/hooks/use-scroll-to-hash.tsx
+++ b/libs/lib-utils/src/lib/hooks/use-scroll-to-hash.tsx
@@ -56,6 +56,66 @@ export const scrollToElement = async ({
   });
 };
 
+/**
+ * Waits for the element with the given id to appear inside `container` and for
+ * its vertical position to stabilize before resolving with it.
+ *
+ * When content is replaced (e.g. a page of paginated terms/passages fetched
+ * around a navigation target), the target element's layout keeps shifting for a
+ * few frames as skeletons are removed and real content hydrates. Scrolling
+ * before it settles lands on a pre-settle position. This polls
+ * `getBoundingClientRect().top` and resolves once it is identical across two
+ * consecutive frames, capping the wait so a target that never renders can't hang
+ * navigation.
+ *
+ * @param container The scope to query within.
+ * @param id The element id to wait for (raw — it is `CSS.escape`d internally).
+ * @param maxFrames Maximum frames to wait before giving up (~2s at 60fps).
+ * @returns The settled element, or null if it never rendered within the cap.
+ */
+export const waitForStableElement = (
+  container: HTMLElement,
+  id: string,
+  maxFrames = 120,
+): Promise<HTMLElement | null> => {
+  return new Promise<HTMLElement | null>((resolve) => {
+    let stabilityCount = 0;
+    let lastTop = -1;
+    let frames = 0;
+
+    const checkStability = () => {
+      if (frames++ > maxFrames) {
+        resolve(container.querySelector<HTMLElement>(`#${CSS.escape(id)}`));
+        return;
+      }
+
+      const el = container.querySelector<HTMLElement>(`#${CSS.escape(id)}`);
+      if (!el) {
+        requestAnimationFrame(checkStability);
+        return;
+      }
+
+      const currentTop = el.getBoundingClientRect().top;
+
+      // Resolve once the position has been identical for 2 consecutive frames.
+      if (currentTop === lastTop) {
+        stabilityCount++;
+        if (stabilityCount >= 2) {
+          resolve(el);
+          return;
+        }
+      } else {
+        stabilityCount = 0;
+      }
+
+      lastTop = currentTop;
+      requestAnimationFrame(checkStability);
+    };
+
+    requestAnimationFrame(checkStability);
+  });
+};
+
 /** Scrolls to an element matching the URL hash.
  * @param delay Optional delay in milliseconds before scrolling.
  * @param behavior Scroll behavior, either 'auto' or 'smooth'.


### PR DESCRIPTION
### Summary

Moves `PaginationProvider`'s logic for waiting for the UI to settle to a shared abstraction and uses it in `GlossaryPaginationProvider` as well.

### Linear

- [DEV-701](https://linear.app/84000/issue/DEV-701)
