### PR TITLE
Fix: Incorrect Folio Mention Labels

### DIFF
--- a/libs/data-access/src/lib/folio.ts
+++ b/libs/data-access/src/lib/folio.ts
@@ -168,16 +168,16 @@ export const getFoliosByUuids = async ({
   }
 
   const { data, error } = await client
-    .from('tibetan_works_folios')
+    .from('folios')
     .select(
       `
-      folio_uuid,
+      folio_uuid:uuid::uuid,
       content::text,
       volume_number::int4,
       folio_number::int4,
       side::text`,
     )
-    .in('folio_uuid', uuids);
+    .in('uuid', uuids);
 
   if (error) {
     console.error('Error fetching folios by uuids:', error);


### PR DESCRIPTION
### Summary

Previously, labels for folio mentions were resolved by reading from the `tibetan_works_folios` view. However, it looks like the data in that view is stale, and at least some labels are no longer accurate. Since the labels do not depend on work membership, they can be derived directly from the `folios` table instead.

### Linear

- [ED-1339](https://linear.app/84000/issue/ED-1339)