### PR TITLE
Editor Cleanup, part 2: load-pipeline correctness

### DIFF
--- a/libs/data-access/src/lib/types/annotation/transform.spec.ts
+++ b/libs/data-access/src/lib/types/annotation/transform.spec.ts
@@ -1,0 +1,57 @@
+import { annotationsFromDTO } from './transform';
+import type { AnnotationDTO } from './dto';
+
+const spanDTO = (start: number, end: number): AnnotationDTO => ({
+  uuid: 'span-1',
+  passage_uuid: 'passage-1',
+  type: 'span',
+  start,
+  end,
+  content: [{ 'text-style': 'emphasis' }],
+});
+
+describe('annotationsFromDTO range validation', () => {
+  it('accepts an annotation spanning the full passage', () => {
+    const [annotation] = annotationsFromDTO([spanDTO(0, 10)], 10);
+    expect(annotation.validated).toBe(true);
+  });
+
+  it('accepts a zero-width annotation at the passage end', () => {
+    const [annotation] = annotationsFromDTO([spanDTO(10, 10)], 10);
+    expect(annotation.validated).toBe(true);
+  });
+
+  it('marks an annotation ending past the passage as invalid', () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const [annotation] = annotationsFromDTO([spanDTO(0, 11)], 10);
+
+    expect(annotation.validated).toBe(false);
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+
+  it('marks an annotation with a negative start as invalid', () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const [annotation] = annotationsFromDTO([spanDTO(-1, 5)], 10);
+
+    expect(annotation.validated).toBe(false);
+    consoleWarn.mockRestore();
+  });
+
+  it('marks every annotation invalid when the passage length is zero', () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const [annotation] = annotationsFromDTO([spanDTO(0, 5)], 0);
+
+    expect(annotation.validated).toBe(false);
+    consoleWarn.mockRestore();
+  });
+});

--- a/libs/data-access/src/lib/types/annotation/transform.ts
+++ b/libs/data-access/src/lib/types/annotation/transform.ts
@@ -113,12 +113,13 @@ export const annotationFromDTO = (
 };
 
 export const annotationsFromDTO = (
-  dto?: AnnotationsDTO,
-  passageLength?: number,
+  dto: AnnotationsDTO | undefined,
+  // Required: defaulting to 0 would silently mark every annotation invalid.
+  passageLength: number,
 ): Annotations => {
   const filtered =
     dto?.filter((a) => !ANNOTATIONS_TO_IGNORE.includes(a.type)) || [];
-  return filtered.map((a) => annotationFromDTO(a, passageLength || 0));
+  return filtered.map((a) => annotationFromDTO(a, passageLength));
 };
 
 export const annotationToDTO = (

--- a/libs/lib-editing/src/lib/block.spec.ts
+++ b/libs/lib-editing/src/lib/block.spec.ts
@@ -1,0 +1,190 @@
+import {
+  AnnotationDTO,
+  Annotations,
+  annotationsFromDTO,
+  PassageDTO,
+  passageFromDTO,
+} from '@eightyfourthousand/data-access';
+import { blockFromPassage, blocksFromTranslationBody } from './block';
+import type { TranslationEditorContentItem } from './components/editor';
+
+const passageDTO = (overrides: Partial<PassageDTO> = {}): PassageDTO => ({
+  sort: 1,
+  type: 'translation',
+  uuid: 'passage-uuid-1',
+  label: '1',
+  xmlId: 'test-passage',
+  parent: 'test-parent',
+  content: 'The quick brown fox jumps over the lazy dog',
+  work_uuid: 'work-uuid-1',
+  annotations: [],
+  ...overrides,
+});
+
+const buildPassage = (dto: PassageDTO) =>
+  passageFromDTO(
+    dto,
+    annotationsFromDTO(dto.annotations || [], dto.content?.length ?? 0),
+  );
+
+const collectText = (item: TranslationEditorContentItem): string => {
+  if (item.type === 'text') {
+    return item.text ?? '';
+  }
+  return (item.content ?? []).map(collectText).join('');
+};
+
+const collectTextNodes = (
+  item: TranslationEditorContentItem,
+): TranslationEditorContentItem[] => {
+  if (item.type === 'text') {
+    return [item];
+  }
+  return (item.content ?? []).flatMap(collectTextNodes);
+};
+
+const assertNoInvertedRanges = (item: TranslationEditorContentItem) => {
+  const start = item.attrs?.start;
+  const end = item.attrs?.end;
+  if (typeof start === 'number' && typeof end === 'number') {
+    expect(start).toBeLessThanOrEqual(end);
+  }
+  for (const mark of item.marks ?? []) {
+    const markStart = mark.attrs?.start;
+    const markEnd = mark.attrs?.end;
+    if (typeof markStart === 'number' && typeof markEnd === 'number') {
+      expect(markStart).toBeLessThanOrEqual(markEnd);
+    }
+  }
+  (item.content ?? []).forEach(assertNoInvertedRanges);
+};
+
+describe('blockFromPassage', () => {
+  it('renders an empty passage as a passage with an empty paragraph', () => {
+    const block = blockFromPassage(buildPassage(passageDTO({ content: '' })));
+
+    expect(block.type).toBe('passage');
+    expect(block.content).toHaveLength(1);
+    expect(block.content?.[0].type).toBe('paragraph');
+    expect(block.content?.[0].content).toEqual([]);
+  });
+
+  it('renders an empty heading passage as an empty heading block', () => {
+    const block = blockFromPassage(
+      buildPassage(passageDTO({ content: '', type: 'translationHeader' })),
+    );
+
+    expect(block.content?.[0].type).toBe('heading');
+    expect(block.content?.[0].content).toEqual([]);
+  });
+
+  it('does not mutate the order of the input annotations array', () => {
+    const annotations: AnnotationDTO[] = [
+      {
+        uuid: 'ann-2',
+        passage_uuid: 'passage-uuid-1',
+        type: 'span',
+        start: 10,
+        end: 19,
+        content: [{ 'text-style': 'emphasis' }],
+      },
+      {
+        uuid: 'ann-1',
+        passage_uuid: 'passage-uuid-1',
+        type: 'span',
+        start: 0,
+        end: 3,
+        content: [{ 'text-style': 'emphasis' }],
+      },
+    ];
+    const dto = passageDTO({ annotations });
+    const passage = buildPassage(dto);
+    const inputOrder = (passage.annotations as Annotations).map((a) => a.uuid);
+
+    blockFromPassage(passage);
+
+    expect((passage.annotations as Annotations).map((a) => a.uuid)).toEqual(
+      inputOrder,
+    );
+  });
+
+  it('preserves the full text content when annotations overlap', () => {
+    const dto = passageDTO({
+      annotations: [
+        {
+          uuid: 'link-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'link',
+          start: 0,
+          end: 15,
+          content: [{ href: 'https://example.com' }],
+        },
+        {
+          uuid: 'span-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'span',
+          start: 4,
+          end: 19,
+          content: [{ 'text-style': 'emphasis' }],
+        },
+      ],
+    });
+
+    const block = blockFromPassage(buildPassage(dto));
+
+    expect(collectText(block)).toBe(dto.content);
+    assertNoInvertedRanges(block);
+  });
+
+  it('applies both marks to the intersection of overlapping annotations', () => {
+    const dto = passageDTO({
+      annotations: [
+        {
+          uuid: 'span-long',
+          passage_uuid: 'passage-uuid-1',
+          type: 'span',
+          start: 0,
+          end: 15,
+          content: [{ 'text-style': 'emphasis' }],
+        },
+        {
+          uuid: 'span-short',
+          passage_uuid: 'passage-uuid-1',
+          type: 'span',
+          start: 4,
+          end: 9,
+          content: [{ 'text-style': 'underline' }],
+        },
+      ],
+    });
+
+    const block = blockFromPassage(buildPassage(dto));
+    const textNodes = collectTextNodes(block);
+    const doubleMarked = textNodes.filter((node) => node.marks?.length === 2);
+
+    expect(doubleMarked.map((node) => node.text).join('')).toBe('quick');
+    assertNoInvertedRanges(block);
+  });
+});
+
+describe('blocksFromTranslationBody', () => {
+  it('keeps empty passages and drops only passages with missing content', () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const empty = buildPassage(passageDTO({ content: '', uuid: 'p-empty' }));
+    const missing = buildPassage(passageDTO({ uuid: 'p-missing' }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (missing as any).content = undefined;
+    const normal = buildPassage(passageDTO({ uuid: 'p-normal' }));
+
+    const blocks = blocksFromTranslationBody([empty, missing, normal]);
+
+    expect(blocks.map((block) => block.attrs?.uuid)).toEqual([
+      'p-empty',
+      'p-normal',
+    ]);
+    consoleWarn.mockRestore();
+  });
+});

--- a/libs/lib-editing/src/lib/block.spec.ts
+++ b/libs/lib-editing/src/lib/block.spec.ts
@@ -167,6 +167,48 @@ describe('blockFromPassage', () => {
   });
 });
 
+describe('blockFromPassage with invalid annotations', () => {
+  it('skips out-of-range annotations and flags the passage', () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const dto = passageDTO({
+      annotations: [
+        {
+          uuid: 'span-invalid',
+          passage_uuid: 'passage-uuid-1',
+          type: 'span',
+          start: 0,
+          end: 999,
+          content: [{ 'text-style': 'emphasis' }],
+        },
+        {
+          uuid: 'span-valid',
+          passage_uuid: 'passage-uuid-1',
+          type: 'span',
+          start: 4,
+          end: 9,
+          content: [{ 'text-style': 'underline' }],
+        },
+      ],
+    });
+
+    const block = blockFromPassage(buildPassage(dto));
+    const textNodes = collectTextNodes(block);
+    const markTypes = textNodes.flatMap(
+      (node) => node.marks?.map((mark) => mark.type) ?? [],
+    );
+
+    expect(block.attrs?.invalid).toBe(true);
+    // The invalid emphasis span must not render anywhere; the valid
+    // underline span still applies.
+    expect(markTypes).toEqual(['underline']);
+    expect(collectText(block)).toBe(dto.content);
+    consoleWarn.mockRestore();
+  });
+});
+
 describe('blocksFromTranslationBody', () => {
   it('keeps empty passages and drops only passages with missing content', () => {
     const consoleWarn = jest

--- a/libs/lib-editing/src/lib/block.spec.ts
+++ b/libs/lib-editing/src/lib/block.spec.ts
@@ -167,6 +167,141 @@ describe('blockFromPassage', () => {
   });
 });
 
+describe('blockFromPassage with annotations straddling split boundaries', () => {
+  it('applies a span that straddles an earlier link boundary', () => {
+    const dto = passageDTO({
+      annotations: [
+        {
+          uuid: 'link-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'link',
+          start: 0,
+          end: 15,
+          content: [{ href: 'https://example.com' }],
+        },
+        {
+          uuid: 'span-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'span',
+          start: 4,
+          end: 19,
+          content: [{ 'text-style': 'underline' }],
+        },
+      ],
+    });
+
+    const block = blockFromPassage(buildPassage(dto));
+    const textNodes = collectTextNodes(block);
+    const underlined = textNodes
+      .filter((node) => node.marks?.some((mark) => mark.type === 'underline'))
+      .map((node) => node.text)
+      .join('');
+
+    // "The quick brown fox ..." — the span covers [4, 19] even though the
+    // link split the text at 15.
+    expect(underlined).toBe('quick brown fox');
+    expect(collectText(block)).toBe(dto.content);
+    expect(block.attrs?.invalid).toBeUndefined();
+    assertNoInvertedRanges(block);
+  });
+
+  it('keeps an atomic mention inside a straddling mark range', () => {
+    const dto = passageDTO({
+      annotations: [
+        {
+          uuid: 'mention-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'mention',
+          start: 10,
+          end: 10,
+          content: [{ uuid: 'entity-1' }, { type: 'glossary' }],
+        },
+        {
+          uuid: 'link-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'link',
+          start: 5,
+          end: 15,
+          content: [{ href: 'https://example.com' }],
+        },
+      ],
+    });
+
+    const block = blockFromPassage(buildPassage(dto));
+    const mentions: TranslationEditorContentItem[] = [];
+    const walk = (item: TranslationEditorContentItem) => {
+      if (item.type === 'mention') mentions.push(item);
+      (item.content ?? []).forEach(walk);
+    };
+    walk(block);
+
+    const linked = collectTextNodes(block)
+      .filter((node) => node.marks?.some((mark) => mark.type === 'link'))
+      .map((node) => node.text)
+      .join('');
+
+    expect(mentions).toHaveLength(1);
+    expect(linked).toBe(dto.content.slice(5, 15));
+    expect(collectText(block)).toBe(dto.content);
+  });
+
+  it('drops and flags a span that straddles a line boundary', () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const dto = passageDTO({
+      content: 'first verse line and the second line',
+      annotations: [
+        {
+          uuid: 'lg-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'line-group',
+          start: 0,
+          end: 36,
+          content: [],
+        },
+        {
+          uuid: 'line-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'line',
+          start: 0,
+          end: 16,
+          content: [],
+        },
+        {
+          uuid: 'line-2',
+          passage_uuid: 'passage-uuid-1',
+          type: 'line',
+          start: 16,
+          end: 36,
+          content: [],
+        },
+        {
+          uuid: 'span-1',
+          passage_uuid: 'passage-uuid-1',
+          type: 'span',
+          start: 10,
+          end: 25,
+          content: [{ 'text-style': 'emphasis' }],
+        },
+      ],
+    });
+
+    const block = blockFromPassage(buildPassage(dto));
+    const marked = collectTextNodes(block).filter(
+      (node) => node.marks?.length,
+    );
+
+    // The span crosses a block boundary, which stays unplaceable — but now
+    // loudly, with the passage flagged instead of a silent drop.
+    expect(marked).toEqual([]);
+    expect(block.attrs?.invalid).toBe(true);
+    expect(collectText(block)).toBe(dto.content);
+    consoleWarn.mockRestore();
+  });
+});
+
 describe('blockFromPassage with invalid annotations', () => {
   it('skips out-of-range annotations and flags the passage', () => {
     const consoleWarn = jest

--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -59,7 +59,9 @@ const headingTemplate = (passage: Passage): TranslationEditorContentItem => {
     },
     content: [],
   };
-  block.content = [textTemplate(passage.content)];
+  // TipTap rejects empty text nodes, so an empty passage renders as an
+  // empty block instead.
+  block.content = passage.content ? [textTemplate(passage.content)] : [];
   return block;
 };
 
@@ -74,7 +76,7 @@ const paragraphTemplate = (passage: Passage): TranslationEditorContentItem => {
     content: [],
   };
 
-  block.content = [textTemplate(passage.content)];
+  block.content = passage.content ? [textTemplate(passage.content)] : [];
   return block;
 };
 
@@ -92,7 +94,7 @@ const abbreviationTemplate = (
     content: [],
   };
 
-  block.content = [textTemplate(passage.content)];
+  block.content = passage.content ? [textTemplate(passage.content)] : [];
   return block;
 };
 
@@ -175,7 +177,10 @@ export const blocksFromTranslationBody = (
 ): TranslationEditorContent => {
   const blocks: TranslationEditorContent = [];
   passages.forEach((passage) => {
-    if (!passage.content) {
+    // Only drop passages with malformed (missing) content; an empty string is
+    // a legitimate empty passage and must still render so it can be edited or
+    // deleted in the editor.
+    if (passage.content == null) {
       console.warn('passage has no content');
       console.warn(passage);
       return;
@@ -203,8 +208,8 @@ export const blockFromPassage = (
   // Sort annotations by start position, then by end position in descending
   // order to ensure that the longest annotations are processed first. If two
   // annotations have the same start and end positions, sort by processing
-  // priority.
-  passage.annotations?.sort((a, b) => {
+  // priority. Sort a copy — the caller's array order must not change.
+  const annotations = [...(passage.annotations ?? [])].sort((a, b) => {
     if (a.start !== b.start) {
       return a.start - b.start;
     }
@@ -220,7 +225,7 @@ export const blockFromPassage = (
     return aPriority - bPriority;
   });
 
-  annotateBlock(block, passage.annotations);
+  annotateBlock(block, annotations);
 
   return block;
 };

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -79,8 +79,15 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
         // Display priority: text (custom override) > displayText (dynamic) > entity UUID (fallback)
         const displayText = item.text || item.displayText;
         anchor.textContent =
-          displayText ||
-          (props.editor.isEditable ? `[${item.entity || 'Unknown'}]` : '');
+          displayText || (props.editor.isEditable ? '[Not Found]' : '');
+        const hasDisplayText = !!displayText;
+        if (!hasDisplayText && isEditable) {
+          anchor.classList.add(
+            'text-error',
+            'decoration-wavy',
+            'decoration-error',
+          );
+        }
 
         // Compute href from linkType + entity
         let href = `/entity/${item.linkType}/${item.entity}`;
@@ -88,7 +95,11 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
           href = `${href}?edit=true`;
         }
 
-        if (item.isSameWork) {
+        if (isEditable || !item.isSameWork) {
+          anchor.setAttribute('href', href);
+          anchor.setAttribute('target', '_blank');
+          anchor.setAttribute('rel', 'noreferrer');
+        } else {
           // Same-work links navigate in-place via panel system
           anchor.setAttribute('href', '#');
           anchor.setAttribute('data-same-work', 'true');
@@ -100,45 +111,38 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
             anchor.setAttribute('data-link-toh', item.linkToh);
           }
 
-          if (!isEditable) {
-            anchor.addEventListener('click', (e) => {
-              e.preventDefault();
-              const query = new URLSearchParams(window.location.search);
+          anchor.addEventListener('click', (e) => {
+            e.preventDefault();
+            const query = new URLSearchParams(window.location.search);
 
-              if (item.linkToh) {
-                query.set('toh', item.linkToh);
+            if (item.linkToh) {
+              query.set('toh', item.linkToh);
+            }
+
+            switch (item.linkType) {
+              case 'bibliography':
+                query.set('right', `open:bibliography:${item.entity}`);
+                break;
+              case 'glossary':
+                query.set('right', `open:glossary:${item.entity}`);
+                break;
+              case 'passage': {
+                const panel = PANEL_FOR_SECTION[item.subtype || ''] || 'main';
+                const tab =
+                  TAB_FOR_SECTION[item.subtype || ''] || 'translation';
+                query.set(panel, `open:${tab}:${item.entity}`);
+                break;
               }
-
-              switch (item.linkType) {
-                case 'bibliography':
-                  query.set('right', `open:bibliography:${item.entity}`);
-                  break;
-                case 'glossary':
-                  query.set('right', `open:glossary:${item.entity}`);
-                  break;
-                case 'passage': {
-                  const panel = PANEL_FOR_SECTION[item.subtype || ''] || 'main';
-                  const tab =
-                    TAB_FOR_SECTION[item.subtype || ''] || 'translation';
-                  query.set(panel, `open:${tab}:${item.entity}`);
-                  break;
-                }
-                case 'folio': {
-                  query.set('main', `open:source:${item.entity}`);
-                  break;
-                }
-                default:
-                  break;
+              case 'folio': {
+                query.set('main', `open:source:${item.entity}`);
+                break;
               }
+              default:
+                break;
+            }
 
-              window.history.pushState({}, '', `?${query.toString()}`);
-            });
-          }
-        } else {
-          // Cross-work links open in a new tab
-          anchor.setAttribute('href', href);
-          anchor.setAttribute('target', '_blank');
-          anchor.setAttribute('rel', 'noreferrer');
+            window.history.pushState({}, '', `?${query.toString()}`);
+          });
         }
 
         // Set DOM attrs for HoverCardProvider identification

--- a/libs/lib-editing/src/lib/round-trip.spec.ts
+++ b/libs/lib-editing/src/lib/round-trip.spec.ts
@@ -1,0 +1,180 @@
+import type { Node } from '@tiptap/pm/model';
+import {
+  Annotation,
+  annotationsFromDTO,
+  PassageDTO,
+  passageFromDTO,
+} from '@eightyfourthousand/data-access';
+import { blockFromPassage } from './block';
+import { annotationExportsFromNode } from './exporters/annotation';
+import type { TranslationEditorContentItem } from './components/editor';
+
+/**
+ * Round-trip contract: every annotation that renders must survive export with
+ * equivalent combined coverage. A mark that was split across segments by an
+ * overlapping annotation persists back as N contiguous annotations (one per
+ * segment) — the same behavior the editor produces when a user hand-applies a
+ * mark across differently-marked text.
+ */
+
+const collectText = (item: TranslationEditorContentItem): string => {
+  if (item.type === 'text') {
+    return item.text ?? '';
+  }
+  return (item.content ?? []).map(collectText).join('');
+};
+
+/**
+ * Mimics the uuid dedup half of ensureUuids(): the save path stamps a fresh
+ * uuid on the 2nd..Nth text segments carrying the same mark uuid so each
+ * segment exports as its own annotation. Returns a map from each new uuid to
+ * the original annotation uuid it derives from.
+ */
+const dedupeMarkUuids = (
+  item: TranslationEditorContentItem,
+  seen = new Set<string>(),
+  families = new Map<string, string>(),
+  counter = { next: 1 },
+): Map<string, string> => {
+  for (const mark of item.marks ?? []) {
+    const uuid = mark.attrs?.uuid as string | undefined;
+    if (!uuid) {
+      continue;
+    }
+    if (seen.has(uuid)) {
+      const fresh = `${uuid}-segment-${counter.next++}`;
+      mark.attrs = { ...mark.attrs, uuid: fresh };
+      families.set(fresh, families.get(uuid) ?? uuid);
+    } else {
+      seen.add(uuid);
+      families.set(uuid, uuid);
+    }
+  }
+  for (const child of item.content ?? []) {
+    dedupeMarkUuids(child, seen, families, counter);
+  }
+  return families;
+};
+
+/** Wraps the JSON block tree in just enough ProseMirror Node shape for the exporters. */
+const toFakeNode = (item: TranslationEditorContentItem): Node => {
+  const children = (item.content ?? []).map(toFakeNode);
+  return {
+    type: { name: item.type ?? 'unknown' },
+    attrs: item.attrs ?? {},
+    marks: (item.marks ?? []).map((mark) => ({
+      type: { name: mark.type },
+      attrs: mark.attrs ?? {},
+    })),
+    isText: item.type === 'text',
+    text: item.text,
+    textContent: collectText(item),
+    content: {
+      size: children.length,
+      childCount: children.length,
+      child: (i: number) => children[i],
+      forEach: (cb: (child: Node) => void) => children.forEach(cb),
+    },
+  } as unknown as Node;
+};
+
+const dto: PassageDTO = {
+  sort: 1,
+  type: 'translation',
+  uuid: 'passage-uuid-1',
+  label: '1',
+  xmlId: 'test-passage',
+  parent: 'test-parent',
+  content: 'The quick brown fox jumps over the lazy dog',
+  work_uuid: 'work-uuid-1',
+  annotations: [
+    {
+      uuid: 'link-1',
+      passage_uuid: 'passage-uuid-1',
+      type: 'link',
+      start: 0,
+      end: 15,
+      content: [{ href: 'https://example.com' }],
+    },
+    // Straddles the link boundary at 15 — renders as two segments.
+    {
+      uuid: 'span-1',
+      passage_uuid: 'passage-uuid-1',
+      type: 'span',
+      start: 4,
+      end: 19,
+      content: [{ 'text-style': 'underline' }],
+    },
+    {
+      uuid: 'glossary-1',
+      passage_uuid: 'passage-uuid-1',
+      type: 'glossary-instance',
+      start: 20,
+      end: 25,
+      content: [
+        { uuid: 'glossary-entry-uuid-1' },
+        { authority: 'authority-uuid-1' },
+      ],
+    },
+  ],
+};
+
+describe('annotation round-trip', () => {
+  const passage = passageFromDTO(
+    dto,
+    annotationsFromDTO(dto.annotations || [], dto.content.length),
+  );
+  // Deep-clone first: positionless marks are shared by reference across the
+  // segments they span, and the dedup below must treat each segment's mark as
+  // its own object (as ProseMirror does when the doc is materialized).
+  const block = JSON.parse(
+    JSON.stringify(blockFromPassage(passage)),
+  ) as TranslationEditorContentItem;
+  const families = dedupeMarkUuids(block);
+  const root = toFakeNode(block);
+
+  const exported = annotationExportsFromNode({
+    passageUuid: dto.uuid,
+    node: root,
+    parent: root,
+    root,
+    start: 0,
+  });
+
+  const coverageByOriginal = new Map<string, Annotation[]>();
+  for (const annotation of exported) {
+    const original = families.get(annotation.uuid);
+    if (!original) {
+      continue;
+    }
+    const family = coverageByOriginal.get(original) ?? [];
+    family.push(annotation);
+    coverageByOriginal.set(original, family);
+  }
+
+  it.each(dto.annotations?.map((a) => [a.uuid, a.start, a.end]) ?? [])(
+    'exports contiguous coverage matching source annotation %s [%i, %i)',
+    (uuid, start, end) => {
+      const family = coverageByOriginal.get(uuid as string) ?? [];
+      expect(family.length).toBeGreaterThan(0);
+
+      const sorted = [...family].sort((a, b) => a.start - b.start);
+      expect(sorted[0].start).toBe(start);
+      expect(sorted[sorted.length - 1].end).toBe(end);
+      for (let i = 1; i < sorted.length; i++) {
+        expect(sorted[i].start).toBe(sorted[i - 1].end);
+      }
+    },
+  );
+
+  it('exports the straddling span as multiple contiguous segments', () => {
+    expect(coverageByOriginal.get('span-1')?.length).toBeGreaterThan(1);
+  });
+
+  it('does not invent annotations that were never in the source', () => {
+    const knownTypes = ['link', 'span', 'glossaryInstance', 'paragraph'];
+    for (const annotation of exported) {
+      expect(knownTypes).toContain(annotation.type);
+    }
+  });
+});

--- a/libs/lib-editing/src/lib/transformers/abbreviation.spec.ts
+++ b/libs/lib-editing/src/lib/transformers/abbreviation.spec.ts
@@ -48,7 +48,7 @@ const dto: PassageDTO = {
 describe('abbreviation transformer', () => {
   const passage = passageFromDTO(
     dto,
-    annotationsFromDTO(dto.annotations || []),
+    annotationsFromDTO(dto.annotations || [], dto.content.length),
   );
   const block = blockFromPassage(passage);
 

--- a/libs/lib-editing/src/lib/transformers/abbreviation.ts
+++ b/libs/lib-editing/src/lib/transformers/abbreviation.ts
@@ -1,5 +1,5 @@
 import { AbbreviationAnnotation } from '@eightyfourthousand/data-access';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 import { Transformer } from './transformer';
 import { splitContent } from './split-content';
 
@@ -7,7 +7,7 @@ export const abbreviation: Transformer = (ctx) => {
   const { annotation } = ctx;
   const { abbreviation, uuid } = annotation as AbbreviationAnnotation;
 
-  recurse({
+  const matched = recurse({
     until: ['text'],
     ...ctx,
     transform: (ctx) => {
@@ -27,4 +27,8 @@ export const abbreviation: Transformer = (ctx) => {
       });
     },
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/annotate.ts
+++ b/libs/lib-editing/src/lib/transformers/annotate.ts
@@ -134,8 +134,19 @@ export const annotateBlock = (
   annotations: Annotations,
 ) => {
   for (const annotation of annotations) {
-    const transformer = TRANSFORMERS[annotation.type] || TRANSFORMERS.unknown;
-    transformer?.({ root: block, block, annotation });
+    if (annotation.validated) {
+      const transformer = TRANSFORMERS[annotation.type] || TRANSFORMERS.unknown;
+      transformer?.({ root: block, block, annotation });
+    } else {
+      // Applying an out-of-range annotation would clamp its markup onto the
+      // wrong text and then persist the fabricated range on the next save.
+      console.warn(
+        `skipping invalid annotation ${annotation.uuid} (${annotation.type}) on passage ${annotation.passageUuid}`,
+      );
+    }
+
+    // Checked again (not folded into the else) so a transformer that flips
+    // validated to false mid-flight still flags the passage.
     if (!annotation.validated) {
       if (!block.attrs) {
         block.attrs = {};

--- a/libs/lib-editing/src/lib/transformers/code.ts
+++ b/libs/lib-editing/src/lib/transformers/code.ts
@@ -1,9 +1,9 @@
 import type { Transformer } from './transformer';
 import { splitContent } from './split-content';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 
 export const code: Transformer = (ctx) => {
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) =>
@@ -19,4 +19,8 @@ export const code: Transformer = (ctx) => {
         },
       }),
   });
+
+  if (!matched) {
+    markUnplaceable(ctx.annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/end-note-link.ts
+++ b/libs/lib-editing/src/lib/transformers/end-note-link.ts
@@ -3,7 +3,7 @@ import {
   serializeTohList,
 } from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 import { splitContentAt } from './split-at';
 import { splitContent } from './split-content';
 
@@ -50,7 +50,7 @@ export const endNoteLink: Transformer = (ctx) => {
 
   const isStart = end === 0;
 
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) => {
@@ -76,4 +76,8 @@ export const endNoteLink: Transformer = (ctx) => {
       });
     },
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/glossary-instance.ts
+++ b/libs/lib-editing/src/lib/transformers/glossary-instance.ts
@@ -3,7 +3,7 @@ import {
   serializeTohList,
 } from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 import { splitContent } from './split-content';
 
 export const glossaryInstance: Transformer = (ctx) => {
@@ -16,7 +16,7 @@ export const glossaryInstance: Transformer = (ctx) => {
     return;
   }
 
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) => {
@@ -40,4 +40,8 @@ export const glossaryInstance: Transformer = (ctx) => {
       });
     },
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
+++ b/libs/lib-editing/src/lib/transformers/has-abbreviation.ts
@@ -1,5 +1,5 @@
 import { HasAbbreviationAnnotation } from '@eightyfourthousand/data-access';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 import { splitContent } from './split-content';
 import { Transformer } from './transformer';
 
@@ -7,7 +7,7 @@ export const hasAbbreviation: Transformer = (ctx) => {
   const { annotation } = ctx;
   const { abbreviation, uuid, start, end } = annotation as HasAbbreviationAnnotation;
 
-  recurse({
+  const matched = recurse({
     until: ['text'],
     ...ctx,
     transform: (ctx) => {
@@ -32,4 +32,8 @@ export const hasAbbreviation: Transformer = (ctx) => {
       });
     },
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/inline-title.ts
+++ b/libs/lib-editing/src/lib/transformers/inline-title.ts
@@ -2,7 +2,7 @@ import { InlineTitleAnnotation } from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
 import { splitContent } from './split-content';
 import { ITALIC_LANGUAGES } from './annotate';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 
 export const inlineTitle: Transformer = (ctx) => {
   const { annotation } = ctx;
@@ -17,7 +17,7 @@ export const inlineTitle: Transformer = (ctx) => {
     return;
   }
 
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) =>
@@ -31,4 +31,8 @@ export const inlineTitle: Transformer = (ctx) => {
         },
       }),
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/internal-link.ts
+++ b/libs/lib-editing/src/lib/transformers/internal-link.ts
@@ -4,7 +4,7 @@ import {
 } from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
 import { splitContent } from './split-content';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 
 // NOTE: over time, internal links become just regular links.
 export const internalLink: Transformer = (ctx) => {
@@ -39,7 +39,7 @@ export const internalLink: Transformer = (ctx) => {
     path = `/entity/${type}/${entity}`;
   }
 
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) =>
@@ -65,4 +65,8 @@ export const internalLink: Transformer = (ctx) => {
         },
       }),
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/italic.ts
+++ b/libs/lib-editing/src/lib/transformers/italic.ts
@@ -1,9 +1,9 @@
 import type { Transformer } from './transformer';
 import { splitContent } from './split-content';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 
 export const italic: Transformer = (ctx) => {
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) =>
@@ -19,4 +19,8 @@ export const italic: Transformer = (ctx) => {
         },
       }),
   });
+
+  if (!matched) {
+    markUnplaceable(ctx.annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/link.ts
+++ b/libs/lib-editing/src/lib/transformers/link.ts
@@ -1,13 +1,13 @@
 import { LinkAnnotation } from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
 import { splitContent } from './split-content';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 
 export const link: Transformer = (ctx) => {
   const { annotation } = ctx;
   const { uuid, href = '#', type } = annotation as LinkAnnotation;
 
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) =>
@@ -24,4 +24,8 @@ export const link: Transformer = (ctx) => {
         },
       }),
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/mantra.ts
+++ b/libs/lib-editing/src/lib/transformers/mantra.ts
@@ -1,7 +1,7 @@
 import { MantraAnnotation } from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
 import { splitContent } from './split-content';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 
 export const mantra: Transformer = (ctx) => {
   const { annotation } = ctx;
@@ -11,7 +11,7 @@ export const mantra: Transformer = (ctx) => {
     return;
   }
 
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) =>
@@ -25,4 +25,8 @@ export const mantra: Transformer = (ctx) => {
         },
       }),
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/mention.ts
+++ b/libs/lib-editing/src/lib/transformers/mention.ts
@@ -3,7 +3,7 @@ import {
   serializeTohList,
 } from '@eightyfourthousand/data-access';
 import { Transformer } from './transformer';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 import { splitAndInsert } from './split-insert';
 
 export const mention: Transformer = (ctx) => {
@@ -35,7 +35,7 @@ export const mention: Transformer = (ctx) => {
     toh: serializeTohList(toh),
     lang,
   };
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text'],
     transform: (ctx) => {
@@ -77,4 +77,8 @@ export const mention: Transformer = (ctx) => {
       });
     },
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/recurse.spec.ts
+++ b/libs/lib-editing/src/lib/transformers/recurse.spec.ts
@@ -1,0 +1,160 @@
+import { Annotation } from '@eightyfourthousand/data-access';
+import { markUnplaceable, recurse } from './recurse';
+import type { TranslationEditorContentItem } from '../components/editor';
+
+const textNode = (
+  start: number,
+  end: number,
+  text: string,
+): TranslationEditorContentItem => ({
+  type: 'text',
+  text,
+  attrs: { start, end },
+});
+
+const paragraph = (
+  start: number,
+  end: number,
+  content: TranslationEditorContentItem[],
+): TranslationEditorContentItem => ({
+  type: 'paragraph',
+  attrs: { start, end, uuid: 'para-1' },
+  content,
+});
+
+const spanAnnotation = (start: number, end: number): Annotation =>
+  ({
+    uuid: 'ann-1',
+    passageUuid: 'passage-1',
+    type: 'span',
+    start,
+    end,
+    validated: true,
+  }) as Annotation;
+
+describe('recurse', () => {
+  it('fires the transform on a single node containing the range', () => {
+    const block = paragraph(0, 20, [textNode(0, 20, 'a'.repeat(20))]);
+    const transform = jest.fn();
+
+    const matched = recurse({
+      block,
+      annotation: spanAnnotation(5, 10),
+      until: ['text'],
+      transform,
+    });
+
+    expect(matched).toBe(true);
+    expect(transform).toHaveBeenCalledTimes(1);
+    expect(transform.mock.calls[0][0].block.type).toBe('text');
+  });
+
+  it('falls back to sibling coverage when the range straddles a split boundary', () => {
+    const first = textNode(0, 10, 'a'.repeat(10));
+    const second = textNode(10, 20, 'b'.repeat(10));
+    const block = paragraph(0, 20, [first, second]);
+    const transform = jest.fn();
+
+    const matched = recurse({
+      block,
+      annotation: spanAnnotation(5, 15),
+      until: ['text'],
+      transform,
+    });
+
+    expect(matched).toBe(true);
+    expect(transform).toHaveBeenCalledTimes(1);
+    // The fallback hands the first covering sibling to the transform with the
+    // containing block as parent, so splitContent can split every sibling.
+    expect(transform.mock.calls[0][0].block).toBe(first);
+    expect(transform.mock.calls[0][0].parent).toBe(block);
+  });
+
+  it('does not fall back for block-level until types', () => {
+    const lines = [
+      {
+        type: 'line',
+        attrs: { start: 0, end: 10 },
+        content: [textNode(0, 10, 'a'.repeat(10))],
+      },
+      {
+        type: 'line',
+        attrs: { start: 10, end: 20 },
+        content: [textNode(10, 20, 'b'.repeat(10))],
+      },
+    ];
+    const block = {
+      type: 'lineGroup',
+      attrs: { start: 0, end: 20 },
+      content: lines,
+    };
+    const transform = jest.fn();
+
+    const matched = recurse({
+      block,
+      annotation: spanAnnotation(5, 15),
+      until: ['line'],
+      transform,
+    });
+
+    expect(matched).toBe(false);
+    expect(transform).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back when the siblings do not cover the range boundaries', () => {
+    // A gap: the covered children end at 10 but the annotation runs to 15.
+    const block = paragraph(0, 20, [
+      textNode(0, 10, 'a'.repeat(10)),
+      { type: 'mention', attrs: { start: 10, end: 20 } },
+    ]);
+    const transform = jest.fn();
+
+    const matched = recurse({
+      block,
+      annotation: spanAnnotation(5, 15),
+      until: ['text'],
+      transform,
+    });
+
+    expect(matched).toBe(false);
+    expect(transform).not.toHaveBeenCalled();
+  });
+
+  it('fires the fallback at the deepest block containing the range', () => {
+    const inner = paragraph(0, 20, [
+      textNode(0, 10, 'a'.repeat(10)),
+      textNode(10, 20, 'b'.repeat(10)),
+    ]);
+    const outer: TranslationEditorContentItem = {
+      type: 'blockquote',
+      attrs: { start: 0, end: 20 },
+      content: [inner],
+    };
+    const transform = jest.fn();
+
+    const matched = recurse({
+      block: outer,
+      annotation: spanAnnotation(5, 15),
+      until: ['text'],
+      transform,
+    });
+
+    expect(matched).toBe(true);
+    expect(transform.mock.calls[0][0].parent).toBe(inner);
+  });
+});
+
+describe('markUnplaceable', () => {
+  it('warns and invalidates the annotation', () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const annotation = spanAnnotation(5, 15);
+
+    markUnplaceable(annotation);
+
+    expect(annotation.validated).toBe(false);
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+});

--- a/libs/lib-editing/src/lib/transformers/recurse.ts
+++ b/libs/lib-editing/src/lib/transformers/recurse.ts
@@ -1,24 +1,40 @@
-import { AnnotationType } from '@eightyfourthousand/data-access';
-import { TransformationContextWithCallback, Transformer } from './transformer';
+import { Annotation, AnnotationType } from '@eightyfourthousand/data-access';
+import { TransformationContextWithCallback } from './transformer';
+import { isInlineAnnotation } from './annotate';
 import { TranslationEditorContentItem } from '../components';
 
-export const recurse: Transformer = (ctx) => {
+/**
+ * Walks the block tree looking for a node that can host the annotation and
+ * fires the transform on it. Returns true when the transform ran.
+ *
+ * The normal match is a single node that fully contains the annotation range.
+ * When an earlier annotation has already split the text at a boundary inside
+ * this range, no single node contains it any more — in that case the fallback
+ * applies inline transforms across the siblings that cover the range
+ * (splitContent already splits every sibling and transforms each middle
+ * segment, so the transform lands on all covered segments).
+ */
+export const recurse = (ctx: TransformationContextWithCallback): boolean => {
   if (trasformOnMatch(ctx)) {
-    return;
+    return true;
   }
 
   const { block } = ctx;
   for (const child of block.content || []) {
-    if (trasformOnMatch({ ...ctx, parent: block, block: child })) {
-      return;
+    if (
+      recurse({
+        ...ctx,
+        parent: block,
+        block: child,
+      })
+    ) {
+      return true;
     }
-
-    recurse({
-      ...ctx,
-      parent: block,
-      block: child,
-    });
   }
+
+  // Post-order: children have all been tried, so the fallback fires at the
+  // deepest block containing the range.
+  return transformAcrossChildren(ctx);
 };
 
 const trasformOnMatch = (ctx: TransformationContextWithCallback) => {
@@ -35,6 +51,80 @@ const trasformOnMatch = (ctx: TransformationContextWithCallback) => {
   }
 
   return false;
+};
+
+/**
+ * Fallback for annotations that straddle a split boundary: when this block
+ * contains the range and its inline children cover both ends, fire the
+ * transform with this block as the parent. Only inline transforms may span
+ * siblings; block transforms keep single-node matching semantics. Returns
+ * false when the range crosses a block boundary (e.g. two lines of a
+ * lineGroup) — that remains unplaceable.
+ */
+const transformAcrossChildren = (
+  ctx: TransformationContextWithCallback,
+): boolean => {
+  const { block, annotation, until = [], transform } = ctx;
+
+  if (
+    !until.length ||
+    !until.every((type) => isInlineAnnotation(type) || type === 'text')
+  ) {
+    return false;
+  }
+
+  const blockStart = block.attrs?.start;
+  const blockEnd = block.attrs?.end;
+  if (
+    typeof blockStart !== 'number' ||
+    typeof blockEnd !== 'number' ||
+    blockStart > annotation.start ||
+    blockEnd < annotation.end
+  ) {
+    return false;
+  }
+
+  const children = (block.content || []).filter(
+    (child) =>
+      child.attrs?.uuid !== annotation.uuid &&
+      until.includes((child.type || 'unknown') as AnnotationType),
+  );
+
+  const coversStart = children.some(
+    (child) =>
+      (child.attrs?.start ?? 0) <= annotation.start &&
+      (child.attrs?.end ?? 0) > annotation.start,
+  );
+  const coversEnd = children.some(
+    (child) =>
+      (child.attrs?.start ?? 0) < annotation.end &&
+      (child.attrs?.end ?? 0) >= annotation.end,
+  );
+  if (!coversStart || !coversEnd) {
+    return false;
+  }
+
+  const first = children.find(
+    (child) => (child.attrs?.end ?? 0) > annotation.start,
+  );
+  if (!first) {
+    return false;
+  }
+
+  transform?.({ ...ctx, parent: block, block: first });
+  return true;
+};
+
+/**
+ * Marks an annotation that no node could host: warns loudly and flips
+ * `validated` so annotateBlock flags the passage as invalid. Call from a
+ * transformer when `recurse` returns false.
+ */
+export const markUnplaceable = (annotation: Annotation) => {
+  console.warn(
+    `annotation ${annotation.uuid} (${annotation.type}) at (${annotation.start}, ${annotation.end}) could not be attached to any node; dropped from render`,
+  );
+  annotation.validated = false;
 };
 
 export const recurseForType = ({

--- a/libs/lib-editing/src/lib/transformers/span.ts
+++ b/libs/lib-editing/src/lib/transformers/span.ts
@@ -2,7 +2,7 @@ import { ExtendedTranslationLanguage, SpanAnnotation } from '@eightyfourthousand
 import type { Transformer } from './transformer';
 import { type SpanMarkType, MARK_TYPES } from '../types';
 import { splitContent } from './split-content';
-import { recurse } from './recurse';
+import { markUnplaceable, recurse } from './recurse';
 
 const MARK_TYPE_FOR_SPAN_TYPE: {
   [key: string]: (
@@ -33,7 +33,7 @@ export const span: Transformer = (ctx) => {
     return;
   }
 
-  recurse({
+  const matched = recurse({
     ...ctx,
     until: ['text', 'glossaryInstance'],
     transform: (ctx) => {
@@ -69,4 +69,8 @@ export const span: Transformer = (ctx) => {
       });
     },
   });
+
+  if (!matched) {
+    markUnplaceable(annotation);
+  }
 };

--- a/libs/lib-editing/src/lib/transformers/split-content.ts
+++ b/libs/lib-editing/src/lib/transformers/split-content.ts
@@ -36,14 +36,17 @@ export const splitContent: Transformer = ({
     const { prefix, middle, suffix } = splitNode(item, annStartAbs, annEndAbs);
 
     newContent.push(...prefix);
-    // Only transform the middle segments
+    // Only transform the middle segments. Atomic textless nodes (mentions,
+    // images) inside the range are kept but must not receive marks.
     for (const midItem of middle) {
-      transform?.({
-        root,
-        parent,
-        block: midItem,
-        annotation,
-      });
+      if (typeof midItem.text === 'string') {
+        transform?.({
+          root,
+          parent,
+          block: midItem,
+          annotation,
+        });
+      }
       newContent.push(midItem);
     }
     newContent.push(...suffix);

--- a/libs/lib-editing/src/lib/transformers/split-marks.spec.ts
+++ b/libs/lib-editing/src/lib/transformers/split-marks.spec.ts
@@ -1,0 +1,126 @@
+import { splitMarks, TranslationMark } from './split-marks';
+
+const rangedMark = (start: number, end: number): TranslationMark => ({
+  type: 'italic',
+  attrs: { start, end, uuid: 'mark-1', type: 'span' },
+});
+
+const positionlessMark: TranslationMark = {
+  type: 'link',
+  attrs: { href: 'https://84000.co', uuid: 'link-1', type: 'href' },
+};
+
+describe('splitMarks', () => {
+  it('returns undefined when there are no marks', () => {
+    expect(splitMarks({ start: 0, end: 10 })).toBeUndefined();
+  });
+
+  it('drops a mark that lies entirely before the segment', () => {
+    const result = splitMarks({
+      marks: [rangedMark(0, 5)],
+      start: 10,
+      end: 20,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('drops a mark that lies entirely after the segment', () => {
+    const result = splitMarks({
+      marks: [rangedMark(15, 20)],
+      start: 0,
+      end: 10,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('never produces an inverted range', () => {
+    const marks = [rangedMark(0, 5), rangedMark(3, 12), rangedMark(8, 25)];
+    const result = splitMarks({ marks, start: 10, end: 20 });
+
+    for (const mark of result ?? []) {
+      expect(mark.attrs?.start).toBeLessThanOrEqual(mark.attrs?.end ?? 0);
+    }
+  });
+
+  it('clamps a partially overlapping mark to the segment', () => {
+    const result = splitMarks({
+      marks: [rangedMark(5, 15)],
+      start: 10,
+      end: 20,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        attrs: expect.objectContaining({ start: 10, end: 15 }),
+      }),
+    ]);
+  });
+
+  it('clamps a mark that contains the segment to the segment bounds', () => {
+    const result = splitMarks({
+      marks: [rangedMark(0, 30)],
+      start: 10,
+      end: 20,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        attrs: expect.objectContaining({ start: 10, end: 20 }),
+      }),
+    ]);
+  });
+
+  it('keeps positionless marks on every segment without injecting attrs', () => {
+    const first = splitMarks({
+      marks: [positionlessMark],
+      start: 0,
+      end: 10,
+    });
+    const second = splitMarks({
+      marks: [positionlessMark],
+      start: 10,
+      end: 20,
+    });
+
+    expect(first).toEqual([positionlessMark]);
+    expect(second).toEqual([positionlessMark]);
+    expect(first?.[0].attrs).not.toHaveProperty('start');
+    expect(first?.[0].attrs).not.toHaveProperty('end');
+  });
+
+  it('attaches a zero-width mark to the segment that starts at its position', () => {
+    const zeroWidth = rangedMark(10, 10);
+
+    const before = splitMarks({ marks: [zeroWidth], start: 0, end: 10 });
+    const after = splitMarks({ marks: [zeroWidth], start: 10, end: 20 });
+
+    expect(before).toEqual([]);
+    expect(after).toHaveLength(1);
+  });
+
+  it('attaches a zero-width mark at the node end only to the last segment', () => {
+    const zeroWidth = rangedMark(20, 20);
+
+    const notLast = splitMarks({ marks: [zeroWidth], start: 10, end: 20 });
+    const last = splitMarks({
+      marks: [zeroWidth],
+      start: 10,
+      end: 20,
+      isLast: true,
+    });
+
+    expect(notLast).toEqual([]);
+    expect(last).toHaveLength(1);
+  });
+
+  it('does not mutate the input marks', () => {
+    const mark = rangedMark(5, 15);
+    const original = JSON.parse(JSON.stringify(mark));
+
+    splitMarks({ marks: [mark], start: 10, end: 20 });
+
+    expect(mark).toEqual(original);
+  });
+});

--- a/libs/lib-editing/src/lib/transformers/split-marks.ts
+++ b/libs/lib-editing/src/lib/transformers/split-marks.ts
@@ -7,36 +7,70 @@ export type TranslationMark = {
   };
 };
 
+/**
+ * Redistributes a node's marks onto one of its split segments [start, end].
+ *
+ * Marks without positional attrs (link, glossaryInstance, endNoteLink, etc. —
+ * only span marks carry start/end) cover the whole original node, so they are
+ * kept on every segment untouched. Ranged marks are kept only when they
+ * actually overlap the segment, then clamped to it; a mark that lies entirely
+ * outside the segment must be dropped, never clamped into an inverted
+ * (start > end) range.
+ */
 export const splitMarks = ({
   marks,
   start,
   end,
+  isLast = false,
 }: {
   marks?: TranslationMark[];
   start: number;
   end: number;
+  /**
+   * True when this is the final segment of the node, so a zero-width mark
+   * sitting exactly on the node's end boundary has a segment to land on.
+   */
+  isLast?: boolean;
 }) => {
   if (!marks) {
     return;
   }
 
-  const nextMarks = marks
-    .filter(
-      (mark) =>
-        (mark.attrs?.end ?? 0) <= end && (mark.attrs?.start ?? 0) <= end,
-    )
+  return marks
+    .filter((mark) => {
+      const markStart = mark.attrs?.start;
+      const markEnd = mark.attrs?.end;
+
+      if (typeof markStart !== 'number' || typeof markEnd !== 'number') {
+        return true;
+      }
+
+      // Zero-width marks attach to exactly one segment: half-open bounds so a
+      // boundary position lands on the following segment, except at the very
+      // end of the node where the last segment claims it.
+      if (markStart === markEnd) {
+        return (
+          markStart >= start && (markStart < end || (isLast && markStart === end))
+        );
+      }
+
+      return markStart < end && markEnd > start;
+    })
     .map((mark) => {
-      const markStart = Math.max(mark.attrs?.start ?? 0, start);
-      const markEnd = Math.min(mark.attrs?.end ?? 0, end);
+      const markStart = mark.attrs?.start;
+      const markEnd = mark.attrs?.end;
+
+      if (typeof markStart !== 'number' || typeof markEnd !== 'number') {
+        return mark;
+      }
+
       return {
         ...mark,
         attrs: {
           ...mark.attrs,
-          start: markStart,
-          end: markEnd,
+          start: Math.max(markStart, start),
+          end: Math.min(markEnd, end),
         },
       };
     });
-
-  return nextMarks;
 };

--- a/libs/lib-editing/src/lib/transformers/split-node.spec.ts
+++ b/libs/lib-editing/src/lib/transformers/split-node.spec.ts
@@ -1,0 +1,71 @@
+import { splitNode } from './split-node';
+import type { TranslationEditorContentItem } from '../components/editor';
+
+const textNode = (
+  start: number,
+  text: string,
+): TranslationEditorContentItem => ({
+  type: 'text',
+  text,
+  attrs: { start, end: start + text.length },
+});
+
+const mentionNode = (start: number, end: number) => ({
+  type: 'mention',
+  attrs: { start, end, items: [{ uuid: 'item-1' }] },
+});
+
+describe('splitNode', () => {
+  it('splits a text node into prefix, middle, and suffix with correct offsets', () => {
+    const { prefix, middle, suffix } = splitNode(
+      textNode(0, '0123456789'),
+      3,
+      7,
+    );
+
+    expect(prefix).toEqual([
+      expect.objectContaining({ text: '012', attrs: { start: 0, end: 3 } }),
+    ]);
+    expect(middle).toEqual([
+      expect.objectContaining({ text: '3456', attrs: { start: 3, end: 7 } }),
+    ]);
+    expect(suffix).toEqual([
+      expect.objectContaining({ text: '789', attrs: { start: 7, end: 10 } }),
+    ]);
+  });
+
+  it('returns the whole node as prefix when it ends before the range', () => {
+    const node = textNode(0, '01234');
+    const { prefix, middle, suffix } = splitNode(node, 10, 20);
+
+    expect(prefix).toEqual([node]);
+    expect(middle).toEqual([]);
+    expect(suffix).toEqual([]);
+  });
+
+  it('returns the whole node as suffix when it starts after the range', () => {
+    const node = textNode(20, '01234');
+    const { prefix, middle, suffix } = splitNode(node, 0, 10);
+
+    expect(prefix).toEqual([]);
+    expect(middle).toEqual([]);
+    expect(suffix).toEqual([node]);
+  });
+
+  it('keeps an atomic textless node overlapping the range whole in the middle', () => {
+    const node = mentionNode(10, 10);
+    const { prefix, middle, suffix } = splitNode(node, 5, 15);
+
+    expect(prefix).toEqual([]);
+    expect(middle).toEqual([node]);
+    expect(suffix).toEqual([]);
+  });
+
+  it('routes a textless node outside the range to prefix or suffix', () => {
+    const before = mentionNode(3, 3);
+    const after = mentionNode(20, 20);
+
+    expect(splitNode(before, 5, 15).prefix).toEqual([before]);
+    expect(splitNode(after, 5, 15).suffix).toEqual([after]);
+  });
+});

--- a/libs/lib-editing/src/lib/transformers/split-node.ts
+++ b/libs/lib-editing/src/lib/transformers/split-node.ts
@@ -34,6 +34,13 @@ export function splitNode(
     return { prefix: [], middle: [], suffix: [item] };
   }
 
+  // Atomic textless nodes (mentions, images, inserted zero-width annotations)
+  // overlapping the range cannot be split; keep them whole in the middle so
+  // they survive the split instead of vanishing.
+  if (typeof item.text !== 'string') {
+    return { prefix: [], middle: [item], suffix: [] };
+  }
+
   const preLen = Math.max(rangeStart - itemStart, 0);
   const midLen = Math.max(
     Math.min(itemEnd, rangeEnd) - Math.max(itemStart, rangeStart),

--- a/libs/lib-editing/src/lib/transformers/split-node.ts
+++ b/libs/lib-editing/src/lib/transformers/split-node.ts
@@ -95,6 +95,7 @@ export function splitNode(
         marks,
         start: midStart,
         end: midEnd,
+        isLast: postStartIdx >= text.length,
       });
 
       if (midMarks?.length) {
@@ -124,6 +125,7 @@ export function splitNode(
         marks,
         start: postStart,
         end: postEnd,
+        isLast: true,
       });
 
       if (postMarks?.length) {


### PR DESCRIPTION
### Summary

Phase 2 of the editor reliability pass: fixes four classes of bugs in the passages→editor transformation pipeline that caused annotations to render on the wrong text content, silently disappear (and then be deleted from the database on the next save), or drop whole passages.

- mark overlap filter — a ranged mark lying entirely outside a split segment was clamped into an inverted (start > end) range on the wrong content, and positionless marks (link, glossary, etc.) had incorrect `start`/`end` attrs injected. Marks are now kept only where they genuinely overlap; zero-width marks land on exactly one segment.
- Annotations straddling split boundaries now render. Ranges crossing block boundaries (e.g. two lines of a lineGroup) remain unplaceable but warn loudly and flag the passage invalid.
- zero-length nodes survive splits
- Empty passages render — Previously, empty passages were dropped from the document entirely (invisible, uneditable, undeletable); they now render as empty blocks.