### PR TITLE
Editor Cleanup, part 4: performance

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -25,6 +25,14 @@ import {
   filterReplacements,
   restoreFailedSave,
 } from './save-bookkeeping';
+import {
+  captureFragmentBaseline,
+  collectPassageUuids,
+  diffPassageUuids,
+  findObservedFragment,
+  shouldRescanFragment,
+  type FragmentBaseline,
+} from './observer-utils';
 
 interface EditorContextState {
   doc?: Doc;
@@ -124,7 +132,7 @@ export const EditorContextProvider = ({
   const isNavigatingRef = useRef(false);
   const isNormalizingForSaveRef = useRef(false);
   const clearedFragmentRef = useRef<XmlFragment | null>(null);
-  const lastObservedUuidsByFragmentRef = useRef<Map<XmlFragment, Set<string>>>(
+  const fragmentBaselinesRef = useRef<Map<XmlFragment, FragmentBaseline>>(
     new Map(),
   );
   const savedBaselineUuidsByEditorRef = useRef<PassageUuidRecord>({});
@@ -155,20 +163,6 @@ export const EditorContextProvider = ({
     [doc],
   );
 
-  const getFragmentUuids = useCallback((fragment: XmlFragment) => {
-    const uuids = new Set<string>();
-    for (let i = 0; i < fragment.length; i++) {
-      const child = fragment.get(i);
-      if (child instanceof XmlElement && child.nodeName === 'passage') {
-        const uuid = child.getAttribute('uuid');
-        if (uuid) {
-          uuids.add(uuid);
-        }
-      }
-    }
-    return uuids;
-  }, []);
-
   const getEditorUuids = useCallback((editor: Editor) => {
     const uuids = new Set<string>();
     editor.state.doc.descendants((node) => {
@@ -193,13 +187,13 @@ export const EditorContextProvider = ({
 
       const fragment = getFragment(key);
       if (fragment) {
-        lastObservedUuidsByFragmentRef.current.set(
+        fragmentBaselinesRef.current.set(
           fragment,
-          getFragmentUuids(fragment),
+          captureFragmentBaseline(fragment),
         );
       }
     },
-    [getEditorUuids, getFragment, getFragmentUuids],
+    [getEditorUuids, getFragment],
   );
 
   const observerFunction = useCallback(
@@ -207,100 +201,71 @@ export const EditorContextProvider = ({
       if (!txn.local) {
         return;
       }
+      if (isNavigatingRef.current || isNormalizingForSaveRef.current) {
+        return;
+      }
 
-      // Detect passage deletions by diffing the last observed UUIDs against
-      // the current fragment state.
-      // We walk up from any event target to find the observed XmlFragment rather than
-      // checking each event's target, because merge operations may only produce events
-      // targeting passage-level XmlElements (not the fragment itself).
-      // We intentionally avoid using Yjs `changes.deleted` because operations like
-      // splitPassage (replaceWith + insert) cause the binding to delete and re-create
-      // XmlElements internally, producing false positives.
-      if (
-        !isNavigatingRef.current &&
-        !isNormalizingForSaveRef.current &&
-        evts.length > 0
-      ) {
-        let fragment: XmlFragment | null = null;
-        let current: XmlFragment | XmlElement | null = evts[0].target;
-        while (current) {
-          if (
-            current instanceof XmlFragment &&
-            !(current instanceof XmlElement)
-          ) {
-            fragment = current;
-            break;
-          }
-          current = current.parent as XmlFragment | XmlElement | null;
-        }
-
+      // Detect passage additions/deletions by diffing the baseline UUIDs
+      // against the current fragment state — but only when the cheap gate
+      // says the passage set could have changed. Plain typing previously
+      // paid this O(passages) scan on every keystroke.
+      // We intentionally avoid deriving additions/deletions from Yjs
+      // `changes.deleted` directly because operations like splitPassage
+      // (replaceWith + insert) cause the binding to delete and re-create
+      // XmlElements internally, producing false positives; the deltas are
+      // only used as a rescan trigger, where a false positive is harmless.
+      // Additions must come from the scan because splitPassage creates
+      // XmlElements with attributes set pre-integration, so txn.changed
+      // never includes them.
+      if (evts.length > 0) {
+        const fragment = findObservedFragment(evts);
         if (fragment) {
-          const liveUuids = new Set<string>();
-          for (let i = 0; i < fragment.length; i++) {
-            const child = fragment.get(i);
-            if (child instanceof XmlElement && child.nodeName === 'passage') {
-              const uuid = child.getAttribute('uuid');
-              if (uuid) {
-                liveUuids.add(uuid);
+          const baseline = fragmentBaselinesRef.current.get(fragment);
+          if (shouldRescanFragment(evts, fragment, baseline)) {
+            const liveUuids = collectPassageUuids(fragment);
+
+            if (baseline && baseline.uuids.size > 0) {
+              const { added, hasDeleted } = diffPassageUuids(
+                baseline.uuids,
+                liveUuids,
+              );
+              added.forEach((uuid) => dirtyUuidsRef.current.add(uuid));
+              if (hasDeleted && !dirtyStore.isDirty) {
+                dirtyStore.setDirty(true);
               }
             }
-          }
 
-          const lastObservedUuidsForFragment =
-            lastObservedUuidsByFragmentRef.current.get(fragment);
-          if (
-            lastObservedUuidsForFragment &&
-            lastObservedUuidsForFragment.size > 0
-          ) {
-            const hasDeleted = Array.from(lastObservedUuidsForFragment).some(
-              (uuid) => !liveUuids.has(uuid),
-            );
-
-            // Detect new passages: UUIDs in the current fragment but not in
-            // the last observed fragment state.
-            // This catches passages created by splitPassage, where the Yjs
-            // binding creates XmlElements with attributes set during construction
-            // (pre-integration), so txn.changed never includes them.
-            liveUuids.forEach((uuid) => {
-              if (!lastObservedUuidsForFragment.has(uuid)) {
-                dirtyUuidsRef.current.add(uuid);
-              }
+            fragmentBaselinesRef.current.set(fragment, {
+              uuids: liveUuids,
+              length: fragment.length,
             });
-
-            if (hasDeleted && !dirtyStore.isDirty) {
-              dirtyStore.setDirty(true);
-            }
           }
-
-          lastObservedUuidsByFragmentRef.current.set(fragment, liveUuids);
         }
       }
 
-      if (!isNavigatingRef.current && !isNormalizingForSaveRef.current) {
-        txn.changed.forEach((_change, key) => {
-          // Start from key itself (not key.parent) so that structural changes
-          // directly on a passage XmlElement (e.g. children moved during merge)
-          // are detected. For leaf types like XmlText, nodeName is undefined so
-          // the walk-up proceeds to the parent as before.
-          let node = key as unknown as XmlElement;
-          while (node?.nodeName !== 'passage' && node?.parent) {
-            node = node.parent as XmlElement;
-          }
+      txn.changed.forEach((_change, key) => {
+        // Start from key itself (not key.parent) so that structural changes
+        // directly on a passage XmlElement (e.g. children moved during merge)
+        // are detected. For leaf types like XmlText, nodeName is undefined so
+        // the walk-up proceeds to the parent as before.
+        let node = key as unknown as XmlElement;
+        while (node?.nodeName !== 'passage' && node?.parent) {
+          node = node.parent as XmlElement;
+        }
 
-          const uuid = node?.getAttribute?.('uuid');
-          if (uuid) {
-            // Add directly to ref - no state update on every keystroke
-            dirtyUuidsRef.current.add(uuid);
-            // Only update dirty state if it's not already dirty
-            // This prevents re-renders on every keystroke after the first one
-            if (!dirtyStore.isDirty) {
-              dirtyStore.setDirty(true);
-            }
+        const uuid = node?.getAttribute?.('uuid');
+        if (uuid) {
+          // Add directly to ref - no state update on every keystroke
+          dirtyUuidsRef.current.add(uuid);
+          // Only update dirty state if it's not already dirty
+          // This prevents re-renders on every keystroke after the first one
+          if (!dirtyStore.isDirty) {
+            dirtyStore.setDirty(true);
           }
-        });
-      }
+        }
+      });
     },
-    [dirtyStore, getFragmentUuids],
+    [dirtyStore],
   );
 
   const startObserving = useCallback(
@@ -315,16 +280,16 @@ export const EditorContextProvider = ({
 
         if (observedFragment) {
           observedFragment.unobserveDeep(observerFunction);
-          lastObservedUuidsByFragmentRef.current.delete(observedFragment);
+          fragmentBaselinesRef.current.delete(observedFragment);
         }
 
-        // Pre-populate lastObservedUuidsByFragmentRef so the diff-based
-        // deletion detection has a baseline from the very first observer event.
+        // Pre-populate the fragment baseline so the diff-based deletion
+        // detection has a baseline from the very first observer event.
         // Without this, a merge that happens before any other edit would not be
         // detected because the ref would be empty and the diff would be skipped.
-        lastObservedUuidsByFragmentRef.current.set(
+        fragmentBaselinesRef.current.set(
           fragment,
-          getFragmentUuids(fragment),
+          captureFragmentBaseline(fragment),
         );
 
         fragment.observeDeep(observerFunction);
@@ -332,7 +297,7 @@ export const EditorContextProvider = ({
         refreshEditorBaseline(builder);
       }
     },
-    [getFragment, getFragmentUuids, observerFunction, refreshEditorBaseline],
+    [getFragment, observerFunction, refreshEditorBaseline],
   );
 
   const stopObserving = useCallback(
@@ -340,7 +305,7 @@ export const EditorContextProvider = ({
       const observedFragment = observedFragmentsByBuilderRef.current[builder];
       if (observedFragment) {
         observedFragment.unobserveDeep(observerFunction);
-        lastObservedUuidsByFragmentRef.current.delete(observedFragment);
+        fragmentBaselinesRef.current.delete(observedFragment);
         delete observedFragmentsByBuilderRef.current[builder];
       }
       delete savedBaselineUuidsByEditorRef.current[builder];
@@ -364,10 +329,10 @@ export const EditorContextProvider = ({
         // entry so other editors (e.g. endnotes) retain their baseline and
         // can still detect deletions.
         if (fragment) {
-          lastObservedUuidsByFragmentRef.current.delete(fragment);
+          fragmentBaselinesRef.current.delete(fragment);
           clearedFragmentRef.current = fragment;
         } else {
-          lastObservedUuidsByFragmentRef.current.clear();
+          fragmentBaselinesRef.current.clear();
         }
       }
 
@@ -377,10 +342,10 @@ export const EditorContextProvider = ({
       if (!navigating && clearedFragmentRef.current) {
         const f = clearedFragmentRef.current;
         clearedFragmentRef.current = null;
-        lastObservedUuidsByFragmentRef.current.set(f, getFragmentUuids(f));
+        fragmentBaselinesRef.current.set(f, captureFragmentBaseline(f));
       }
     },
-    [getFragmentUuids],
+    [],
   );
 
   const isNavigating = useCallback(() => isNavigatingRef.current, []);

--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -534,6 +534,16 @@ export const EditorContextProvider = ({
           isNormalizingForSaveRef.current = false;
         }
 
+        // Blur only the focused editor, once, to flush any pending IME
+        // composition into ProseMirror state before the docs are read —
+        // blurring editors that never had focus accomplishes nothing, and
+        // the old per-editor blur/focus pair stole focus across panels and
+        // scrolled the viewport on every save.
+        const focusedEntry = editorEntries.find(
+          ([, editor]) => editor.isFocused,
+        );
+        focusedEntry?.[1].commands.blur();
+
         editorEntries.forEach(([, editor]) => {
           const editorUuids = Array.from(getEditorUuids(editor)).filter(
             (uuid) => uuidsToSaveSet.has(uuid),
@@ -542,7 +552,6 @@ export const EditorContextProvider = ({
             return;
           }
 
-          editor.commands.blur();
           passages.push(
             ...passagesFromNodes({
               uuids: editorUuids,
@@ -550,8 +559,12 @@ export const EditorContextProvider = ({
               editor,
             }),
           );
-          editor.commands.focus();
         });
+
+        // Restore focus where it was, keeping the existing selection and
+        // without scrolling, before the network await so focus is never
+        // visibly lost.
+        focusedEntry?.[1].commands.focus(null, { scrollIntoView: false });
       }
       const result = await savePassages({
         client,

--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -82,6 +82,7 @@ export const PaginationProvider = ({
   content,
   fragment,
   isEditable = true,
+  autofocus = false,
   hasMoreAfter,
   onCreate,
   children,
@@ -93,6 +94,7 @@ export const PaginationProvider = ({
   content: TranslationEditorContent;
   fragment?: XmlFragment;
   isEditable?: boolean;
+  autofocus?: boolean;
   hasMoreAfter?: boolean;
   onCreate?: (params: { editor: Editor }) => void;
   children: ReactNode;
@@ -145,6 +147,7 @@ export const PaginationProvider = ({
     extensions,
     content,
     isEditable,
+    autofocus,
     onCreate: ({ editor }) => {
       setEndIsLoading(false);
       setIsEditorReady(true);

--- a/libs/lib-editing/src/lib/components/editor/TranslationBuilder.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationBuilder.tsx
@@ -11,6 +11,12 @@ import {
   removeAllEndnoteLinksForPassage,
   syncEndnoteLinkLabelsAcrossEditors,
 } from './extensions/EndNoteLink/endnote-utils';
+import {
+  collectPassageUuidsByType,
+  diffPassageUuidsByType,
+} from './endnote-tracking';
+
+const ENDNOTE_SYNC_DEBOUNCE_MS = 150;
 
 export const TranslationBuilder = ({
   content,
@@ -42,7 +48,7 @@ export const TranslationBuilder = ({
   // can be cleared during navigation.
   const passageUuidsByTypeRef = useRef<Record<string, Set<string>>>({});
   const debouncedSyncRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const pendingDeletedByTypeRef = useRef<Record<string, Set<string>>>({});
+  const baselineInvalidatedRef = useRef(false);
 
   useEffect(() => {
     (async () => {
@@ -84,93 +90,76 @@ export const TranslationBuilder = ({
 
         if (name === 'endnotes') {
           // Initialize known passage UUIDs grouped by type
-          const byType: Record<string, Set<string>> = {};
-          const doc = editor.state.doc;
-          for (let i = 0; i < doc.childCount; i++) {
-            const child = doc.child(i);
-            if (child.type.name === 'passage' && child.attrs.uuid) {
-              const pType = (child.attrs.type as string) || 'unknown';
-              (byType[pType] ??= new Set()).add(child.attrs.uuid);
-            }
-          }
-          passageUuidsByTypeRef.current = byType;
+          passageUuidsByTypeRef.current = collectPassageUuidsByType(
+            editor.state.doc,
+          );
 
-          const handleEndnotesUpdate = () => {
-            // Collect current passage UUIDs grouped by type (cheap)
-            const currentByType: Record<string, Set<string>> = {};
-            const doc = editor.state.doc;
-            for (let i = 0; i < doc.childCount; i++) {
-              const child = doc.child(i);
-              if (child.type.name === 'passage' && child.attrs.uuid) {
-                const pType = (child.attrs.type as string) || 'unknown';
-                (currentByType[pType] ??= new Set()).add(child.attrs.uuid);
-              }
+          // All traversal and diffing happens here, at most once per debounce
+          // window — a burst of keystrokes collapses to one diff against the
+          // pre-burst baseline, which by construction accumulates every
+          // addition and deletion since the last flush.
+          const flushEndnotesSync = () => {
+            debouncedSyncRef.current = undefined;
+            if (editor.isDestroyed) {
+              return;
             }
 
-            // Detect deleted and added passages per type (skip during
-            // navigation to avoid false positives from content replacement)
-            const deletedByType: Record<string, string[]> = {};
-            let hasAdded = false;
-            if (!isNavigating()) {
-              const prevByType = passageUuidsByTypeRef.current;
-              for (const pType of Object.keys(prevByType)) {
-                const prev = prevByType[pType];
-                const curr = currentByType[pType];
-                prev.forEach((uuid) => {
-                  if (!curr?.has(uuid)) {
-                    (deletedByType[pType] ??= []).push(uuid);
-                  }
-                });
-              }
-              if (!hasAdded) {
-                outer: for (const pType of Object.keys(currentByType)) {
-                  const prev = prevByType[pType];
-                  for (const uuid of currentByType[pType]) {
-                    if (!prev?.has(uuid)) {
-                      hasAdded = true;
-                      break outer;
-                    }
-                  }
-                }
-              }
+            // Diffing a half-replaced doc would report mass false deletions
+            // and strip endnote links from the other editors; retry after
+            // navigation settles and refresh the baseline without diffing.
+            if (isNavigating()) {
+              baselineInvalidatedRef.current = true;
+              debouncedSyncRef.current = setTimeout(
+                flushEndnotesSync,
+                ENDNOTE_SYNC_DEBOUNCE_MS,
+              );
+              return;
             }
 
-            // Always update the baseline so the next diff is accurate
+            const currentByType = collectPassageUuidsByType(editor.state.doc);
+            const skipDiff = baselineInvalidatedRef.current;
+            baselineInvalidatedRef.current = false;
+            const prevByType = passageUuidsByTypeRef.current;
             passageUuidsByTypeRef.current = currentByType;
+            if (skipDiff) {
+              return;
+            }
 
-            const hasDeleted = Object.keys(deletedByType).length > 0;
+            const { deletedByType, hasAdded } = diffPassageUuidsByType(
+              prevByType,
+              currentByType,
+            );
 
-            // Accumulate deletions and debounce the expensive sync work
-            // so rapid keystrokes don't trigger multiple full traversals
-            for (const [pType, uuids] of Object.entries(deletedByType)) {
-              const pending = (pendingDeletedByTypeRef.current[pType] ??=
-                new Set());
-              for (const uuid of uuids) {
-                pending.add(uuid);
+            const deletedEndnotes = deletedByType['endnotes'] ?? [];
+            if (deletedEndnotes.length) {
+              const frontEditor = getEditor('front');
+              const translationEditor = getEditor('translation');
+              for (const uuid of deletedEndnotes) {
+                if (frontEditor)
+                  removeAllEndnoteLinksForPassage(frontEditor, uuid);
+                if (translationEditor)
+                  removeAllEndnoteLinksForPassage(translationEditor, uuid);
               }
             }
 
-            if (hasDeleted || hasAdded) {
-              if (debouncedSyncRef.current) {
-                clearTimeout(debouncedSyncRef.current);
-              }
-              debouncedSyncRef.current = setTimeout(() => {
-                const pendingEndnotes =
-                  pendingDeletedByTypeRef.current['endnotes'];
-                if (pendingEndnotes?.size) {
-                  const frontEditor = getEditor('front');
-                  const translationEditor = getEditor('translation');
-                  for (const uuid of pendingEndnotes) {
-                    if (frontEditor)
-                      removeAllEndnoteLinksForPassage(frontEditor, uuid);
-                    if (translationEditor)
-                      removeAllEndnoteLinksForPassage(translationEditor, uuid);
-                  }
-                }
-                pendingDeletedByTypeRef.current = {};
-                syncEndnoteLinkLabelsAcrossEditors(editor, getEditor);
-              }, 150);
+            if (Object.keys(deletedByType).length > 0 || hasAdded) {
+              syncEndnoteLinkLabelsAcrossEditors(editor, getEditor);
             }
+          };
+
+          // O(1) per keystroke: record whether the baseline went stale and
+          // (re)arm the timer; the doc traversals run in the flush.
+          const handleEndnotesUpdate = () => {
+            if (isNavigating()) {
+              baselineInvalidatedRef.current = true;
+            }
+            if (debouncedSyncRef.current) {
+              clearTimeout(debouncedSyncRef.current);
+            }
+            debouncedSyncRef.current = setTimeout(
+              flushEndnotesSync,
+              ENDNOTE_SYNC_DEBOUNCE_MS,
+            );
           };
 
           editor.on('update', handleEndnotesUpdate);

--- a/libs/lib-editing/src/lib/components/editor/TranslationBuilder.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TranslationBuilder.tsx
@@ -80,6 +80,7 @@ export const TranslationBuilder = ({
       content={content}
       fragment={fragment}
       isEditable={isEditable}
+      autofocus={panel === 'main' && name === 'translation'}
       hasMoreAfter={hasMoreAfter}
       onCreate={({ editor }) => {
         setEditor(name, editor);

--- a/libs/lib-editing/src/lib/components/editor/endnote-tracking.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/endnote-tracking.spec.ts
@@ -1,0 +1,100 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import {
+  collectPassageUuidsByType,
+  diffPassageUuidsByType,
+} from './endnote-tracking';
+
+const fakeDoc = (
+  children: Array<{ type: string; uuid?: string; passageType?: string }>,
+): ProseMirrorNode =>
+  ({
+    childCount: children.length,
+    child: (i: number) => ({
+      type: { name: children[i].type },
+      attrs: { uuid: children[i].uuid, type: children[i].passageType },
+    }),
+  }) as unknown as ProseMirrorNode;
+
+describe('collectPassageUuidsByType', () => {
+  it('groups passage uuids by type and skips non-passages and uuid-less nodes', () => {
+    const doc = fakeDoc([
+      { type: 'passage', uuid: 'e-1', passageType: 'endnotes' },
+      { type: 'passage', uuid: 'e-2', passageType: 'endnotes' },
+      { type: 'passage', uuid: 'h-1', passageType: 'endnotesHeader' },
+      { type: 'passage', passageType: 'endnotes' },
+      { type: 'paragraph', uuid: 'not-a-passage' },
+    ]);
+
+    const byType = collectPassageUuidsByType(doc);
+
+    expect(Array.from(byType['endnotes'])).toEqual(['e-1', 'e-2']);
+    expect(Array.from(byType['endnotesHeader'])).toEqual(['h-1']);
+    expect(Object.keys(byType)).toHaveLength(2);
+  });
+
+  it('defaults missing passage types to unknown', () => {
+    const doc = fakeDoc([{ type: 'passage', uuid: 'p-1' }]);
+
+    expect(Array.from(collectPassageUuidsByType(doc)['unknown'])).toEqual([
+      'p-1',
+    ]);
+  });
+});
+
+describe('diffPassageUuidsByType', () => {
+  const byType = (entries: Record<string, string[]>) =>
+    Object.fromEntries(
+      Object.entries(entries).map(([key, uuids]) => [key, new Set(uuids)]),
+    );
+
+  it('reports deletions per type', () => {
+    const { deletedByType, hasAdded } = diffPassageUuidsByType(
+      byType({ endnotes: ['e-1', 'e-2'] }),
+      byType({ endnotes: ['e-2'] }),
+    );
+
+    expect(deletedByType).toEqual({ endnotes: ['e-1'] });
+    expect(hasAdded).toBe(false);
+  });
+
+  it('accumulates all deletions in a burst against the pre-burst baseline', () => {
+    // Two deletions happened across the debounce window; one diff against
+    // the pre-burst baseline reports both.
+    const { deletedByType } = diffPassageUuidsByType(
+      byType({ endnotes: ['e-1', 'e-2', 'e-3'] }),
+      byType({ endnotes: ['e-2'] }),
+    );
+
+    expect(deletedByType['endnotes'].sort()).toEqual(['e-1', 'e-3']);
+  });
+
+  it('reports additions without listing them', () => {
+    const { deletedByType, hasAdded } = diffPassageUuidsByType(
+      byType({ endnotes: ['e-1'] }),
+      byType({ endnotes: ['e-1', 'e-2'] }),
+    );
+
+    expect(deletedByType).toEqual({});
+    expect(hasAdded).toBe(true);
+  });
+
+  it('treats a vanished type as deletions and a new type as additions', () => {
+    const { deletedByType, hasAdded } = diffPassageUuidsByType(
+      byType({ endnotes: ['e-1'] }),
+      byType({ endnotesHeader: ['h-1'] }),
+    );
+
+    expect(deletedByType).toEqual({ endnotes: ['e-1'] });
+    expect(hasAdded).toBe(true);
+  });
+
+  it('reports no changes for identical sets', () => {
+    const { deletedByType, hasAdded } = diffPassageUuidsByType(
+      byType({ endnotes: ['e-1'] }),
+      byType({ endnotes: ['e-1'] }),
+    );
+
+    expect(deletedByType).toEqual({});
+    expect(hasAdded).toBe(false);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/endnote-tracking.ts
+++ b/libs/lib-editing/src/lib/components/editor/endnote-tracking.ts
@@ -1,0 +1,46 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+
+/**
+ * Collects top-level passage uuids grouped by passage type. Used by the
+ * endnotes editor to detect added/deleted note passages between debounced
+ * sync flushes.
+ */
+export const collectPassageUuidsByType = (
+  doc: ProseMirrorNode,
+): Record<string, Set<string>> => {
+  const byType: Record<string, Set<string>> = {};
+  for (let i = 0; i < doc.childCount; i++) {
+    const child = doc.child(i);
+    if (child.type.name === 'passage' && child.attrs.uuid) {
+      const pType = (child.attrs.type as string) || 'unknown';
+      (byType[pType] ??= new Set()).add(child.attrs.uuid);
+    }
+  }
+  return byType;
+};
+
+export const diffPassageUuidsByType = (
+  prev: Record<string, Set<string>>,
+  curr: Record<string, Set<string>>,
+): { deletedByType: Record<string, string[]>; hasAdded: boolean } => {
+  const deletedByType: Record<string, string[]> = {};
+  for (const pType of Object.keys(prev)) {
+    prev[pType].forEach((uuid) => {
+      if (!curr[pType]?.has(uuid)) {
+        (deletedByType[pType] ??= []).push(uuid);
+      }
+    });
+  }
+
+  let hasAdded = false;
+  outer: for (const pType of Object.keys(curr)) {
+    for (const uuid of curr[pType]) {
+      if (!prev[pType]?.has(uuid)) {
+        hasAdded = true;
+        break outer;
+      }
+    }
+  }
+
+  return { deletedByType, hasAdded };
+};

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
@@ -219,13 +219,6 @@ export const PassageNode = PassageNodeSSR.extend({
 
       const content = document.createElement('div');
       content.className = PASSAGE_CONTENT_CLASS;
-      // NOTE: do not add content-visibility here (or on the wrapper) as a
-      // rendering shortcut. Its implied paint containment clips the
-      // label/bookmark gutter chrome (negative offsets), and its layout
-      // containment stops the first child's top margin collapsing out,
-      // shifting the gutter chrome relative to the text. Off-screen
-      // rendering cost is addressed by windowed mounting in the
-      // editor-per-passage model (Local Persistence project) instead.
 
       inner.append(label, bookmark, content);
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
@@ -185,13 +185,6 @@ export const PassageNode = PassageNodeSSR.extend({
 
       const wrapper = document.createElement('div');
       wrapper.className = PASSAGE_WRAPPER_CLASS;
-      // Off-screen passages skip layout and paint entirely; the ProseMirror
-      // data model is untouched, so Yjs sync, dirty tracking, and save are
-      // unaffected. `auto` intrinsic sizing remembers the last rendered
-      // height (with a pre-first-render estimate) so scroll position stays
-      // stable as passages enter and leave the viewport.
-      wrapper.style.contentVisibility = 'auto';
-      wrapper.style.containIntrinsicSize = 'auto 8rem';
 
       const applyWrapperAttrs = (n: PMNode) => {
         if (n.attrs.uuid) wrapper.id = n.attrs.uuid;
@@ -225,6 +218,16 @@ export const PassageNode = PassageNodeSSR.extend({
 
       const content = document.createElement('div');
       content.className = PASSAGE_CONTENT_CLASS;
+      // Off-screen passage content skips layout and paint entirely; the
+      // ProseMirror data model is untouched, so Yjs sync, dirty tracking,
+      // and save are unaffected. `auto` intrinsic sizing remembers the last
+      // rendered height (with a pre-first-render estimate) so scroll
+      // position stays stable as passages enter and leave the viewport.
+      // Applied to the content hole rather than the wrapper: the label and
+      // bookmark hang in the left gutter via negative offsets, and the paint
+      // containment content-visibility implies would clip them.
+      content.style.contentVisibility = 'auto';
+      content.style.containIntrinsicSize = 'auto 8rem';
 
       inner.append(label, bookmark, content);
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
@@ -185,6 +185,13 @@ export const PassageNode = PassageNodeSSR.extend({
 
       const wrapper = document.createElement('div');
       wrapper.className = PASSAGE_WRAPPER_CLASS;
+      // Off-screen passages skip layout and paint entirely; the ProseMirror
+      // data model is untouched, so Yjs sync, dirty tracking, and save are
+      // unaffected. `auto` intrinsic sizing remembers the last rendered
+      // height (with a pre-first-render estimate) so scroll position stays
+      // stable as passages enter and leave the viewport.
+      wrapper.style.contentVisibility = 'auto';
+      wrapper.style.containIntrinsicSize = 'auto 8rem';
 
       const applyWrapperAttrs = (n: PMNode) => {
         if (n.attrs.uuid) wrapper.id = n.attrs.uuid;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageNode.ts
@@ -190,7 +190,8 @@ export const PassageNode = PassageNodeSSR.extend({
         if (n.attrs.uuid) wrapper.id = n.attrs.uuid;
         if (n.attrs.toh) wrapper.setAttribute('data-toh', n.attrs.toh);
         else wrapper.removeAttribute('data-toh');
-        if (n.attrs.type) wrapper.setAttribute('data-passage-type', n.attrs.type);
+        if (n.attrs.type)
+          wrapper.setAttribute('data-passage-type', n.attrs.type);
         else wrapper.removeAttribute('data-passage-type');
         if (n.attrs.invalid) wrapper.setAttribute('data-invalid', 'true');
         else wrapper.removeAttribute('data-invalid');
@@ -218,16 +219,13 @@ export const PassageNode = PassageNodeSSR.extend({
 
       const content = document.createElement('div');
       content.className = PASSAGE_CONTENT_CLASS;
-      // Off-screen passage content skips layout and paint entirely; the
-      // ProseMirror data model is untouched, so Yjs sync, dirty tracking,
-      // and save are unaffected. `auto` intrinsic sizing remembers the last
-      // rendered height (with a pre-first-render estimate) so scroll
-      // position stays stable as passages enter and leave the viewport.
-      // Applied to the content hole rather than the wrapper: the label and
-      // bookmark hang in the left gutter via negative offsets, and the paint
-      // containment content-visibility implies would clip them.
-      content.style.contentVisibility = 'auto';
-      content.style.containIntrinsicSize = 'auto 8rem';
+      // NOTE: do not add content-visibility here (or on the wrapper) as a
+      // rendering shortcut. Its implied paint containment clips the
+      // label/bookmark gutter chrome (negative offsets), and its layout
+      // containment stops the first child's top margin collapsing out,
+      // shifting the gutter chrome relative to the text. Off-screen
+      // rendering cost is addressed by windowed mounting in the
+      // editor-per-passage model (Local Persistence project) instead.
 
       inner.append(label, bookmark, content);
 

--- a/libs/lib-editing/src/lib/components/editor/hooks/useBlockEditor.ts
+++ b/libs/lib-editing/src/lib/components/editor/hooks/useBlockEditor.ts
@@ -17,18 +17,24 @@ export const useBlockEditor = ({
   content,
   extensions = [],
   isEditable = true,
+  // Off by default: multiple editors mount simultaneously (front,
+  // translation, endnotes, abbreviations) and each grabbing focus scrolls
+  // its container — last mount wins and the viewport jumps. Only the
+  // primary editor should opt in.
+  autofocus = false,
   onCreate,
   ...rest
 }: UseEditorOptions & {
   content: Content;
   extensions?: Extensions;
   isEditable?: boolean;
+  autofocus?: boolean;
 }) => {
   const editor = useEditor({
     extensions,
     immediatelyRender: false,
     shouldRerenderOnTransaction: false,
-    autofocus: true,
+    autofocus: autofocus ? 'start' : false,
     editable: isEditable,
     editorProps: {
       attributes: {
@@ -43,7 +49,9 @@ export const useBlockEditor = ({
     onCreate: (ctx) => {
       if (ctx.editor.isEmpty) {
         ctx.editor.commands.setContent(content);
-        ctx.editor.commands.focus('start', { scrollIntoView: true });
+        if (autofocus) {
+          ctx.editor.commands.focus('start', { scrollIntoView: true });
+        }
       }
       onCreate?.(ctx);
     },

--- a/libs/lib-editing/src/lib/components/editor/observer-utils.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/observer-utils.spec.ts
@@ -1,0 +1,166 @@
+import { Doc, XmlElement, XmlFragment, XmlText, YEvent } from 'yjs';
+import {
+  captureFragmentBaseline,
+  collectPassageUuids,
+  diffPassageUuids,
+  findObservedFragment,
+  shouldRescanFragment,
+} from './observer-utils';
+
+const passageElement = (uuid: string, text = 'content') => {
+  const passage = new XmlElement('passage');
+  passage.setAttribute('uuid', uuid);
+  const paragraph = new XmlElement('paragraph');
+  paragraph.insert(0, [new XmlText(text)]);
+  passage.insert(0, [paragraph]);
+  return passage;
+};
+
+const setup = (uuids: string[]) => {
+  const doc = new Doc();
+  const fragment = doc.getXmlFragment('translation');
+  doc.transact(() => {
+    fragment.insert(0, uuids.map((uuid) => passageElement(uuid)));
+  });
+
+  let captured: YEvent<XmlFragment | XmlElement>[] = [];
+  let rescan: boolean | undefined;
+  let baseline: ReturnType<typeof captureFragmentBaseline> | undefined;
+
+  // shouldRescanFragment may touch event.changes, which Yjs only allows
+  // INSIDE the observer callback (as the production observer does) — so the
+  // gate must be evaluated here, not after the handler returns.
+  fragment.observeDeep((events) => {
+    captured = events as YEvent<XmlFragment | XmlElement>[];
+    rescan = shouldRescanFragment(captured, fragment, baseline);
+  });
+
+  return {
+    doc,
+    fragment,
+    events: () => captured,
+    rescan: () => rescan,
+    setBaseline: (next: ReturnType<typeof captureFragmentBaseline>) => {
+      baseline = next;
+    },
+  };
+};
+
+describe('collectPassageUuids / captureFragmentBaseline', () => {
+  it('collects top-level passage uuids and records the fragment length', () => {
+    const { fragment } = setup(['p-1', 'p-2']);
+
+    const baseline = captureFragmentBaseline(fragment);
+
+    expect(Array.from(baseline.uuids).sort()).toEqual(['p-1', 'p-2']);
+    expect(baseline.length).toBe(2);
+  });
+
+  it('skips passages without a uuid', () => {
+    const { doc, fragment } = setup(['p-1']);
+    doc.transact(() => {
+      fragment.insert(1, [new XmlElement('passage')]);
+    });
+
+    expect(Array.from(collectPassageUuids(fragment))).toEqual(['p-1']);
+  });
+});
+
+describe('findObservedFragment', () => {
+  it('walks up from a nested event target to the root fragment', () => {
+    const { doc, fragment, events } = setup(['p-1']);
+
+    // A text edit deep inside a passage produces events targeting the
+    // nested XmlText, not the fragment.
+    doc.transact(() => {
+      const paragraph = (fragment.get(0) as XmlElement).get(0) as XmlElement;
+      (paragraph.get(0) as XmlText).insert(0, 'x');
+    });
+
+    expect(events().length).toBeGreaterThan(0);
+    expect(findObservedFragment(events())).toBe(fragment);
+  });
+
+  it('returns null for empty event lists', () => {
+    expect(findObservedFragment([])).toBeNull();
+  });
+});
+
+describe('shouldRescanFragment', () => {
+  it('does not rescan for a text-only edit', () => {
+    const { doc, fragment, rescan, setBaseline } = setup(['p-1', 'p-2']);
+    setBaseline(captureFragmentBaseline(fragment));
+
+    doc.transact(() => {
+      const paragraph = (fragment.get(0) as XmlElement).get(0) as XmlElement;
+      (paragraph.get(0) as XmlText).insert(0, 'typing');
+    });
+
+    expect(rescan()).toBe(false);
+  });
+
+  it('rescans when a passage is inserted', () => {
+    const { doc, fragment, rescan, setBaseline } = setup(['p-1']);
+    setBaseline(captureFragmentBaseline(fragment));
+
+    doc.transact(() => {
+      fragment.insert(1, [passageElement('p-2')]);
+    });
+
+    expect(rescan()).toBe(true);
+  });
+
+  it('rescans when a passage is deleted', () => {
+    const { doc, fragment, rescan, setBaseline } = setup(['p-1', 'p-2']);
+    setBaseline(captureFragmentBaseline(fragment));
+
+    doc.transact(() => {
+      fragment.delete(1, 1);
+    });
+
+    expect(rescan()).toBe(true);
+  });
+
+  it('rescans an equal-length top-level replace via fragment deltas', () => {
+    const { doc, fragment, rescan, setBaseline } = setup(['p-1', 'p-2']);
+    const baseline = captureFragmentBaseline(fragment);
+    setBaseline(baseline);
+
+    // Delete + insert in one transaction: length is unchanged, but the
+    // event targeting the fragment carries add/delete deltas.
+    doc.transact(() => {
+      fragment.delete(0, 1);
+      fragment.insert(0, [passageElement('p-replacement')]);
+    });
+
+    expect(fragment.length).toBe(baseline.length);
+    expect(rescan()).toBe(true);
+  });
+
+  it('rescans when there is no baseline yet', () => {
+    const { fragment } = setup(['p-1']);
+    expect(shouldRescanFragment([], fragment, undefined)).toBe(true);
+  });
+});
+
+describe('diffPassageUuids', () => {
+  it('reports additions and detects deletions', () => {
+    const { added, hasDeleted } = diffPassageUuids(
+      new Set(['p-1', 'p-2']),
+      new Set(['p-2', 'p-3']),
+    );
+
+    expect(added).toEqual(['p-3']);
+    expect(hasDeleted).toBe(true);
+  });
+
+  it('reports no changes for identical sets', () => {
+    const { added, hasDeleted } = diffPassageUuids(
+      new Set(['p-1']),
+      new Set(['p-1']),
+    );
+
+    expect(added).toEqual([]);
+    expect(hasDeleted).toBe(false);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/observer-utils.ts
+++ b/libs/lib-editing/src/lib/components/editor/observer-utils.ts
@@ -1,0 +1,101 @@
+import { XmlElement, XmlFragment, YEvent } from 'yjs';
+
+export interface FragmentBaseline {
+  uuids: Set<string>;
+  length: number;
+}
+
+export const collectPassageUuids = (fragment: XmlFragment): Set<string> => {
+  const uuids = new Set<string>();
+  for (let i = 0; i < fragment.length; i++) {
+    const child = fragment.get(i);
+    if (child instanceof XmlElement && child.nodeName === 'passage') {
+      const uuid = child.getAttribute('uuid');
+      if (uuid) {
+        uuids.add(uuid);
+      }
+    }
+  }
+  return uuids;
+};
+
+export const captureFragmentBaseline = (
+  fragment: XmlFragment,
+): FragmentBaseline => ({
+  uuids: collectPassageUuids(fragment),
+  length: fragment.length,
+});
+
+/**
+ * Walks up from the first event's target to the observed XmlFragment. Merge
+ * operations may only produce events targeting passage-level XmlElements
+ * (not the fragment itself), so the fragment must be found by ancestry
+ * rather than by checking each event's target.
+ */
+export const findObservedFragment = (
+  events: YEvent<XmlFragment | XmlElement>[],
+): XmlFragment | null => {
+  let current: XmlFragment | XmlElement | null = events[0]?.target ?? null;
+  while (current) {
+    if (current instanceof XmlFragment && !(current instanceof XmlElement)) {
+      return current;
+    }
+    current = current.parent as XmlFragment | XmlElement | null;
+  }
+  return null;
+};
+
+/**
+ * Cheap per-transaction gate for the O(passages) fragment scan. Plain typing
+ * produces events targeting nested XmlText/XmlElement nodes with the
+ * fragment length unchanged — no scan. Structural changes either change the
+ * top-level child count or produce an event on the fragment itself with
+ * add/delete deltas (the equal-length replace case), so a false negative is
+ * impossible for them; a false positive just runs one scan that finds
+ * nothing. `event.changes` is computed lazily by Yjs, so it is only touched
+ * for events targeting the fragment itself.
+ *
+ * Known benign gap: a uuid-attribute-only change (e.g. EnsureUniqueUuids
+ * re-stamping a duplicate) no longer refreshes the baseline immediately. The
+ * txn.changed walk still dirties the new uuid, save payloads derive from the
+ * per-editor ProseMirror baselines rather than this map, and the next
+ * structural scan reconciles the stale entry.
+ */
+export const shouldRescanFragment = (
+  events: YEvent<XmlFragment | XmlElement>[],
+  fragment: XmlFragment,
+  baseline: FragmentBaseline | undefined,
+): boolean => {
+  if (!baseline) {
+    return true;
+  }
+  if (fragment.length !== baseline.length) {
+    return true;
+  }
+  return events.some(
+    (event) =>
+      event.target === fragment &&
+      (event.changes.added.size > 0 || event.changes.deleted.size > 0),
+  );
+};
+
+export const diffPassageUuids = (
+  previous: Set<string>,
+  live: Set<string>,
+): { added: string[]; hasDeleted: boolean } => {
+  const added: string[] = [];
+  live.forEach((uuid) => {
+    if (!previous.has(uuid)) {
+      added.push(uuid);
+    }
+  });
+
+  let hasDeleted = false;
+  previous.forEach((uuid) => {
+    if (!live.has(uuid)) {
+      hasDeleted = true;
+    }
+  });
+
+  return { added, hasDeleted };
+};


### PR DESCRIPTION
### Summary

Next phase of the editor reliability pass: per-keystroke costs no longer scale with document size. The Yjs observer's O(all-passages) scan is gated behind structural-change detection, the endnotes editor's doc traversals move inside the debounce, and editors stop stealing focus on mount and on save.

### Notes

- The observer gate touches dirty tracking, which feeds save-time deletion. Worth a manual pass on a large text: split/merge/delete → undo → save, watching the payload for unexpected `deletedUuids`; typing should no longer show the fragment loop in a Performance trace.
- Benign delta (documented in `shouldRescanFragment`): uuid-restamp-only transactions don't refresh the fragment baseline until the next structural scan.