### PR TITLE
Avoid undefined attributes in SSR content

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/Bold.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Bold.ts
@@ -1,4 +1,3 @@
-import { mergeAttributes } from '@tiptap/react';
 import { Bold as TipTapBold } from '@tiptap/extension-bold';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -9,28 +8,22 @@ export const Bold = TipTapBold.extend({
       type: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-type'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, { 'data-type': attributes.type });
-        },
+        renderHTML: (attributes) =>
+          attributes.type ? { 'data-type': attributes.type } : {},
       },
       textStyle: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-text-style'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-text-style': attributes.textStyle,
-          });
-        },
+        renderHTML: (attributes) =>
+          attributes.textStyle
+            ? { 'data-text-style': attributes.textStyle }
+            : {},
       },
       lang: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-lang'),
-        renderHTML(attributes) {
-          if (!attributes.lang) {
-            return attributes;
-          }
-          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
-        },
+        renderHTML: (attributes) =>
+          attributes.lang ? { 'data-lang': attributes.lang } : {},
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
@@ -15,21 +15,28 @@ export const GlossaryInstanceNodeSSR = Mark.create<GlossaryInstanceSSROptions>({
     };
   },
 
+  // `renderHTML` below emits authority/glossary/uuid itself from `mark.attrs`,
+  // so these are `rendered: false` to stop the static SSR renderer also
+  // auto-emitting them (duplicates, plus `isInline="true"` is internal-only
+  // state). Storage and parseHTML are unaffected.
   addAttributes() {
     return {
       authority: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('authority'),
       },
       glossary: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('glossary'),
       },
       uuid: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('uuid'),
       },
-      isInline: { default: true },
+      isInline: { default: true, rendered: false },
     };
   },
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstanceNode.ssr.ts
@@ -10,7 +10,7 @@ export const GlossaryInstanceNodeSSR = Mark.create<GlossaryInstanceSSROptions>({
   addOptions() {
     return {
       HTMLAttributes: {
-        className: 'glossary-instance',
+        class: 'glossary-instance',
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/Indent.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Indent.ts
@@ -1,4 +1,4 @@
-import { Extension, mergeAttributes } from '@tiptap/core';
+import { Extension } from '@tiptap/core';
 import { v4 as uuidv4 } from 'uuid';
 
 export interface IndentOptions {
@@ -42,12 +42,8 @@ export const Indent = Extension.create<IndentOptions>({
           hasIndent: {
             default: this.options.defaultHasIndent,
             parseHTML: (element) => element.className.includes('pl-8'),
-            renderHTML: (attributes) => {
-              if (!attributes.hasIndent) {
-                return {};
-              }
-              return mergeAttributes(attributes, { class: 'pl-8' });
-            },
+            renderHTML: (attributes) =>
+              attributes.hasIndent ? { class: 'pl-8' } : {},
           },
           indentUuid: {
             default: undefined,

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLink.ssr.ts
@@ -15,35 +15,47 @@ export const InternalLinkSSR = Mark.create<InternalLinkSSROptions>({
     };
   },
 
+  // `renderHTML` below constructs every output attribute itself from
+  // `mark.attrs`, so each stored attribute is marked `rendered: false` to keep
+  // the static SSR renderer from also auto-emitting it (which would leak raw
+  // `undefined` values for the optional ones). Storage and parseHTML are
+  // unaffected.
   addAttributes() {
     return {
       entity: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('entity'),
       },
       type: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('entity-type'),
       },
       href: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('href'),
       },
       uuid: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('uuid'),
       },
       isSameWork: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) =>
           element.getAttribute('data-same-work') === 'true',
       },
       subtype: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('data-subtype'),
       },
       linkToh: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('data-link-toh'),
       },
     };

--- a/libs/lib-editing/src/lib/components/editor/extensions/Italic.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Italic.ts
@@ -1,5 +1,4 @@
 import { Italic as TiptapItalic } from '@tiptap/extension-italic';
-import { mergeAttributes } from '@tiptap/react';
 import { v4 as uuidv4 } from 'uuid';
 
 export const Italic = TiptapItalic.extend({
@@ -9,28 +8,22 @@ export const Italic = TiptapItalic.extend({
       type: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-type'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, { 'data-type': attributes.type });
-        },
+        renderHTML: (attributes) =>
+          attributes.type ? { 'data-type': attributes.type } : {},
       },
       textStyle: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-text-style'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-text-style': attributes.textStyle,
-          });
-        },
+        renderHTML: (attributes) =>
+          attributes.textStyle
+            ? { 'data-text-style': attributes.textStyle }
+            : {},
       },
       lang: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-lang'),
-        renderHTML(attributes) {
-          if (!attributes.lang) {
-            return attributes;
-          }
-          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
-        },
+        renderHTML: (attributes) =>
+          attributes.lang ? { 'data-lang': attributes.lang } : {},
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/LeadingSpace.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/LeadingSpace.ts
@@ -1,4 +1,4 @@
-import { Extension, mergeAttributes } from '@tiptap/core';
+import { Extension } from '@tiptap/core';
 import { v4 as uuidv4 } from 'uuid';
 
 export interface LeadingSpaceOptions {
@@ -42,12 +42,8 @@ export const LeadingSpace = Extension.create<LeadingSpaceOptions>({
           hasLeadingSpace: {
             default: this.options.defaultHasLeadingSpace,
             parseHTML: (element) => element.className.includes('mt-6'),
-            renderHTML: (attributes) => {
-              if (attributes.hasLeadingSpace) {
-                return mergeAttributes(attributes, { class: 'mt-6 no-indent' });
-              }
-              return {};
-            },
+            renderHTML: (attributes) =>
+              attributes.hasLeadingSpace ? { class: 'mt-6 no-indent' } : {},
           },
           leadingSpaceUuid: {
             default: undefined,

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ssr.ts
@@ -14,7 +14,7 @@ export const LinkSSR = TipTapLink.extend({
       ...Object.fromEntries(
         Object.entries(parentAttributes).map(([key, value]) => [
           key,
-          { ...value, rendered: false },
+          { ...(value as Record<string, unknown>), rendered: false },
         ]),
       ),
       uuid: {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Link/Link.ssr.ts
@@ -3,11 +3,23 @@ import { mergeAttributes } from '@tiptap/core';
 import { safeHref } from '@eightyfourthousand/lib-utils';
 
 export const LinkSSR = TipTapLink.extend({
+  // `renderHTML` below builds the anchor's href/target/rel/uuid itself from
+  // `mark.attrs`, so the inherited link attributes (href, class, title, …) and
+  // uuid are marked `rendered: false` to stop the static SSR renderer from
+  // auto-emitting them (which leaked `class="null"`, `title="null"`,
+  // `uuid="undefined"`). Storage and parseHTML are unaffected.
   addAttributes() {
+    const parentAttributes = this.parent?.() ?? {};
     return {
-      ...this.parent?.(),
+      ...Object.fromEntries(
+        Object.entries(parentAttributes).map(([key, value]) => [
+          key,
+          { ...value, rendered: false },
+        ]),
+      ),
       uuid: {
         default: undefined,
+        rendered: false,
         parseHTML: (element) => element.getAttribute('uuid'),
       },
     };

--- a/libs/lib-editing/src/lib/components/editor/extensions/List.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/List.ts
@@ -1,5 +1,4 @@
 import { BulletList, ListItem as TipTapListItem } from '@tiptap/extension-list';
-import { mergeAttributes } from '@tiptap/core';
 
 const ITEM_STYLE_TO_CLASS: { [key: string]: string } = {
   none: 'list-none',
@@ -34,14 +33,11 @@ export const List = BulletList.extend({
       spacing: {
         default: 'horizontal',
         parseHTML: (element) => element.getAttribute('data-spacing'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-spacing': attributes.spacing,
-            class:
-              LIST_SPACING_TO_CLASS[attributes.spacing || 'horizontal'] ||
-              'ml-4',
-          });
-        },
+        renderHTML: (attributes) => ({
+          'data-spacing': attributes.spacing,
+          class:
+            LIST_SPACING_TO_CLASS[attributes.spacing || 'horizontal'] || 'ml-4',
+        }),
       },
       nesting: {
         default: undefined,
@@ -49,23 +45,19 @@ export const List = BulletList.extend({
           const nesting = element.getAttribute('data-nesting');
           return nesting ? parseInt(nesting, 10) : 0;
         },
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-nesting': `${attributes.nesting}`,
-          });
-        },
+        renderHTML: (attributes) =>
+          attributes.nesting != null
+            ? { 'data-nesting': `${attributes.nesting}` }
+            : {},
       },
       itemStyle: {
         default: 'none',
         parseHTML: (element) => element.getAttribute('data-item-style'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-item-style': attributes.itemStyle,
-            class:
-              ITEM_STYLE_TO_CLASS[attributes.itemStyle || 'none'] ||
-              'list-none',
-          });
-        },
+        renderHTML: (attributes) => ({
+          'data-item-style': attributes.itemStyle,
+          class:
+            ITEM_STYLE_TO_CLASS[attributes.itemStyle || 'none'] || 'list-none',
+        }),
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -43,6 +43,10 @@ export const MentionSSR = Node.create<MentionSSROptions>({
     return {
       items: {
         default: [],
+        // `renderHTML` builds the mention's children from `node.attrs.items`;
+        // `rendered: false` stops the static SSR renderer from also serializing
+        // the raw array as `items="[object Object]"`. parseHTML is unaffected.
+        rendered: false,
         parseHTML: (element) => {
           const itemsAttr = element.getAttribute('data-items');
           if (!itemsAttr) return [];

--- a/libs/lib-editing/src/lib/components/editor/extensions/ParagraphIndent.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/ParagraphIndent.ts
@@ -1,4 +1,4 @@
-import { Extension, mergeAttributes } from '@tiptap/core';
+import { Extension } from '@tiptap/core';
 
 export interface ParagraphIndentOptions {
   types: string[];
@@ -42,14 +42,10 @@ export const ParagraphIndent = Extension.create<ParagraphIndentOptions>({
             default: this.options.defaultHasParagraphIndent,
             parseHTML: (element) =>
               element.className.includes('conditional-indent'),
-            renderHTML: (attributes) => {
-              if (attributes.hasParagraphIndent) {
-                return mergeAttributes(attributes, {
-                  class: 'conditional-indent',
-                });
-              }
-              return mergeAttributes(attributes, { class: 'no-indent' });
-            },
+            renderHTML: (attributes) =>
+              attributes.hasParagraphIndent
+                ? { class: 'conditional-indent' }
+                : { class: 'no-indent' },
           },
         },
       },

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ssr.ts
@@ -50,19 +50,21 @@ export const PassageNodeSSR = Node.create({
         default: null,
         parseHTML: (element) => element.getAttribute('label'),
         renderHTML: (attributes) =>
-          mergeAttributes(attributes, { label: attributes.label }),
+          attributes.label ? { label: attributes.label } : {},
       },
       sort: {
         default: 0,
         parseHTML: (element) => element.getAttribute('sort'),
-        renderHTML: (attributes) =>
-          mergeAttributes(attributes, { sort: attributes.sort }),
+        renderHTML: (attributes) => ({ sort: attributes.sort }),
       },
+      // Internal editor state — never serialize to the public SSR markup.
       alignments: {
         default: {},
+        renderHTML: () => ({}),
       },
       references: {
         default: [],
+        renderHTML: () => ({}),
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/SmallCaps.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/SmallCaps.ts
@@ -42,28 +42,22 @@ export const SmallCaps = Mark.create<SmallCapsOptions>({
       type: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-type'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, { 'data-type': attributes.type });
-        },
+        renderHTML: (attributes) =>
+          attributes.type ? { 'data-type': attributes.type } : {},
       },
       textStyle: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-text-style'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-text-style': attributes.textStyle,
-          });
-        },
+        renderHTML: (attributes) =>
+          attributes.textStyle
+            ? { 'data-text-style': attributes.textStyle }
+            : {},
       },
       lang: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-lang'),
-        renderHTML(attributes) {
-          if (!attributes.lang) {
-            return attributes;
-          }
-          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
-        },
+        renderHTML: (attributes) =>
+          attributes.lang ? { 'data-lang': attributes.lang } : {},
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/Subscript.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Subscript.ts
@@ -1,4 +1,3 @@
-import { mergeAttributes } from '@tiptap/react';
 import { Subscript as TipTapSubscript } from '@tiptap/extension-subscript';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -9,28 +8,22 @@ export const Subscript = TipTapSubscript.extend({
       type: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-type'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, { 'data-type': attributes.type });
-        },
+        renderHTML: (attributes) =>
+          attributes.type ? { 'data-type': attributes.type } : {},
       },
       textStyle: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-text-style'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-text-style': attributes.textStyle,
-          });
-        },
+        renderHTML: (attributes) =>
+          attributes.textStyle
+            ? { 'data-text-style': attributes.textStyle }
+            : {},
       },
       lang: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-lang'),
-        renderHTML(attributes) {
-          if (!attributes.lang) {
-            return attributes;
-          }
-          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
-        },
+        renderHTML: (attributes) =>
+          attributes.lang ? { 'data-lang': attributes.lang } : {},
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/Superscript.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Superscript.ts
@@ -1,4 +1,3 @@
-import { mergeAttributes } from '@tiptap/react';
 import { Superscript as TipTapSuperscript } from '@tiptap/extension-superscript';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -9,28 +8,22 @@ export const Superscript = TipTapSuperscript.extend({
       type: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-type'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, { 'data-type': attributes.type });
-        },
+        renderHTML: (attributes) =>
+          attributes.type ? { 'data-type': attributes.type } : {},
       },
       textStyle: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-text-style'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-text-style': attributes.textStyle,
-          });
-        },
+        renderHTML: (attributes) =>
+          attributes.textStyle
+            ? { 'data-text-style': attributes.textStyle }
+            : {},
       },
       lang: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-lang'),
-        renderHTML(attributes) {
-          if (!attributes.lang) {
-            return attributes;
-          }
-          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
-        },
+        renderHTML: (attributes) =>
+          attributes.lang ? { 'data-lang': attributes.lang } : {},
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/extensions/Underline.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Underline.ts
@@ -1,4 +1,3 @@
-import { mergeAttributes } from '@tiptap/react';
 import { Underline as TipTapUnderline } from '@tiptap/extension-underline';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -9,28 +8,22 @@ export const Underline = TipTapUnderline.extend({
       type: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-type'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, { 'data-type': attributes.type });
-        },
+        renderHTML: (attributes) =>
+          attributes.type ? { 'data-type': attributes.type } : {},
       },
       textStyle: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-text-style'),
-        renderHTML(attributes) {
-          return mergeAttributes(attributes, {
-            'data-text-style': attributes.textStyle,
-          });
-        },
+        renderHTML: (attributes) =>
+          attributes.textStyle
+            ? { 'data-text-style': attributes.textStyle }
+            : {},
       },
       lang: {
         default: undefined,
         parseHTML: (element) => element.getAttribute('data-lang'),
-        renderHTML(attributes) {
-          if (!attributes.lang) {
-            return attributes;
-          }
-          return mergeAttributes(attributes, { 'data-lang': attributes.lang });
-        },
+        renderHTML: (attributes) =>
+          attributes.lang ? { 'data-lang': attributes.lang } : {},
       },
     };
   },

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -89,6 +89,134 @@ describe('TranslationSSRContent', () => {
     );
   });
 
+  it('emits no undefined/null/object attrs across all SSR node and mark types', () => {
+    // Exercises the full SSR extension set (headings, lists, links, glossary,
+    // mentions, foreign/mantra marks, inline styles) so that any extension
+    // leaking internal state — via a renderHTML attribute spread or an
+    // attribute with no renderHTML the static renderer serializes raw — is
+    // caught here, not just on the minimal passage fixture (see DEV-644).
+    const richDoc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'heading',
+              attrs: { level: 1 },
+              content: [{ type: 'text', text: 'Head' }],
+            },
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'gi',
+                  marks: [
+                    {
+                      type: 'glossaryInstance',
+                      attrs: {
+                        authority: 'auth-1',
+                        glossary: 'gloss-1',
+                        uuid: 'gi-1',
+                      },
+                    },
+                  ],
+                },
+                {
+                  type: 'text',
+                  text: 'il',
+                  marks: [
+                    {
+                      type: 'internalLink',
+                      attrs: {
+                        href: '/reader/x',
+                        entity: 'ent-1',
+                        type: 'work',
+                        uuid: 'il-1',
+                      },
+                    },
+                  ],
+                },
+                {
+                  type: 'text',
+                  text: 'ln',
+                  marks: [
+                    { type: 'link', attrs: { href: 'https://example.com' } },
+                  ],
+                },
+                {
+                  type: 'text',
+                  text: 'fo',
+                  marks: [
+                    {
+                      type: 'foreign',
+                      attrs: { lang: 'foreign', uuid: 'f-1' },
+                    },
+                  ],
+                },
+                {
+                  type: 'text',
+                  text: 'ma',
+                  marks: [
+                    { type: 'mantra', attrs: { lang: 'Sa-Ltn', uuid: 'm-1' } },
+                  ],
+                },
+                { type: 'text', text: 'sc', marks: [{ type: 'smallCaps' }] },
+                { type: 'text', text: 'sub', marks: [{ type: 'subscript' }] },
+                { type: 'text', text: 'sup', marks: [{ type: 'superscript' }] },
+                { type: 'text', text: 'me', marks: [{ type: 'italic' }] },
+              ],
+            },
+            {
+              type: 'bulletList',
+              content: [
+                {
+                  type: 'listItem',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: 'item' }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'mention',
+                  attrs: {
+                    items: [
+                      {
+                        text: 'Mentioned',
+                        entity: 'me-1',
+                        linkType: 'work',
+                        uuid: 'mi-1',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const el = TranslationSSRContent({
+      content: richDoc,
+    }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    expect(html).not.toContain('undefined');
+    expect(html).not.toContain('"null"');
+    expect(html).not.toContain('[object Object]');
+    expect(html).toMatchInlineSnapshot(
+      `"<div label="1.1" sort="0" class="flex md:flex-row flex-col w-full md:gap-10 gap-2 scroll-mt-20"><div class="w-full"><div class="relative scroll-m-20 w-full self-start"><div class="absolute labeled -left-16 w-16 text-end hover:cursor-pointer" contenteditable="false" data-passage-label="">1.1</div><div class="passage-bookmark hidden absolute -left-15.75 top-6 w-16 flex justify-end" contenteditable="false"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-accent size-3"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg></div><div class="passage is-editable pl-6 @c/sidebar:pl-4"><h1 class="font-serif mt-6 scroll-m-20 pb-4 text-4xl @c/sidebar:pb-2" type="heading">Head</h1><p class="no-indent paragraph" type="paragraph"><span class="glossary-instance" type="glossaryInstance" authority="auth-1" glossary="gloss-1" uuid="gi-1">gi</span><a class="text-primary underline decoration-primary underline-offset-[3px] transition-colors cursor-pointer" type="internalLink" entity="ent-1" entity-type="work" uuid="il-1" href="/reader/x">il</a><a href="https://example.com" target="_blank" rel="noreferrer noopener">ln</a><span uuid="f-1" type="span" textStyle="foreign" lang="foreign" data-text-style="foreign">fo</span><span uuid="m-1" type="mantra" lang="Sa-Ltn">ma</span><sm class="uppercase">sc</sm><sub>sub</sub><sup>sup</sup><em>me</em></p><ul data-spacing="horizontal" class="ml-4 list-none" data-item-style="none"><li><p class="no-indent paragraph" type="paragraph">item</p></li></ul><p class="no-indent paragraph" type="paragraph"><span class="mention-container" data-type="mention"><a class="mention-link px-1" uuid="mi-1" entity="me-1" entity-type="work" href="/entity/work/me-1" target="_blank" rel="noreferrer noopener">Mentioned</a></span></p></div></div></div><div class="passage-compare-source w-full hidden md:mt-1" contenteditable="false" data-compare-source=""><div class="passage pl-6 @c/sidebar:pl-4"><div class="passage-compare-text leading-7 font-tibetan text-lg whitespace-normal mt-1.5 pb-4 md:pb-2"></div></div></div></div>"`,
+    );
+  });
+
   it('accepts an array of nodes and wraps them as a doc', () => {
     const el = TranslationSSRContent({
       content: passageDoc.content as JSONContent[],

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -73,6 +73,22 @@ describe('TranslationSSRContent', () => {
     expect(html).toMatch(/<strong[^>]*>world<\/strong>/);
   });
 
+  it('emits no undefined/null/object attribute values in SSR output', () => {
+    // The static string renderer serializes attribute values literally, so any
+    // extension renderHTML that returns undefined/null/an object leaks it onto
+    // crawler-facing markup. Lock the cleaned output (see DEV-644).
+    const el = TranslationSSRContent({
+      content: passageDoc,
+    }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    expect(html).not.toContain('undefined');
+    expect(html).not.toContain('"null"');
+    expect(html).not.toContain('[object Object]');
+    expect(html).toMatchInlineSnapshot(
+      `"<div label="1.1" sort="0" class="flex md:flex-row flex-col w-full md:gap-10 gap-2 scroll-mt-20"><div class="w-full"><div class="relative scroll-m-20 w-full self-start"><div class="absolute labeled -left-16 w-16 text-end hover:cursor-pointer" contenteditable="false" data-passage-label="">1.1</div><div class="passage-bookmark hidden absolute -left-15.75 top-6 w-16 flex justify-end" contenteditable="false"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-accent size-3"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg></div><div class="passage is-editable pl-6 @c/sidebar:pl-4"><p class="no-indent paragraph" type="paragraph">Hello <strong>world</strong></p></div></div></div><div class="passage-compare-source w-full hidden md:mt-1" contenteditable="false" data-compare-source=""><div class="passage pl-6 @c/sidebar:pl-4"><div class="passage-compare-text leading-7 font-tibetan text-lg whitespace-normal mt-1.5 pb-4 md:pb-2"></div></div></div></div>"`,
+    );
+  });
+
   it('accepts an array of nodes and wraps them as a doc', () => {
     const el = TranslationSSRContent({
       content: passageDoc.content as JSONContent[],
@@ -159,7 +175,9 @@ describe('TranslationSSRContent', () => {
       ],
     };
 
-    const el = TranslationSSRContent({ content: doc }) as ReactElement<DangerousProps>;
+    const el = TranslationSSRContent({
+      content: doc,
+    }) as ReactElement<DangerousProps>;
     const html = renderedHtml(el);
     expect(html).toContain('marked');
     // Start sup carries a trailing word joiner (U+2060); end sup a leading one,
@@ -210,7 +228,9 @@ describe('TranslationSSRContent', () => {
       ],
     };
 
-    const el = TranslationSSRContent({ content: doc }) as ReactElement<DangerousProps>;
+    const el = TranslationSSRContent({
+      content: doc,
+    }) as ReactElement<DangerousProps>;
     const html = renderedHtml(el);
     expect(html).toMatch(/marked<sup[^>]*endNote="en-only"[^>]*>⁠c<\/sup>/);
   });
@@ -249,7 +269,9 @@ describe('TranslationSSRContent', () => {
       ],
     };
 
-    const el = TranslationSSRContent({ content: doc }) as ReactElement<DangerousProps>;
+    const el = TranslationSSRContent({
+      content: doc,
+    }) as ReactElement<DangerousProps>;
     const html = renderedHtml(el);
     expect(html).toContain('marked');
     // The valid note still renders; the orphaned one is dropped entirely.


### PR DESCRIPTION
### Summary

Generally avoid using `mergeAttributes` in the `renderHTML` function of editor content to avoid leaking internal state.

### Linear

- [DEV-644](https://linear.app/84000/issue/DEV-644)
