### PR TITLE
Toh Paths in Studio

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/translations/editor/[slug]/layout.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/translations/editor/[slug]/layout.tsx
@@ -1,7 +1,37 @@
-'use client';
-
 import { EditorLayout } from '@eightyfourthousand/lib-editing';
+import { lookupEntity } from '@eightyfourthousand/data-access/ssr';
+import { isUuid } from '@eightyfourthousand/lib-utils';
+import { notFound, redirect } from 'next/navigation';
+import { ReactNode } from 'react';
 
-const Layout = EditorLayout;
+const Layout = async ({
+  left,
+  main,
+  right,
+  params,
+}: {
+  left: ReactNode;
+  main: ReactNode;
+  right: ReactNode;
+  params: Promise<{ slug: string }>;
+}) => {
+  const { slug } = await params;
+
+  if (!isUuid(slug)) {
+    const { path } = await lookupEntity({
+      type: 'translation',
+      entity: slug,
+      prefix: '/translations/editor',
+    });
+
+    if (path) {
+      redirect(path);
+    }
+
+    notFound();
+  }
+
+  return <EditorLayout left={left} main={main} right={right} params={params} />;
+};
 
 export default Layout;

--- a/apps/web-main/src/app/(DashboardLayout)/translations/reader/[slug]/layout.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/translations/reader/[slug]/layout.tsx
@@ -1,7 +1,10 @@
 import { ReaderLayout } from '@eightyfourthousand/lib-editing';
+import { lookupEntity } from '@eightyfourthousand/data-access/ssr';
+import { isUuid } from '@eightyfourthousand/lib-utils';
+import { notFound, redirect } from 'next/navigation';
 import { ReactNode } from 'react';
 
-const Layout = ({
+const Layout = async ({
   left,
   main,
   right,
@@ -12,6 +15,22 @@ const Layout = ({
   right: ReactNode;
   params: Promise<{ slug: string }>;
 }) => {
+  const { slug } = await params;
+
+  if (!isUuid(slug)) {
+    const { path } = await lookupEntity({
+      type: 'translation',
+      entity: slug,
+      prefix: '/translations/reader',
+    });
+
+    if (path) {
+      redirect(path);
+    }
+
+    notFound();
+  }
+
   return (
     <ReaderLayout
       withHeader={true}


### PR DESCRIPTION
### Summary

Support `/translations/editor/{toh}` and `/translations/reader/{toh}` paths in Studio as a convenience. Work uuids are still used for the canonical route and SSR.

### Linear

- [DEV-658](https://linear.app/84000/issue/DEV-658)
