### PR TITLE
Browser Translation Support

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/hooks/useBlockEditor.ts
+++ b/libs/lib-editing/src/lib/components/editor/hooks/useBlockEditor.ts
@@ -37,6 +37,7 @@ export const useBlockEditor = ({
         autocorrect: 'off',
         autocapitalize: 'off',
         class: 'min-h-full focus:outline-none',
+        translate: isEditable ? 'no' : 'yes',
       },
     },
     onCreate: (ctx) => {


### PR DESCRIPTION
### Summary

Under the hood, ProseMirror adds the html attribute `translate="no"` to the outer div of editor content, disabling browser translation. We want that enabled in the reader, though, so it is now set to `yes` when content is read-only.

### Linear

- [DEV-702](https://linear.app/84000/issue/DEV-702)