### PR TITLE
Editor Cleanup, part 3: save reliability

### DIFF
--- a/apps/api-graphql/src/graphql/schema/passage/passage.graphql
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.graphql
@@ -205,6 +205,13 @@ input PassageInput {
   Annotations as JSON array
   """
   annotations: JSON!
+
+  """
+  True when the client could not serialize every annotation on this passage.
+  The server must not delete stored annotations missing from an incomplete
+  set — the omission is a serialization gap, not an editor deletion.
+  """
+  annotationsIncomplete: Boolean
 }
 
 """

--- a/apps/api-graphql/src/graphql/schema/passage/passage.mutation.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.mutation.ts
@@ -34,6 +34,7 @@ interface PassageInput {
   // Annotations come as JSON from GraphQL
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   annotations: any[];
+  annotationsIncomplete?: boolean | null;
 }
 
 interface SavePassagesResult {
@@ -97,6 +98,7 @@ export const savePassagesMutation = async (
       type: input.type as Passage['type'],
       xmlId: input.xmlId ?? undefined,
       annotations: input.annotations as Annotation[],
+      annotationsIncomplete: input.annotationsIncomplete ?? undefined,
     }));
 
     return savePassagesWithDeletions({

--- a/libs/client-graphql/src/lib/functions/save-passages.ts
+++ b/libs/client-graphql/src/lib/functions/save-passages.ts
@@ -37,6 +37,7 @@ interface PassageInput {
   type: string;
   xmlId?: string;
   annotations: unknown[];
+  annotationsIncomplete?: boolean;
 }
 
 /**
@@ -51,6 +52,7 @@ const passageToInput = (passage: Passage): PassageInput => ({
   type: passage.type,
   xmlId: passage.xmlId,
   annotations: passage.annotations,
+  annotationsIncomplete: passage.annotationsIncomplete,
 });
 
 /**

--- a/libs/client-graphql/src/lib/generated/graphql.ts
+++ b/libs/client-graphql/src/lib/generated/graphql.ts
@@ -99,6 +99,28 @@ export type CurrentUser = {
   role: UserRole;
 };
 
+/**
+ * A lightweight reference to a searchable entity, used by the editor's mention
+ * picker.
+ */
+export type EntitySearchResult = {
+  __typename?: 'EntitySearchResult';
+  /**
+   * Short identifier (toh, passage/folio label, g.<term_number>, or bibliography
+   * entry label).
+   */
+  label: Scalars['String']['output'];
+  /**
+   * Secondary descriptive text (work title, content excerpt, English glossary
+   * term, or bibliography excerpt).
+   */
+  text: Scalars['String']['output'];
+  /** Entity kind: "work", "passage", "folio", "bibliography", or "glossary". */
+  type: Scalars['String']['output'];
+  /** UUID of the matched entity. */
+  uuid: Scalars['ID']['output'];
+};
+
 /** A folio page from a Tibetan work */
 export type Folio = {
   __typename?: 'Folio';
@@ -406,6 +428,12 @@ export type PassageFilter = {
 export type PassageInput = {
   /** Annotations as JSON array */
   annotations: Scalars['JSON']['input'];
+  /**
+   * True when the client could not serialize every annotation on this passage.
+   * The server must not delete stored annotations missing from an incomplete
+   * set — the omission is a serialization gap, not an editor deletion.
+   */
+  annotationsIncomplete?: InputMaybe<Scalars['Boolean']['input']>;
   /** Text content of the passage */
   content: Scalars['String']['input'];
   /** Display label for the passage */
@@ -459,6 +487,15 @@ export type Query = {
    * At least one of uuid or legacy xmlId must be provided. Prefers uuid if both are present.
    */
   passage?: Maybe<Passage>;
+  /**
+   * Generic entity search for mention authoring. Accent- and case-insensitive.
+   *
+   * `work` results are always global. `workUuid` and `toh` are optional scoping
+   * filters for the work-internal types (passage, folio, bibliography, glossary):
+   * when provided they scope the search, when omitted those types are searched
+   * globally. `types` restricts the search to specific entity kinds.
+   */
+  search: Array<EntitySearchResult>;
   /** Get the current API version */
   version: Scalars['String']['output'];
   /**
@@ -511,6 +548,16 @@ export type QueryLookupArgs = {
 export type QueryPassageArgs = {
   uuid?: InputMaybe<Scalars['ID']['input']>;
   xmlId?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** Root Query type - extend this in other schema files */
+export type QuerySearchArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  query: Scalars['String']['input'];
+  toh?: InputMaybe<Scalars['String']['input']>;
+  types?: InputMaybe<Array<Scalars['String']['input']>>;
+  workUuid?: InputMaybe<Scalars['ID']['input']>;
 };
 
 

--- a/libs/data-access/src/lib/passage/save.spec.ts
+++ b/libs/data-access/src/lib/passage/save.spec.ts
@@ -541,6 +541,67 @@ describe('savePassagesWithDeletions failure propagation', () => {
     expect(renumberIndex).toBeGreaterThan(deleteIndex);
   });
 
+  it('preserves stored annotations for passages with an incomplete export', async () => {
+    const state = createState({
+      annotations: [
+        annotationRow,
+        { ...annotationRow, uuid: 'annotation-2', start: 5, end: 9 },
+      ],
+      passages: [passageRow],
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      // annotation-2 is absent from the payload, but the export is flagged
+      // incomplete — the omission is a serialization gap, not a deletion.
+      passages: [{ ...passage, annotationsIncomplete: true }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(state.deletedAnnotationUuids).toEqual([]);
+  });
+
+  it('still deletes omitted annotations of complete sibling passages', async () => {
+    const completeSibling: Passage = {
+      ...passage,
+      uuid: 'passage-2',
+      sort: 2,
+      label: '2',
+      annotations: [],
+    };
+    const siblingRow: PassageRowDTO = {
+      ...passageRow,
+      uuid: 'passage-2',
+      sort: 2,
+      label: '2',
+    };
+
+    const state = createState({
+      annotations: [
+        annotationRow,
+        {
+          ...annotationRow,
+          uuid: 'annotation-sibling',
+          passage_uuid: 'passage-2',
+        },
+      ],
+      passages: [passageRow, siblingRow],
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [
+        { ...passage, annotationsIncomplete: true },
+        completeSibling,
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    // The incomplete passage's annotation survives; the complete sibling's
+    // omitted annotation is deleted as a real removal.
+    expect(state.deletedAnnotationUuids).toEqual(['annotation-sibling']);
+  });
+
   it('reports failure when the orphaned annotation delete fails', async () => {
     const state = createState({
       annotations: [

--- a/libs/data-access/src/lib/passage/save.spec.ts
+++ b/libs/data-access/src/lib/passage/save.spec.ts
@@ -3,13 +3,29 @@ import type { AnnotationDTO, Passage, PassageRowDTO } from '../types';
 
 type TableName = 'passages' | 'passage_annotations';
 
+/**
+ * Operation names recorded in `state.ops` and accepted by `state.failOn`:
+ * - rpc:shift_passage_sorts / rpc:rename_passage_label_prefix
+ * - select:passages / select:passages:renumber / select:annotations /
+ *   select:annotations:endnote-refs
+ * - upsert:passages / upsert:passages:labels / upsert:annotations
+ * - delete:passages / delete:annotations / delete:annotations:by-passage
+ */
 type FakeState = {
   annotations: AnnotationDTO[];
   deletedAnnotationUuids: string[];
   deletedPassageUuids: string[];
   passageUpserts: PassageRowDTO[][];
+  labelUpserts: { uuid: string; label: string }[][];
   passages: PassageRowDTO[];
   annotationUpserts: AnnotationDTO[][];
+  ops: string[];
+  failOn?: Partial<Record<string, string>>;
+};
+
+const failResult = (state: FakeState, op: string) => {
+  const message = state.failOn?.[op];
+  return message ? { message } : null;
 };
 
 class FakeQueryBuilder {
@@ -17,6 +33,8 @@ class FakeQueryBuilder {
   private inColumn?: string;
   private inValues: string[] = [];
   private eqType?: string;
+  private eqWorkUuid?: string;
+  private gtSort?: number;
   private filterContentUuid?: string;
 
   constructor(
@@ -36,8 +54,31 @@ class FakeQueryBuilder {
 
   upsert(rows: PassageRowDTO[] | AnnotationDTO[]) {
     if (this.table === 'passages') {
-      this.state.passageUpserts.push(rows as PassageRowDTO[]);
+      const isLabelOnly = (rows as { uuid: string }[]).every(
+        (row) =>
+          Object.keys(row)
+            .sort()
+            .join(',') === 'label,uuid',
+      );
+      const op = isLabelOnly ? 'upsert:passages:labels' : 'upsert:passages';
+      this.state.ops.push(op);
+      const error = failResult(this.state, op);
+      if (error) {
+        return Promise.resolve({ error });
+      }
+      if (isLabelOnly) {
+        this.state.labelUpserts.push(
+          rows as { uuid: string; label: string }[],
+        );
+      } else {
+        this.state.passageUpserts.push(rows as PassageRowDTO[]);
+      }
     } else {
+      this.state.ops.push('upsert:annotations');
+      const error = failResult(this.state, 'upsert:annotations');
+      if (error) {
+        return Promise.resolve({ error });
+      }
       this.state.annotationUpserts.push(rows as AnnotationDTO[]);
     }
     return Promise.resolve({ error: null });
@@ -57,6 +98,9 @@ class FakeQueryBuilder {
     if (column === 'type') {
       this.eqType = value;
     }
+    if (column === 'work_uuid') {
+      this.eqWorkUuid = value;
+    }
     return this;
   }
 
@@ -72,7 +116,10 @@ class FakeQueryBuilder {
     return this;
   }
 
-  gt() {
+  gt(column: string, value: number) {
+    if (column === 'sort') {
+      this.gtSort = value;
+    }
     return this;
   }
 
@@ -84,11 +131,31 @@ class FakeQueryBuilder {
     return this;
   }
 
+  private opName(): string {
+    if (this.action === 'delete') {
+      if (this.table === 'passages') {
+        return 'delete:passages';
+      }
+      return this.inColumn === 'passage_uuid'
+        ? 'delete:annotations:by-passage'
+        : 'delete:annotations';
+    }
+
+    if (this.table === 'passages') {
+      return this.gtSort !== undefined
+        ? 'select:passages:renumber'
+        : 'select:passages';
+    }
+    return this.filterContentUuid
+      ? 'select:annotations:endnote-refs'
+      : 'select:annotations';
+  }
+
   then<TResult1 = unknown, TResult2 = never>(
     onfulfilled?:
       | ((value: {
-          data: unknown[];
-          error?: null;
+          data: unknown[] | null;
+          error: { message: string } | null;
         }) => TResult1 | PromiseLike<TResult1>)
       | null,
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
@@ -97,6 +164,13 @@ class FakeQueryBuilder {
   }
 
   private execute() {
+    const op = this.opName();
+    this.state.ops.push(op);
+    const error = failResult(this.state, op);
+    if (error) {
+      return { data: null, error };
+    }
+
     if (this.action === 'delete') {
       if (this.table === 'passage_annotations') {
         if (this.inColumn === 'passage_uuid') {
@@ -139,6 +213,19 @@ class FakeQueryBuilder {
       };
     }
 
+    if (this.eqWorkUuid !== undefined && this.gtSort !== undefined) {
+      const gtSort = this.gtSort;
+      return {
+        data: this.state.passages
+          .filter(
+            (passage) =>
+              passage.work_uuid === this.eqWorkUuid && passage.sort > gtSort,
+          )
+          .sort((a, b) => a.sort - b.sort),
+        error: null,
+      };
+    }
+
     return {
       data: this.inColumn
         ? this.state.passages.filter((passage) =>
@@ -153,22 +240,32 @@ class FakeQueryBuilder {
 const createFakeClient = (state: FakeState) =>
   ({
     from: (table: TableName) => new FakeQueryBuilder(state, table),
-    rpc: jest.fn().mockResolvedValue({ error: null }),
+    rpc: (name: string) => {
+      const op = `rpc:${name}`;
+      state.ops.push(op);
+      const error = failResult(state, op);
+      return Promise.resolve({ error });
+    },
   }) as never;
 
 const createState = ({
   annotations = [],
   passages = [],
+  failOn,
 }: {
   annotations?: AnnotationDTO[];
   passages?: PassageRowDTO[];
+  failOn?: Partial<Record<string, string>>;
 }): FakeState => ({
   annotations,
   deletedAnnotationUuids: [],
   deletedPassageUuids: [],
   passageUpserts: [],
+  labelUpserts: [],
   passages,
   annotationUpserts: [],
+  ops: [],
+  failOn,
 });
 
 const passage: Passage = {
@@ -208,6 +305,14 @@ const annotationRow: AnnotationDTO = {
 };
 
 describe('savePassagesWithDeletions', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('does not upsert unchanged passage or annotation rows', async () => {
     const state = createState({
       annotations: [annotationRow],
@@ -317,5 +422,141 @@ describe('savePassagesWithDeletions', () => {
     // The reference lives on a different passage, so it is only removed via
     // the content-containment cascade, not the delete-by-passage_uuid pass.
     expect(state.deletedAnnotationUuids).toEqual(['ref-1']);
+  });
+});
+
+describe('savePassagesWithDeletions failure propagation', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const newPassage: Passage = {
+    ...passage,
+    uuid: 'passage-new',
+    sort: 2,
+    label: '2',
+    annotations: [],
+  };
+
+  it('aborts before any content writes when shift_passage_sorts fails', async () => {
+    const state = createState({
+      passages: [],
+      failOn: { 'rpc:shift_passage_sorts': 'shift failed' },
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [newPassage],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('shift');
+    expect(state.ops).not.toContain('upsert:passages');
+    expect(state.ops).not.toContain('delete:passages');
+  });
+
+  it('surfaces passage upsert failures', async () => {
+    const state = createState({
+      passages: [passageRow],
+      failOn: { 'upsert:passages': 'upsert failed' },
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [{ ...passage, content: 'Changed text' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Failed to save passages');
+    expect(state.ops).not.toContain('upsert:annotations');
+  });
+
+  it('commits content before renumbering and surfaces renumber failures', async () => {
+    // A neighbor whose label must shift when the new passage is inserted.
+    const neighbor: PassageRowDTO = {
+      uuid: 'passage-neighbor',
+      work_uuid: 'work-1',
+      content: 'Neighbor',
+      label: '2',
+      sort: 3,
+      type: 'translation',
+    };
+    const state = createState({
+      passages: [neighbor],
+      failOn: { 'upsert:passages:labels': 'renumber failed' },
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [newPassage],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('labels were not renumbered');
+    // The content upsert committed before the renumber attempt.
+    expect(state.ops.indexOf('upsert:passages')).toBeGreaterThanOrEqual(0);
+    expect(state.ops.indexOf('upsert:passages')).toBeLessThan(
+      state.ops.indexOf('upsert:passages:labels'),
+    );
+  });
+
+  it('aborts the deletion sequence while passages still exist when annotation cleanup fails', async () => {
+    const state = createState({
+      annotations: [annotationRow],
+      passages: [passageRow],
+      failOn: { 'delete:annotations:by-passage': 'cleanup failed' },
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [],
+      deletedUuids: ['passage-1'],
+    });
+
+    expect(result.success).toBe(false);
+    expect(state.ops).not.toContain('delete:passages');
+    expect(state.deletedPassageUuids).toEqual([]);
+  });
+
+  it('renumbers labels only after the passage delete succeeds', async () => {
+    const state = createState({
+      annotations: [],
+      passages: [passageRow],
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [],
+      deletedUuids: ['passage-1'],
+    });
+
+    expect(result.success).toBe(true);
+    const deleteIndex = state.ops.indexOf('delete:passages');
+    const renumberIndex = state.ops.indexOf('select:passages:renumber');
+    expect(deleteIndex).toBeGreaterThanOrEqual(0);
+    expect(renumberIndex).toBeGreaterThan(deleteIndex);
+  });
+
+  it('reports failure when the orphaned annotation delete fails', async () => {
+    const state = createState({
+      annotations: [
+        annotationRow,
+        { ...annotationRow, uuid: 'annotation-2', start: 5, end: 9 },
+      ],
+      passages: [passageRow],
+      failOn: { 'delete:annotations': 'orphan delete failed' },
+    });
+
+    const result = await savePassagesWithDeletions({
+      client: createFakeClient(state),
+      passages: [passage],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('stale annotations');
   });
 });

--- a/libs/data-access/src/lib/passage/save.ts
+++ b/libs/data-access/src/lib/passage/save.ts
@@ -24,7 +24,7 @@ async function normalizePassageLabelsAfter({
   fromSort: number;
   fromLabel: string;
   delta: number;
-}): Promise<void> {
+}): Promise<{ error?: string }> {
   const parts = fromLabel.split('.');
   const depth = parts.length;
   const prefix = depth > 1 ? `${parts.slice(0, -1).join('.')}.` : '';
@@ -41,7 +41,11 @@ async function normalizePassageLabelsAfter({
       .order('sort', { ascending: true })
       .limit(SAVE_PAGE_SIZE);
 
-    if (error || !data || data.length === 0) break;
+    if (error) {
+      console.error('Error fetching passages for label normalization:', error);
+      return { error: error.message };
+    }
+    if (!data || data.length === 0) break;
 
     const labelUpdates: { uuid: string; label: string }[] = [];
     const prefixRenames: { oldPrefix: string; newPrefix: string }[] = [];
@@ -76,6 +80,7 @@ async function normalizePassageLabelsAfter({
         .upsert(labelUpdates, { onConflict: 'uuid' });
       if (upsertError) {
         console.error('Error normalizing passage labels:', upsertError);
+        return { error: upsertError.message };
       }
 
       for (const { oldPrefix, newPrefix } of prefixRenames) {
@@ -89,6 +94,7 @@ async function normalizePassageLabelsAfter({
         );
         if (prefixError) {
           console.error('Error renaming passage label prefix:', prefixError);
+          return { error: prefixError.message };
         }
       }
     }
@@ -96,6 +102,8 @@ async function normalizePassageLabelsAfter({
     if (done || data.length < SAVE_PAGE_SIZE) break;
     lastSort = data[data.length - 1].sort;
   }
+
+  return {};
 }
 
 export type SavedPassageRow = {
@@ -185,6 +193,28 @@ const annotationHasChanged = (
   );
 };
 
+const failure = (
+  error: string,
+  savedCount = 0,
+): SavePassagesWithDeletionsResult => ({
+  success: false,
+  savedCount,
+  passages: [],
+  error,
+});
+
+/**
+ * Persists edited passages and their annotations, and removes deleted
+ * passages.
+ *
+ * supabase-js provides no transactions, so this runs as a sequence of
+ * independent writes ordered to keep the partial-failure window small: sort
+ * shifts, then core content upserts, then cosmetic label renumbering, then
+ * deletions (labels renumbered only after the delete succeeds), then orphaned
+ * annotation cleanup. Every write is an idempotent upsert/delete keyed by
+ * uuid, so any failure reported to the client converges when the client
+ * retries the same save.
+ */
 export const savePassagesWithDeletions = async ({
   client,
   passages,
@@ -208,6 +238,8 @@ export const savePassagesWithDeletions = async ({
   const newPassages = passages.filter((p) => !existingUuidSet.has(p.uuid));
   const sortedNewPassages = [...newPassages].sort((a, b) => b.sort - a.sort);
 
+  // Make room for new passages before their rows are inserted; a sort
+  // collision here would corrupt ordering, so abort on failure.
   for (const passage of sortedNewPassages) {
     const { error } = await client.rpc('shift_passage_sorts', {
       p_work_uuid: passage.workUuid,
@@ -216,113 +248,12 @@ export const savePassagesWithDeletions = async ({
     });
     if (error) {
       console.error('Error shifting passage sorts:', error);
+      return failure(`Failed to shift passage sorts: ${error.message}`);
     }
   }
 
-  for (const passage of sortedNewPassages) {
-    await normalizePassageLabelsAfter({
-      client,
-      workUuid: passage.workUuid,
-      fromSort: passage.sort,
-      fromLabel: passage.label,
-      delta: 1,
-    });
-  }
-
-  let deletedCount = 0;
-  if (deletedUuids.length > 0) {
-    const { data: deletedPassages } = await client
-      .from('passages')
-      .select('uuid, sort, label, work_uuid')
-      .in('uuid', deletedUuids);
-
-    if (deletedPassages && deletedPassages.length > 0) {
-      const sortedDeleted = [...deletedPassages].sort(
-        (a, b) => b.sort - a.sort,
-      );
-      for (const deletedPassage of sortedDeleted) {
-        await normalizePassageLabelsAfter({
-          client,
-          workUuid: deletedPassage.work_uuid,
-          fromSort: deletedPassage.sort,
-          fromLabel: deletedPassage.label,
-          delta: -1,
-        });
-      }
-
-      const { error: deleteAnnotationsError } = await client
-        .from('passage_annotations')
-        .delete()
-        .in('passage_uuid', deletedUuids);
-
-      if (deleteAnnotationsError) {
-        console.error(
-          'Error deleting annotations for deleted passages:',
-          deleteAnnotationsError,
-        );
-      }
-
-      // Cascade: remove `endNoteLink` annotations on OTHER passages that
-      // reference any deleted endnote passage. These live on the referencing
-      // (translation/front) passages, not on the deleted note itself, so the
-      // delete-by-passage_uuid above never reaches them. Left behind, they
-      // become orphaned references that render as a stray "*". Doing this
-      // server-side fixes the case where the referencing passage is not loaded
-      // in the editor (so client-side cleanup can't reach it).
-      for (const deletedUuid of deletedUuids) {
-        const { data: referencingAnnotations, error: findReferencesError } =
-          await client
-            .from('passage_annotations')
-            .select('uuid')
-            .eq('type', 'end-note-link')
-            .filter('content', 'cs', JSON.stringify([{ uuid: deletedUuid }]));
-
-        if (findReferencesError) {
-          console.error(
-            'Error finding endnote-link references to deleted passage:',
-            findReferencesError,
-          );
-          continue;
-        }
-
-        const referenceUuids = (referencingAnnotations ?? []).map(
-          (annotation) => annotation.uuid,
-        );
-
-        if (referenceUuids.length > 0) {
-          const { error: deleteReferencesError } = await client
-            .from('passage_annotations')
-            .delete()
-            .in('uuid', referenceUuids);
-
-          if (deleteReferencesError) {
-            console.error(
-              'Error deleting endnote-link references to deleted passage:',
-              deleteReferencesError,
-            );
-          }
-        }
-      }
-
-      const { error: deletePassagesError } = await client
-        .from('passages')
-        .delete()
-        .in('uuid', deletedUuids);
-
-      if (deletePassagesError) {
-        console.error('Error deleting passages:', deletePassagesError);
-        return {
-          success: false,
-          savedCount: 0,
-          passages: [],
-          error: `Failed to delete passages: ${deletePassagesError.message}`,
-        };
-      }
-
-      deletedCount = deletedPassages.length;
-    }
-  }
-
+  // Compute row/annotation diffs against the pre-save state before any
+  // content writes happen.
   const dtos = passagesToDTO(passages);
   const passageRowDtos = passagesToRowDTO(passages);
   const passageUuids = passages.map((p) => p.uuid);
@@ -364,6 +295,8 @@ export const savePassagesWithDeletions = async ({
       ),
   );
 
+  // Core content commits first — everything after this point is cosmetic
+  // renumbering or cleanup.
   if (passageRowsToUpsert.length > 0) {
     const { error: passageError } = await client
       .from('passages')
@@ -371,12 +304,7 @@ export const savePassagesWithDeletions = async ({
 
     if (passageError) {
       console.error('Error saving passages:', passageError);
-      return {
-        success: false,
-        savedCount: 0,
-        passages: [],
-        error: `Failed to save passages: ${passageError.message}`,
-      };
+      return failure(`Failed to save passages: ${passageError.message}`);
     }
   }
 
@@ -387,15 +315,160 @@ export const savePassagesWithDeletions = async ({
 
     if (annotationError) {
       console.error('Error saving annotations:', annotationError);
-      return {
-        success: false,
-        savedCount: passages.length,
-        passages: [],
-        error: `Passages saved but annotations failed: ${annotationError.message}`,
-      };
+      return failure(
+        `Passages saved but annotations failed: ${annotationError.message}`,
+        passages.length,
+      );
     }
   }
 
+  // Renumber neighbors of inserted passages now that the content is safe.
+  for (const passage of sortedNewPassages) {
+    const { error } = await normalizePassageLabelsAfter({
+      client,
+      workUuid: passage.workUuid,
+      fromSort: passage.sort,
+      fromLabel: passage.label,
+      delta: 1,
+    });
+    if (error) {
+      return failure(
+        `Content saved but passage labels were not renumbered: ${error}`,
+        passages.length,
+      );
+    }
+  }
+
+  let deletedCount = 0;
+  if (deletedUuids.length > 0) {
+    const { data: deletedPassages, error: deletedFetchError } = await client
+      .from('passages')
+      .select('uuid, sort, label, work_uuid')
+      .in('uuid', deletedUuids);
+
+    if (deletedFetchError) {
+      console.error(
+        'Error fetching passages marked for deletion:',
+        deletedFetchError,
+      );
+      return failure(
+        `Failed to fetch passages marked for deletion: ${deletedFetchError.message}`,
+        passages.length,
+      );
+    }
+
+    if (deletedPassages && deletedPassages.length > 0) {
+      const sortedDeleted = [...deletedPassages].sort(
+        (a, b) => b.sort - a.sort,
+      );
+
+      // All annotation cleanup runs before the passage delete: if any step
+      // fails we abort while the passage rows still exist, so a retry can
+      // redo the whole sequence.
+      const { error: deleteAnnotationsError } = await client
+        .from('passage_annotations')
+        .delete()
+        .in('passage_uuid', deletedUuids);
+
+      if (deleteAnnotationsError) {
+        console.error(
+          'Error deleting annotations for deleted passages:',
+          deleteAnnotationsError,
+        );
+        return failure(
+          `Failed to delete annotations for deleted passages: ${deleteAnnotationsError.message}`,
+          passages.length,
+        );
+      }
+
+      // Cascade: remove `endNoteLink` annotations on OTHER passages that
+      // reference any deleted endnote passage. These live on the referencing
+      // (translation/front) passages, not on the deleted note itself, so the
+      // delete-by-passage_uuid above never reaches them. Left behind, they
+      // become orphaned references that render as a stray "*". Doing this
+      // server-side fixes the case where the referencing passage is not loaded
+      // in the editor (so client-side cleanup can't reach it).
+      for (const deletedUuid of deletedUuids) {
+        const { data: referencingAnnotations, error: findReferencesError } =
+          await client
+            .from('passage_annotations')
+            .select('uuid')
+            .eq('type', 'end-note-link')
+            .filter('content', 'cs', JSON.stringify([{ uuid: deletedUuid }]));
+
+        if (findReferencesError) {
+          console.error(
+            'Error finding endnote-link references to deleted passage:',
+            findReferencesError,
+          );
+          return failure(
+            `Failed to find endnote-link references to deleted passage: ${findReferencesError.message}`,
+            passages.length,
+          );
+        }
+
+        const referenceUuids = (referencingAnnotations ?? []).map(
+          (annotation) => annotation.uuid,
+        );
+
+        if (referenceUuids.length > 0) {
+          const { error: deleteReferencesError } = await client
+            .from('passage_annotations')
+            .delete()
+            .in('uuid', referenceUuids);
+
+          if (deleteReferencesError) {
+            console.error(
+              'Error deleting endnote-link references to deleted passage:',
+              deleteReferencesError,
+            );
+            return failure(
+              `Failed to delete endnote-link references to deleted passage: ${deleteReferencesError.message}`,
+              passages.length,
+            );
+          }
+        }
+      }
+
+      const { error: deletePassagesError } = await client
+        .from('passages')
+        .delete()
+        .in('uuid', deletedUuids);
+
+      if (deletePassagesError) {
+        console.error('Error deleting passages:', deletePassagesError);
+        return failure(
+          `Failed to delete passages: ${deletePassagesError.message}`,
+          passages.length,
+        );
+      }
+
+      deletedCount = deletedPassages.length;
+
+      // Renumber neighbors only after the delete succeeded — renumbering
+      // first would leave labels shifted while the passage still exists if
+      // the delete failed. The deleted rows' sort/label were captured above.
+      for (const deletedPassage of sortedDeleted) {
+        const { error } = await normalizePassageLabelsAfter({
+          client,
+          workUuid: deletedPassage.work_uuid,
+          fromSort: deletedPassage.sort,
+          fromLabel: deletedPassage.label,
+          delta: -1,
+        });
+        if (error) {
+          return failure(
+            `Passages deleted but labels were not renumbered: ${error}`,
+            passages.length,
+          );
+        }
+      }
+    }
+  }
+
+  // Stale rows left behind here resurrect deleted markup on the next load,
+  // so a failure must reach the client even though the content upserts
+  // already committed.
   if (annotationsToDelete && annotationsToDelete.length > 0) {
     const { error: deleteError } = await client
       .from('passage_annotations')
@@ -407,6 +480,10 @@ export const savePassagesWithDeletions = async ({
 
     if (deleteError) {
       console.error('Error deleting annotations:', deleteError);
+      return failure(
+        `Passages saved but stale annotations could not be removed: ${deleteError.message}`,
+        passages.length,
+      );
     }
   }
 

--- a/libs/data-access/src/lib/passage/save.ts
+++ b/libs/data-access/src/lib/passage/save.ts
@@ -288,8 +288,18 @@ export const savePassagesWithDeletions = async ({
     ),
   );
 
+  // A passage whose annotation set is incomplete (serialization gap on the
+  // client) must not have its stored annotations treated as deletions —
+  // deleting them would turn a transient export failure into permanent data
+  // loss. They are cleaned up by the next complete export.
+  const incompletePassageUuids = new Set(
+    passages
+      .filter((passage) => passage.annotationsIncomplete)
+      .map((passage) => passage.uuid),
+  );
   const annotationsToDelete = existingAnnotations?.filter(
     (existingAnnotation) =>
+      !incompletePassageUuids.has(existingAnnotation.passage_uuid) &&
       !annotations.find(
         (annotation) => annotation.uuid === existingAnnotation.uuid,
       ),

--- a/libs/data-access/src/lib/types/passage.ts
+++ b/libs/data-access/src/lib/types/passage.ts
@@ -76,6 +76,14 @@ export type Passage = {
   parent?: string;
   toh?: TohokuCatalogEntry;
   references?: Passages;
+  /**
+   * True when the exporters could not serialize every annotation on this
+   * passage (missing uuid, unlocatable node, or the passage was flagged
+   * invalid on load). The save path must not delete DB annotations absent
+   * from an incomplete set — the omission is a serialization gap, not an
+   * editor deletion.
+   */
+  annotationsIncomplete?: boolean;
 };
 
 export type Passages = Passage[];

--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -20,6 +20,11 @@ import { passagesFromNodes, ensureUuids } from '../../passage';
 import { NavigationProvider } from '../shared';
 import { useDirtyStore, type DirtyStore } from './hooks/useDirtyStore';
 import { computeSavePayload, type PassageUuidRecord } from './save-filter';
+import {
+  beginSave,
+  filterReplacements,
+  restoreFailedSave,
+} from './save-bookkeeping';
 
 interface EditorContextState {
   doc?: Doc;
@@ -115,6 +120,7 @@ export const EditorContextProvider = ({
   const [doc, setDoc] = React.useState<Doc>(initialDoc || new Doc());
   // Use ref for immediate tracking to avoid state updates on every keystroke
   const dirtyUuidsRef = useRef<Set<string>>(new Set());
+  const isSavingRef = useRef(false);
   const isNavigatingRef = useRef(false);
   const isNormalizingForSaveRef = useRef(false);
   const clearedFragmentRef = useRef<XmlFragment | null>(null);
@@ -457,6 +463,11 @@ export const EditorContextProvider = ({
   );
 
   const save = useCallback(async () => {
+    if (isSavingRef.current) {
+      console.warn('Save already in progress; skipping.');
+      return;
+    }
+
     const editorEntries = Object.entries(editorCache.current).filter(
       ([, editor]) => !editor.isDestroyed,
     );
@@ -494,11 +505,35 @@ export const EditorContextProvider = ({
       return;
     }
 
-    const passages: Passage[] = [];
-    if (uuidsToSave.length) {
-      const uuidsToSaveSet = new Set(uuidsToSave);
-      isNormalizingForSaveRef.current = true;
-      try {
+    // Swap in a fresh dirty set before any await: keystrokes made while the
+    // network round-trip is pending land in the new set and survive the
+    // post-save bookkeeping instead of being silently cleared.
+    const { inFlight: inFlightDirty, next } = beginSave(dirtyUuidsRef.current);
+    dirtyUuidsRef.current = next;
+    isSavingRef.current = true;
+
+    try {
+      // Everything up to the await is synchronous, so the serialized payload
+      // is consistent with the uuid sets captured above.
+      const passages: Passage[] = [];
+      if (uuidsToSave.length) {
+        const uuidsToSaveSet = new Set(uuidsToSave);
+        isNormalizingForSaveRef.current = true;
+        try {
+          editorEntries.forEach(([, editor]) => {
+            const editorUuids = Array.from(getEditorUuids(editor)).filter(
+              (uuid) => uuidsToSaveSet.has(uuid),
+            );
+            if (editorUuids.length === 0) {
+              return;
+            }
+
+            ensureUuids(editor, { passageUuids: new Set(editorUuids) });
+          });
+        } finally {
+          isNormalizingForSaveRef.current = false;
+        }
+
         editorEntries.forEach(([, editor]) => {
           const editorUuids = Array.from(getEditorUuids(editor)).filter(
             (uuid) => uuidsToSaveSet.has(uuid),
@@ -507,64 +542,84 @@ export const EditorContextProvider = ({
             return;
           }
 
-          ensureUuids(editor, { passageUuids: new Set(editorUuids) });
+          editor.commands.blur();
+          passages.push(
+            ...passagesFromNodes({
+              uuids: editorUuids,
+              workUuid: work.uuid,
+              editor,
+            }),
+          );
+          editor.commands.focus();
         });
-      } finally {
-        isNormalizingForSaveRef.current = false;
+      }
+      const result = await savePassages({
+        client,
+        passages,
+        deletedUuids: deletedUuids.length > 0 ? deletedUuids : undefined,
+      });
+
+      if (!result?.success) {
+        // Nothing was durably confirmed; restore the attempted set so the
+        // next save retries it alongside any mid-flight edits.
+        dirtyUuidsRef.current = restoreFailedSave(
+          inFlightDirty,
+          dirtyUuidsRef.current,
+        );
+        console.error('Save failed:', result?.error ?? 'unknown error');
+        toast('Error saving content.', {
+          icon: <CircleAlertIcon className="size-4 text-error" />,
+        });
+        return;
       }
 
-      editorEntries.forEach(([, editor]) => {
-        const editorUuids = Array.from(getEditorUuids(editor)).filter((uuid) =>
-          uuidsToSaveSet.has(uuid),
-        );
-        if (editorUuids.length === 0) {
-          return;
+      console.log('Document state saved.');
+      toast('Content saved', {
+        icon: <CircleCheckIcon className="size-4 text-success" />,
+      });
+
+      // Baselines become the uuid sets captured at save start — not the live
+      // editor — so passages added or deleted during the flight are still
+      // detected by the next save. Skip editors swapped out mid-flight.
+      editorEntries.forEach(([key, editor]) => {
+        if (editorCache.current[key] === editor && !editor.isDestroyed) {
+          savedBaselineUuidsByEditorRef.current[key] = liveUuidsByEditor[key];
         }
-
-        editor.commands.blur();
-        passages.push(
-          ...passagesFromNodes({
-            uuids: editorUuids,
-            workUuid: work.uuid,
-            editor,
-          }),
-        );
-        editor.commands.focus();
       });
-    }
-    const result = await savePassages({
-      client,
-      passages,
-      deletedUuids: deletedUuids.length > 0 ? deletedUuids : undefined,
-    });
 
-    if (!result?.success) {
-      console.error('Save failed:', result?.error ?? 'unknown error');
-      toast('Error saving content.', {
-        icon: <CircleAlertIcon className="size-4 text-error" />,
+      // Server replacements must not overwrite passages the user re-edited
+      // during the flight — their newer local content wins and is saved on
+      // the next save.
+      const replacements = filterReplacements(
+        result.passages ?? [],
+        dirtyUuidsRef.current,
+      );
+      if (replacements.length) {
+        await applyReplacedPassages(replacements);
+      }
+
+      // The dirty flag reflects what is left: mid-flight edits plus any
+      // structural changes that have not been saved yet.
+      const residualLive: PassageUuidRecord = {};
+      Object.entries(editorCache.current)
+        .filter(([, editor]) => !editor.isDestroyed)
+        .forEach(([key, editor]) => {
+          residualLive[key] = getEditorUuids(editor);
+        });
+      const residual = computeSavePayload({
+        dirtyUuids: dirtyUuidsRef.current,
+        baseline: savedBaselineUuidsByEditorRef.current,
+        current: residualLive,
       });
-      return;
+      dirtyStore.setDirty(residual.hasChanges);
+    } finally {
+      isSavingRef.current = false;
     }
-
-    console.log('Document state saved.');
-    toast('Content saved', {
-      icon: <CircleCheckIcon className="size-4 text-success" />,
-    });
-
-    if (result.passages?.length) {
-      await applyReplacedPassages(result.passages);
-    }
-
-    // Clear both ref and state
-    dirtyUuidsRef.current.clear();
-    editorEntries.forEach(([key]) => refreshEditorBaseline(key));
-    dirtyStore.setDirty(false);
   }, [
     client,
     work.uuid,
     getEditorUuids,
     applyReplacedPassages,
-    refreshEditorBaseline,
     dirtyStore,
   ]);
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.spec.ts
@@ -1,17 +1,19 @@
-import { Schema } from '@tiptap/pm/model';
+import { Fragment, Schema, Slice } from '@tiptap/pm/model';
 import { EditorState, Plugin } from '@tiptap/pm/state';
-import { EnsureUniqueUuids } from './EnsureUniqueUuids';
+import { EnsureUniqueUuids, regenerateSliceUuids } from './EnsureUniqueUuids';
 
 // Minimal schema mirroring the editor's relevant shape: block nodes and an
 // inline leaf (atom) all carry a `uuid` attr, just as TranslationMetadata adds
-// a global `uuid` to every node type except text/doc.
+// a global `uuid` to every node type except text/doc. `mention` additionally
+// carries `items[].uuid` (its real identity), `paragraph` carries a
+// parameter-annotation uuid, and marks carry annotation uuids.
 const schema = new Schema({
   nodes: {
     doc: { content: 'block+' },
     paragraph: {
       group: 'block',
       content: 'inline*',
-      attrs: { uuid: { default: null } },
+      attrs: { uuid: { default: null }, leadingSpaceUuid: { default: null } },
       parseDOM: [{ tag: 'p' }],
       toDOM: () => ['p', 0],
     },
@@ -21,10 +23,20 @@ const schema = new Schema({
       inline: true,
       atom: true,
       marks: '',
-      attrs: { uuid: { default: null } },
+      attrs: { uuid: { default: null }, items: { default: null } },
       toDOM: () => ['span'],
     },
     text: { group: 'inline' },
+  },
+  marks: {
+    link: {
+      attrs: { uuid: { default: null }, href: { default: null } },
+      toDOM: () => ['a', 0],
+    },
+    endNoteLink: {
+      attrs: { notes: { default: null } },
+      toDOM: () => ['sup', 0],
+    },
   },
 });
 
@@ -74,5 +86,107 @@ describe('EnsureUniqueUuids plugin', () => {
     // All uuid-bearing nodes end up with distinct, non-null uuids.
     expect(uuids.every((u) => !!u)).toBe(true);
     expect(new Set(uuids).size).toBe(uuids.length);
+  });
+
+  it('regenerates non-adjacent duplicates, keeping the first occurrence', () => {
+    const plugin = getPlugin();
+
+    // The duplicate is separated from the original by another paragraph —
+    // the case the old previous-sibling check missed (paste far away).
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', { uuid: 'original' }, [schema.text('one')]),
+      schema.node('paragraph', { uuid: 'other' }, [schema.text('two')]),
+      schema.node('paragraph', { uuid: 'original' }, [schema.text('three')]),
+    ]);
+
+    let state = EditorState.create({ schema, doc, plugins: [plugin] });
+    state = state.apply(state.tr.insertText('x', doc.content.size - 1));
+
+    const uuids = collectUuids(state);
+    expect(uuids[0]).toBe('original');
+    expect(uuids[1]).toBe('other');
+    expect(uuids[2]).not.toBe('original');
+    expect(new Set(uuids).size).toBe(3);
+  });
+});
+
+describe('regenerateSliceUuids', () => {
+  const linkMark = schema.marks.link.create({
+    uuid: 'link-1',
+    href: 'https://84000.co',
+  });
+  const noteMark = schema.marks.endNoteLink.create({
+    notes: [{ uuid: 'note-1', endNote: 'endnote-passage-1' }],
+  });
+
+  // The two link segments carry different mark sets so ProseMirror does not
+  // merge them back into a single text node — the same shape splitContent
+  // produces when an endnote lands inside a link.
+  const buildSlice = () =>
+    new Slice(
+      Fragment.from([
+        schema.node(
+          'paragraph',
+          { uuid: 'passage-1', leadingSpaceUuid: 'leading-1' },
+          [
+            schema.text('linked ', [linkMark]),
+            schema.text('text', [linkMark, noteMark]),
+            schema.node('mention', {
+              uuid: null,
+              items: [{ uuid: 'item-1', entity: 'entity-1' }],
+            }),
+          ],
+        ),
+      ]),
+      1,
+      1,
+    );
+
+  const findMark = (node: import('@tiptap/pm/model').Node, name: string) =>
+    node.marks.find((mark) => mark.type.name === name);
+
+  it('regenerates node, parameter, mention item, and endnote uuids', () => {
+    const result = regenerateSliceUuids(buildSlice());
+    const paragraph = result.content.child(0);
+
+    expect(paragraph.attrs.uuid).not.toBe('passage-1');
+    expect(paragraph.attrs.uuid).toBeTruthy();
+    expect(paragraph.attrs.leadingSpaceUuid).not.toBe('leading-1');
+    expect(paragraph.attrs.leadingSpaceUuid).toBeTruthy();
+
+    const mention = paragraph.child(2);
+    expect(mention.attrs.items[0].uuid).not.toBe('item-1');
+    expect(mention.attrs.items[0].uuid).toBeTruthy();
+    // Non-identity fields survive.
+    expect(mention.attrs.items[0].entity).toBe('entity-1');
+
+    const note = findMark(paragraph.child(1), 'endNoteLink');
+    expect(note?.attrs.notes[0].uuid).not.toBe('note-1');
+    // The reference to the endnote passage is the identity of ANOTHER
+    // passage and must not change.
+    expect(note?.attrs.notes[0].endNote).toBe('endnote-passage-1');
+  });
+
+  it('keeps one new identity for a mark split across text nodes', () => {
+    const result = regenerateSliceUuids(buildSlice());
+    const paragraph = result.content.child(0);
+
+    const firstSegment = findMark(paragraph.child(0), 'link');
+    const secondSegment = findMark(paragraph.child(1), 'link');
+
+    expect(firstSegment?.attrs.uuid).not.toBe('link-1');
+    expect(firstSegment?.attrs.uuid).toBe(secondSegment?.attrs.uuid);
+    expect(firstSegment?.attrs.href).toBe('https://84000.co');
+  });
+
+  it('preserves slice depths and generates distinct uuids per call', () => {
+    const first = regenerateSliceUuids(buildSlice());
+    const second = regenerateSliceUuids(buildSlice());
+
+    expect(first.openStart).toBe(1);
+    expect(first.openEnd).toBe(1);
+    expect(first.content.child(0).attrs.uuid).not.toBe(
+      second.content.child(0).attrs.uuid,
+    );
   });
 });

--- a/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
-import { Node } from '@tiptap/pm/model';
+import { Fragment, Mark, Node, Slice } from '@tiptap/pm/model';
 import { v4 as uuidv4 } from 'uuid';
 
 const DEPENDENT_ATTR_DEFAULTS: Record<string, unknown> = {
@@ -10,6 +10,9 @@ const DEPENDENT_ATTR_DEFAULTS: Record<string, unknown> = {
   hasIndent: false,
   hasParagraphIndent: false,
 };
+
+// Node attrs that hold annotation uuids of their own (parameter annotations).
+const PARAM_UUID_KEYS = ['leadingSpaceUuid', 'indentUuid'] as const;
 
 const hasUuidAttr = (node: Node) =>
   Object.prototype.hasOwnProperty.call(node.type.spec.attrs ?? {}, 'uuid');
@@ -25,6 +28,94 @@ const resetDependentAttrs = (node: Node, base: Record<string, unknown>) => {
   return attrs;
 };
 
+/**
+ * Regenerates every annotation identity in a pasted slice: node uuids, mark
+ * uuids, parameter-annotation uuids, mention `items[].uuid`, and endnote-link
+ * `notes[].uuid`.
+ *
+ * Without this, pasting a copied passage leaves two passages sharing a uuid —
+ * the save path collapses them into a Set and resolves the first match, so
+ * the pasted passage's edits are never saved — and duplicated annotation
+ * uuids upsert rows that steal `passage_uuid` from the original passage.
+ *
+ * Regeneration is memoized per source uuid so one logical mark split across
+ * several text nodes keeps a single (new) identity. Only clipboard pastes go
+ * through `transformPasted`; internal drag-moves keep their identity.
+ */
+export const regenerateSliceUuids = (slice: Slice): Slice => {
+  const uuidMap = new Map<string, string>();
+  const fresh = (old?: string | null): string => {
+    if (!old) {
+      return uuidv4();
+    }
+    let mapped = uuidMap.get(old);
+    if (!mapped) {
+      mapped = uuidv4();
+      uuidMap.set(old, mapped);
+    }
+    return mapped;
+  };
+
+  const mapMarks = (marks: readonly Mark[]): Mark[] =>
+    marks.map((mark) => {
+      let attrs = mark.attrs;
+      if (attrs.uuid != null) {
+        attrs = { ...attrs, uuid: fresh(attrs.uuid as string) };
+      }
+      if (Array.isArray(attrs.notes)) {
+        attrs = {
+          ...attrs,
+          notes: attrs.notes.map((note: { uuid?: string }) => ({
+            ...note,
+            uuid: fresh(note.uuid),
+          })),
+        };
+      }
+      return attrs === mark.attrs ? mark : mark.type.create(attrs);
+    });
+
+  const mapNode = (node: Node): Node => {
+    if (node.isText) {
+      return node.mark(mapMarks(node.marks));
+    }
+
+    let attrs = node.attrs;
+    if (hasUuidAttr(node)) {
+      attrs = { ...attrs, uuid: fresh(attrs.uuid as string | null) };
+    }
+    for (const key of PARAM_UUID_KEYS) {
+      if (attrs[key]) {
+        attrs = { ...attrs, [key]: fresh(attrs[key] as string) };
+      }
+    }
+    if (Array.isArray(attrs.items)) {
+      // Mention identity lives in attrs.items[].uuid, not attrs.uuid.
+      attrs = {
+        ...attrs,
+        items: attrs.items.map((item: { uuid?: string }) => ({
+          ...item,
+          uuid: fresh(item.uuid),
+        })),
+      };
+    }
+    return node.type.create(
+      attrs,
+      mapFragment(node.content),
+      mapMarks(node.marks),
+    );
+  };
+
+  const mapFragment = (fragment: Fragment): Fragment => {
+    const children: Node[] = [];
+    for (let i = 0; i < fragment.childCount; i++) {
+      children.push(mapNode(fragment.child(i)));
+    }
+    return Fragment.fromArray(children);
+  };
+
+  return new Slice(mapFragment(slice.content), slice.openStart, slice.openEnd);
+};
+
 export const EnsureUniqueUuids = Extension.create({
   name: 'ensureUniqueUuids',
 
@@ -32,6 +123,9 @@ export const EnsureUniqueUuids = Extension.create({
     return [
       new Plugin({
         key: new PluginKey('ensureUniqueUuids'),
+        props: {
+          transformPasted: regenerateSliceUuids,
+        },
         appendTransaction(transactions, _oldState, newState) {
           if (!transactions.some((tr) => tr.docChanged)) {
             return null;
@@ -40,7 +134,13 @@ export const EnsureUniqueUuids = Extension.create({
           const updates: Array<{ pos: number; attrs: Record<string, unknown> }> =
             [];
 
-          newState.doc.descendants((node, pos, parent, index) => {
+          // Doc-order duplicate scan: the first occurrence of a uuid keeps
+          // it; any later occurrence — adjacent or not — is regenerated.
+          // transformPasted already handles pastes, so this is the safety net
+          // for duplicates arriving by other routes (collab edge cases,
+          // stale drops).
+          const seen = new Set<string>();
+          newState.doc.descendants((node, pos) => {
             if (!hasUuidAttr(node)) {
               return true;
             }
@@ -53,11 +153,7 @@ export const EnsureUniqueUuids = Extension.create({
               return true;
             }
 
-            if (
-              parent &&
-              index > 0 &&
-              parent.child(index - 1).attrs.uuid === node.attrs.uuid
-            ) {
+            if (seen.has(node.attrs.uuid)) {
               updates.push({
                 pos,
                 attrs: resetDependentAttrs(node, {
@@ -65,6 +161,8 @@ export const EnsureUniqueUuids = Extension.create({
                   uuid: uuidv4(),
                 }),
               });
+            } else {
+              seen.add(node.attrs.uuid);
             }
 
             return true;

--- a/libs/lib-editing/src/lib/components/editor/save-bookkeeping.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/save-bookkeeping.spec.ts
@@ -1,0 +1,77 @@
+import {
+  beginSave,
+  filterReplacements,
+  restoreFailedSave,
+} from './save-bookkeeping';
+import { computeSavePayload } from './save-filter';
+
+describe('save bookkeeping', () => {
+  it('keeps edits typed during a successful save dirty', () => {
+    const dirty = new Set(['passage-1']);
+    const { inFlight, next } = beginSave(dirty);
+
+    // The user types into passage-2 while the network round-trip is pending.
+    next.add('passage-2');
+
+    // On success the in-flight set is discarded; the swapped set holds
+    // exactly the mid-flight edits.
+    expect(inFlight.has('passage-2')).toBe(false);
+    expect(Array.from(next)).toEqual(['passage-2']);
+  });
+
+  it('restores the union of attempted and mid-flight edits on failure', () => {
+    const dirty = new Set(['passage-1', 'passage-2']);
+    const { inFlight, next } = beginSave(dirty);
+    next.add('passage-2');
+    next.add('passage-3');
+
+    const restored = restoreFailedSave(inFlight, next);
+
+    expect(Array.from(restored).sort()).toEqual([
+      'passage-1',
+      'passage-2',
+      'passage-3',
+    ]);
+  });
+
+  it('excludes re-dirtied passages from server replacements', () => {
+    const replacements = [
+      { uuid: 'passage-1', content: 'server copy' },
+      { uuid: 'passage-2', content: 'server copy' },
+    ];
+    const residualDirty = new Set(['passage-2']);
+
+    expect(filterReplacements(replacements, residualDirty)).toEqual([
+      { uuid: 'passage-1', content: 'server copy' },
+    ]);
+  });
+
+  it('detects a passage deleted mid-flight on the next save', () => {
+    // Baseline snapshotted at save start includes passage-2; the user deletes
+    // it during the flight, so the live set no longer has it.
+    const baseline = { main: new Set(['passage-1', 'passage-2']) };
+    const current = { main: new Set(['passage-1']) };
+
+    const payload = computeSavePayload({
+      dirtyUuids: new Set(),
+      baseline,
+      current,
+    });
+
+    expect(payload.uuidsToDelete).toEqual(['passage-2']);
+    expect(payload.hasChanges).toBe(true);
+  });
+
+  it('detects a passage added mid-flight on the next save', () => {
+    const baseline = { main: new Set(['passage-1']) };
+    const current = { main: new Set(['passage-1', 'passage-new']) };
+
+    const payload = computeSavePayload({
+      dirtyUuids: new Set(),
+      baseline,
+      current,
+    });
+
+    expect(payload.uuidsToSave).toEqual(['passage-new']);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/save-bookkeeping.ts
+++ b/libs/lib-editing/src/lib/components/editor/save-bookkeeping.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure bookkeeping for the save lifecycle. A save serializes its payload
+ * synchronously, then awaits the network; edits typed during that await must
+ * survive. The contract:
+ *
+ * - `beginSave` swaps the live dirty set for a fresh one before any await, so
+ *   in-flight keystrokes land in the new set instead of being cleared by the
+ *   post-save bookkeeping.
+ * - On failure, `restoreFailedSave` unions the attempted set back in — nothing
+ *   was durably confirmed, so the next save retries everything.
+ * - On success, the caller keeps the swapped set as-is (it holds exactly the
+ *   edits made during the flight) and uses `filterReplacements` to keep the
+ *   server from overwriting passages the user has already re-edited.
+ */
+
+export const beginSave = (
+  dirtyUuids: Set<string>,
+): { inFlight: Set<string>; next: Set<string> } => ({
+  inFlight: dirtyUuids,
+  next: new Set<string>(),
+});
+
+export const restoreFailedSave = (
+  inFlight: Set<string>,
+  dirtiedDuringFlight: Set<string>,
+): Set<string> => {
+  const restored = new Set(inFlight);
+  dirtiedDuringFlight.forEach((uuid) => restored.add(uuid));
+  return restored;
+};
+
+export const filterReplacements = <T extends { uuid: string }>(
+  replacements: T[],
+  residualDirty: Set<string>,
+): T[] => replacements.filter((passage) => !residualDirty.has(passage.uuid));

--- a/libs/lib-editing/src/lib/exporters/annotation.ts
+++ b/libs/lib-editing/src/lib/exporters/annotation.ts
@@ -131,7 +131,7 @@ export const markAnnotationFromNode = (ctx: ExporterContext): Annotation[] => {
   node.marks.forEach((mark) => {
     const start = findNodePosition(ctx.root, mark.attrs.uuid, mark.type.name);
     if (start === undefined) {
-      return nodeNotFound(mark);
+      return nodeNotFound(mark, ctx.skipped);
     }
     const type = mark.type.name as AnnotationType;
     const annotation = EXPORTERS[type]?.({ ...ctx, mark, start });
@@ -163,10 +163,13 @@ export const annotationExportsFromNode = (
   // annotation. Ignore nodes without a uuid.
   if (!node.attrs.uuid) {
     if (blockAnnotation) {
-      console.warn(
+      console.error(
         `Node "${node.type.name}" is missing a uuid — its annotation was skipped. ` +
           'This is likely a timing issue where ensureUuids() was not called before export.',
       );
+      if (ctx.skipped) {
+        ctx.skipped.count++;
+      }
     }
   } else if (blockAnnotation) {
     if (Array.isArray(blockAnnotation)) {
@@ -179,7 +182,7 @@ export const annotationExportsFromNode = (
   node.content.forEach((child) => {
     const start = findNodePosition(root, child.attrs.uuid, child.type.name);
     if (start === undefined) {
-      return nodeNotFound(child);
+      return nodeNotFound(child, ctx.skipped);
     }
     annotations.push(
       ...annotationExportsFromNode({

--- a/libs/lib-editing/src/lib/exporters/export.ts
+++ b/libs/lib-editing/src/lib/exporters/export.ts
@@ -7,6 +7,13 @@ export type ExporterContext = {
   root: Node;
   start: number;
   mark?: Mark;
+  /**
+   * Shared collector counting annotations the exporters had to skip
+   * (unlocatable node/mark, missing uuid). A non-zero count marks the
+   * passage's annotation set incomplete so the save path preserves rows it
+   * would otherwise treat as deleted.
+   */
+  skipped?: { count: number };
 };
 
 export type Exporter<T> = (ctx: ExporterContext) => T | undefined;

--- a/libs/lib-editing/src/lib/exporters/paragraph.spec.ts
+++ b/libs/lib-editing/src/lib/exporters/paragraph.spec.ts
@@ -86,9 +86,9 @@ describe('paragraph exporter', () => {
 });
 
 describe('annotationExportsFromNode — null UUID guard', () => {
-  it('should produce no annotation and emit a warning when a paragraph node has no uuid', () => {
-    const warnSpy = jest
-      .spyOn(console, 'warn')
+  it('should produce no annotation and emit an error when a paragraph node has no uuid', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
       .mockImplementation(() => undefined);
 
     const parent = {
@@ -119,12 +119,12 @@ describe('annotationExportsFromNode — null UUID guard', () => {
     // The paragraph annotation must be absent — no annotation for a uuid-less node.
     expect(annotations.filter((a) => a.type === 'paragraph')).toHaveLength(0);
 
-    // A warning must be emitted so the issue is visible in development.
-    expect(warnSpy).toHaveBeenCalledWith(
+    // An error must be emitted so the issue is visible in development.
+    expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('missing a uuid'),
     );
 
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('should produce a paragraph annotation when the paragraph node has a valid uuid', () => {

--- a/libs/lib-editing/src/lib/exporters/util.ts
+++ b/libs/lib-editing/src/lib/exporters/util.ts
@@ -55,8 +55,14 @@ export const findNodePosition = (
   return targetFound ? textOffset : undefined;
 };
 
-export const nodeNotFound = (node: Node | Mark) => {
-  console.warn(
-    `Could not find position of node with uuid ${node.attrs.uuid} and type ${node.type.name}`,
+export const nodeNotFound = (
+  node: Node | Mark,
+  skipped?: { count: number },
+) => {
+  console.error(
+    `Could not find position of node with uuid ${node.attrs.uuid} and type ${node.type.name}; its annotation was not exported`,
   );
+  if (skipped) {
+    skipped.count++;
+  }
 };

--- a/libs/lib-editing/src/lib/passage.ts
+++ b/libs/lib-editing/src/lib/passage.ts
@@ -158,12 +158,14 @@ export const passageFromNode = (node: Node, workUuid: string): Passage => {
   const type = node.attrs.type;
   const toh = node.attrs.toh;
 
+  const skipped = { count: 0 };
   const ctx: ExporterContext = {
     passageUuid: uuid,
     node,
     parent: node,
     root: node,
     start: 0,
+    skipped,
   };
   const annotations = [
     ...parameterAnnotationFromNode(ctx),
@@ -172,7 +174,7 @@ export const passageFromNode = (node: Node, workUuid: string): Passage => {
   node.content.forEach((child) => {
     const start = findNodePosition(node, child.attrs.uuid, child.type.name);
     if (start === undefined) {
-      return nodeNotFound(child);
+      return nodeNotFound(child, skipped);
     }
     annotations.push(
       ...annotationExportsFromNode({
@@ -181,9 +183,22 @@ export const passageFromNode = (node: Node, workUuid: string): Passage => {
         parent: node,
         root: node,
         start,
+        skipped,
       }),
     );
   });
+
+  // A passage flagged invalid on load carries annotations that were never
+  // rendered (out of range or unplaceable), so its exported set is incomplete
+  // by construction.
+  const annotationsIncomplete = skipped.count > 0 || !!node.attrs.invalid;
+  if (annotationsIncomplete) {
+    console.error(
+      `Annotation export for passage ${uuid} is incomplete ` +
+        `(${skipped.count} skipped${node.attrs.invalid ? ', passage flagged invalid' : ''}); ` +
+        'its existing annotations will be preserved on save.',
+    );
+  }
 
   const passage: Passage = {
     uuid,
@@ -194,6 +209,7 @@ export const passageFromNode = (node: Node, workUuid: string): Passage => {
     content: node.textContent,
     toh,
     annotations,
+    ...(annotationsIncomplete ? { annotationsIncomplete } : {}),
   };
   return passage;
 };

--- a/libs/lib-editing/src/lib/round-trip.spec.ts
+++ b/libs/lib-editing/src/lib/round-trip.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@eightyfourthousand/data-access';
 import { blockFromPassage } from './block';
 import { annotationExportsFromNode } from './exporters/annotation';
+import { passageFromNode } from './passage';
 import type { TranslationEditorContentItem } from './components/editor';
 
 /**
@@ -176,5 +177,73 @@ describe('annotation round-trip', () => {
     for (const annotation of exported) {
       expect(knownTypes).toContain(annotation.type);
     }
+  });
+});
+
+describe('passageFromNode annotationsIncomplete flag', () => {
+  const buildBlock = (annotations: PassageDTO['annotations'] = []) => {
+    const passageDto = { ...dto, annotations };
+    const passage = passageFromDTO(
+      passageDto,
+      annotationsFromDTO(
+        passageDto.annotations || [],
+        passageDto.content.length,
+      ),
+    );
+    return JSON.parse(
+      JSON.stringify(blockFromPassage(passage)),
+    ) as TranslationEditorContentItem;
+  };
+
+  it('leaves the flag unset when every annotation exports', () => {
+    const block = buildBlock(dto.annotations);
+    dedupeMarkUuids(block);
+    const passage = passageFromNode(toFakeNode(block) as never, 'work-uuid-1');
+
+    expect(passage.annotationsIncomplete).toBeUndefined();
+    expect(passage.annotations.length).toBeGreaterThan(0);
+  });
+
+  it('sets the flag when a node with an exportable annotation lacks a uuid', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const block = buildBlock([]);
+    // Simulate the ensureUuids timing gap: the paragraph's uuid is missing at
+    // export time, so its block annotation cannot be exported.
+    delete block.content?.[0]?.attrs?.uuid;
+    const passage = passageFromNode(toFakeNode(block) as never, 'work-uuid-1');
+
+    expect(passage.annotationsIncomplete).toBe(true);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('sets the flag for passages flagged invalid on load', () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    // An out-of-range annotation is skipped on load and marks the passage
+    // invalid; the export set is incomplete by construction.
+    const block = buildBlock([
+      {
+        uuid: 'span-invalid',
+        passage_uuid: 'passage-uuid-1',
+        type: 'span',
+        start: 0,
+        end: 999,
+        content: [{ 'text-style': 'emphasis' }],
+      },
+    ]);
+    const passage = passageFromNode(toFakeNode(block) as never, 'work-uuid-1');
+
+    expect(passage.annotationsIncomplete).toBe(true);
+    consoleWarn.mockRestore();
+    consoleError.mockRestore();
   });
 });


### PR DESCRIPTION
### Summary

Phase 3 of the editor reliability pass: the save path no longer loses data silently. Save failures reach the user instead of returning success, edits typed during an in-flight save survive, pasting a passage regenerates its uuids so the copy actually saves, and exporter serialization gaps no longer delete stored annotations.

### Notes

- `savePassagesWithDeletions` writes are reordered (content first, renumbering after, delete-side renumbering only after the delete succeeds) and every step aborts loudly. All writes are idempotent, so a failed save converges on retry. Full atomicity still needs a Postgres function — tracked separately.
- `annotationsIncomplete` is a new optional field on `PassageInput` (codegen run); old clients keep current behavior.
- Worth a manual pass: type during a throttled save, and paste a passage non-adjacently → edit → save → reload.