### PR TITLE
Translation data table improvements

### DIFF
--- a/apps/web-main/src/app/(DashboardLayout)/translations/editor/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/translations/editor/page.tsx
@@ -1,7 +1,7 @@
 import { TranslationsTable } from '@eightyfourthousand/lib-editing';
 import { H2 } from '@eightyfourthousand/design-system';
 import { createBuildGraphQLClient, getTranslationsMetadata } from '@eightyfourthousand/client-graphql/ssr';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 export const revalidate = 60;
 
@@ -13,7 +13,9 @@ const page = async () => {
     <div className="flex flex-row justify-center pt-0 pb-8 px-4 w-full bg-surface">
       <div className="w-full max-w-feed">
         <H2 className="text-primary">{'Translation Editor'}</H2>
-        <TranslationsTable works={works} />
+        <Suspense>
+          <TranslationsTable works={works} />
+        </Suspense>
       </div>
     </div>
   );

--- a/apps/web-main/src/app/(DashboardLayout)/translations/reader/page.tsx
+++ b/apps/web-main/src/app/(DashboardLayout)/translations/reader/page.tsx
@@ -1,7 +1,7 @@
 import { TranslationsTable } from '@eightyfourthousand/lib-editing';
 import { H2 } from '@eightyfourthousand/design-system';
 import { createBuildGraphQLClient, getTranslationsMetadata } from '@eightyfourthousand/client-graphql/ssr';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 export const revalidate = 60;
 
@@ -13,7 +13,9 @@ const page = async () => {
     <div className="flex flex-row justify-center pt-0 pb-8 px-4 w-full bg-surface">
       <div className="w-full max-w-feed">
         <H2 className="text-primary">{'The Reading Room'}</H2>
-        <TranslationsTable works={works} />
+        <Suspense>
+          <TranslationsTable works={works} />
+        </Suspense>
       </div>
     </div>
   );

--- a/libs/client-graphql/src/lib/functions/get-translations-metadata.ts
+++ b/libs/client-graphql/src/lib/functions/get-translations-metadata.ts
@@ -1,7 +1,7 @@
 import type { GraphQLClient } from 'graphql-request';
 import { gql } from 'graphql-request';
 import type { Work } from '@eightyfourthousand/data-access';
-import { worksFromGraphQL } from '../mappers';
+import { worksFromGraphQL, type GraphQLWork } from '../mappers';
 
 const GET_ALL_WORKS = gql`
   query GetAllWorks($cursor: String, $limit: Int) {
@@ -15,6 +15,13 @@ const GET_ALL_WORKS = gql`
         pages
         restriction
         section
+        imprint {
+          mainTitles {
+            tibetan
+            wylie
+            sanskrit
+          }
+        }
       }
       pageInfo {
         nextCursor
@@ -23,17 +30,6 @@ const GET_ALL_WORKS = gql`
     }
   }
 `;
-
-type GraphQLWork = {
-  uuid: string;
-  title: string;
-  toh: string[];
-  publicationDate: string;
-  publicationVersion: string;
-  pages: number;
-  restriction: boolean;
-  section: string;
-};
 
 type GetAllWorksResponse = {
   works: {

--- a/libs/client-graphql/src/lib/generated/graphql.ts
+++ b/libs/client-graphql/src/lib/generated/graphql.ts
@@ -904,7 +904,7 @@ export type TocFieldsFragment = { __typename?: 'Toc', frontMatter: Array<(
     & TocEntryNestedFragment
   )> };
 
-export type WorkFieldsFragment = { __typename?: 'Work', uuid: string, title: string, toh: Array<string>, publicationDate?: string | null, publicationVersion: string, pages: number, restriction: boolean, section: string };
+export type WorkFieldsFragment = { __typename?: 'Work', uuid: string, title: string, toh: Array<string>, publicationDate?: string | null, publicationVersion: string, pages: number, restriction: boolean, section: string, imprint?: { __typename?: 'Imprint', mainTitles?: { __typename?: 'TitlesByLanguage', tibetan?: string | null, wylie?: string | null, sanskrit?: string | null } | null } | null };
 
 export type LookupQueryVariables = Exact<{
   toh?: InputMaybe<Scalars['String']['input']>;
@@ -1211,6 +1211,13 @@ export const WorkFieldsFragmentDoc = gql`
   pages
   restriction
   section
+  imprint {
+    mainTitles {
+      tibetan
+      wylie
+      sanskrit
+    }
+  }
 }
     `;
 export const LookupDocument = gql`

--- a/libs/client-graphql/src/lib/graphql/fragments/work.graphql
+++ b/libs/client-graphql/src/lib/graphql/fragments/work.graphql
@@ -7,4 +7,11 @@ fragment WorkFields on Work {
   pages
   restriction
   section
+  imprint {
+    mainTitles {
+      tibetan
+      wylie
+      sanskrit
+    }
+  }
 }

--- a/libs/client-graphql/src/lib/mappers/work.ts
+++ b/libs/client-graphql/src/lib/mappers/work.ts
@@ -7,11 +7,18 @@ export type GraphQLWork = {
   uuid: string;
   title: string;
   toh: string[];
-  publicationDate: string;
+  publicationDate: string | null;
   publicationVersion: string;
   pages: number;
   restriction: boolean;
   section: string;
+  imprint?: {
+    mainTitles?: {
+      tibetan?: string | null;
+      wylie?: string | null;
+      sanskrit?: string | null;
+    } | null;
+  } | null;
 };
 
 /**
@@ -22,7 +29,12 @@ export function workFromGraphQL(gqlWork: GraphQLWork): Work {
     uuid: gqlWork.uuid,
     title: gqlWork.title,
     toh: gqlWork.toh as TohokuCatalogEntry[],
-    publicationDate: new Date(gqlWork.publicationDate),
+    tibetanTitle: gqlWork.imprint?.mainTitles?.tibetan ?? undefined,
+    wylieTitle: gqlWork.imprint?.mainTitles?.wylie ?? undefined,
+    sanskritTitle: gqlWork.imprint?.mainTitles?.sanskrit ?? undefined,
+    publicationDate: gqlWork.publicationDate
+      ? new Date(gqlWork.publicationDate)
+      : undefined,
     publicationVersion: gqlWork.publicationVersion as SemVer,
     pages: gqlWork.pages,
     restriction: gqlWork.restriction,

--- a/libs/data-access/src/lib/types/work.ts
+++ b/libs/data-access/src/lib/types/work.ts
@@ -6,6 +6,9 @@ export type Work = {
   title: string;
   description?: string;
   toh: TohokuCatalogEntry[];
+  tibetanTitle?: string;
+  wylieTitle?: string;
+  sanskritTitle?: string;
   publicationDate?: Date;
   publicationVersion: SemVer;
   pages: number;

--- a/libs/design-system/src/lib/Table/DataTable/DataTable.stories.tsx
+++ b/libs/design-system/src/lib/Table/DataTable/DataTable.stories.tsx
@@ -137,4 +137,29 @@ export const Default: Story = {
   ),
 };
 
+const MANY_ROWS: InvoiceRow[] = Array.from({ length: 200 }, (_, i) => ({
+  uuid: `${i + 1}`,
+  invoice: `INV${`${i + 1}`.padStart(3, '0')}`,
+  status: i % 3 === 0 ? 'Unpaid' : 'Paid',
+  method: (['Credit Card', 'Transfer', 'Cash'] as const)[i % 3],
+  amount: 100 + (i % 17) * 25,
+}));
+
+export const InfiniteScroll: Story = {
+  render: (_props) => (
+    <DataTable
+      name="invoices"
+      data={MANY_ROWS}
+      columns={COLUMNS}
+      visibility={{ uuid: false }}
+      infiniteScroll
+      filters={(table) => (
+        <div className="flex gap-2">
+          <FuzzyGlobalFilter table={table} placeholder="Search invoices..." />
+        </div>
+      )}
+    />
+  ),
+};
+
 export default meta;

--- a/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
+++ b/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
@@ -12,6 +12,7 @@ import { ReactElement, useEffect, useState } from 'react';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { DataTableColumn, DataTableRow, useDataTable } from '../hooks';
 import { FilterResultsBanner } from '../FilterResultsBanner/FilterResultsBanner';
+import { InfiniteScrollFooter } from '../InfiniteScrollFooter/InfiniteScrollFooter';
 import {
   Table,
   TableBody,
@@ -32,6 +33,7 @@ export const DataTable = <T extends DataTableRow>({
   globalFilter,
   className,
   filters,
+  infiniteScroll = false,
 }: {
   name: string;
   data: T[];
@@ -42,6 +44,7 @@ export const DataTable = <T extends DataTableRow>({
   globalFilter?: string;
   className?: string;
   filters?: (table: HeadlessTable<T>) => ReactElement;
+  infiniteScroll?: boolean;
 }) => {
   const [columnClasses, setColumnClasses] = useState<{ [key: string]: string }>(
     {},
@@ -71,7 +74,9 @@ export const DataTable = <T extends DataTableRow>({
     columns,
     visibility,
     sorting,
-    pagination,
+    pagination:
+      pagination ??
+      (infiniteScroll ? { pageIndex: 0, pageSize: 50 } : undefined),
     globalFilter,
   });
 
@@ -145,7 +150,11 @@ export const DataTable = <T extends DataTableRow>({
           </TableBody>
         </Table>
       </div>
-      <TablePagination table={table} />
+      {infiniteScroll ? (
+        <InfiniteScrollFooter table={table} />
+      ) : (
+        <TablePagination table={table} />
+      )}
     </div>
   );
 };

--- a/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
+++ b/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
@@ -102,7 +102,7 @@ export const DataTable = <T extends DataTableRow>({
       )}
       <div
         className={cn(
-          'overflow-hidden rounded-2xl border shadow-md',
+          'overflow-hidden rounded-2xl border shadow-md bg-background',
           className,
         )}
       >

--- a/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
+++ b/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
@@ -2,6 +2,7 @@
 
 import {
   Cell,
+  ColumnFiltersState,
   Table as HeadlessTable,
   PaginationState,
   SortingState,
@@ -10,7 +11,12 @@ import {
 } from '@tanstack/react-table';
 import { ReactElement, useEffect, useState } from 'react';
 import { cn } from '@eightyfourthousand/lib-utils';
-import { DataTableColumn, DataTableRow, useDataTable } from '../hooks';
+import {
+  DataTableColumn,
+  DataTableRow,
+  DataTableState,
+  useDataTable,
+} from '../hooks';
 import { FilterResultsBanner } from '../FilterResultsBanner/FilterResultsBanner';
 import { InfiniteScrollFooter } from '../InfiniteScrollFooter/InfiniteScrollFooter';
 import {
@@ -31,6 +37,8 @@ export const DataTable = <T extends DataTableRow>({
   sorting,
   pagination,
   globalFilter,
+  columnFilters,
+  onStateChange,
   className,
   filters,
   infiniteScroll = false,
@@ -42,6 +50,8 @@ export const DataTable = <T extends DataTableRow>({
   sorting?: SortingState;
   pagination?: PaginationState;
   globalFilter?: string;
+  columnFilters?: ColumnFiltersState;
+  onStateChange?: (state: DataTableState) => void;
   className?: string;
   filters?: (table: HeadlessTable<T>) => ReactElement;
   infiniteScroll?: boolean;
@@ -78,6 +88,8 @@ export const DataTable = <T extends DataTableRow>({
       pagination ??
       (infiniteScroll ? { pageIndex: 0, pageSize: 50 } : undefined),
     globalFilter,
+    columnFilters,
+    onStateChange,
   });
 
   return (

--- a/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
+++ b/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
@@ -102,11 +102,11 @@ export const DataTable = <T extends DataTableRow>({
       )}
       <div
         className={cn(
-          'overflow-hidden rounded-2xl border shadow-md bg-background',
+          'overflow-hidden rounded-2xl border shadow-md',
           className,
         )}
       >
-        <Table>
+        <Table className="bg-background">
           <TableHeader className="sticky top-0">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>

--- a/libs/design-system/src/lib/Table/FuzzyGlobalFilter/FuzzyGlobalFilter.tsx
+++ b/libs/design-system/src/lib/Table/FuzzyGlobalFilter/FuzzyGlobalFilter.tsx
@@ -1,5 +1,5 @@
 import { removeDiacritics } from '@eightyfourthousand/lib-utils';
-import { rankItem } from '@tanstack/match-sorter-utils';
+import { rankItem, RankingInfo } from '@tanstack/match-sorter-utils';
 import { FilterMeta, Row, RowData, Table } from '@tanstack/react-table';
 import { DebounceLevel, Input } from '../../Input/Input';
 
@@ -37,3 +37,16 @@ export const fuzzyFilterFn = <T extends RowData>(
   addMeta({ itemRank });
   return itemRank.passed && itemRank.rank > 2;
 };
+
+/**
+ * The best match rank `fuzzyFilterFn` recorded for a row across its columns.
+ * Only ranks up to the first passing column are recorded, since global
+ * filtering stops evaluating a row's columns once one passes.
+ */
+export const globalFilterRank = <T extends RowData>(row: Row<T>): number =>
+  Math.max(
+    0,
+    ...Object.values(row.columnFiltersMeta).map(
+      (meta) => (meta as { itemRank?: RankingInfo }).itemRank?.rank ?? 0,
+    ),
+  );

--- a/libs/design-system/src/lib/Table/FuzzyGlobalFilter/FuzzyGlobalFilter.tsx
+++ b/libs/design-system/src/lib/Table/FuzzyGlobalFilter/FuzzyGlobalFilter.tsx
@@ -1,6 +1,7 @@
 import { removeDiacritics } from '@eightyfourthousand/lib-utils';
 import { rankItem, RankingInfo } from '@tanstack/match-sorter-utils';
 import { FilterMeta, Row, RowData, Table } from '@tanstack/react-table';
+import { XIcon } from 'lucide-react';
 import { DebounceLevel, Input } from '../../Input/Input';
 
 export const FuzzyGlobalFilter = <T extends RowData>({
@@ -12,14 +13,27 @@ export const FuzzyGlobalFilter = <T extends RowData>({
   placeholder: string;
   delay?: DebounceLevel;
 }) => {
+  const value = table.getState().globalFilter ?? '';
   return (
-    <Input
-      placeholder={placeholder}
-      value={table.getState().globalFilter ?? ''}
-      onChange={(event) => table.setGlobalFilter(event.target.value)}
-      className="min-w-sm md:max-w-md"
-      delay={delay}
-    />
+    <div className="relative min-w-sm md:max-w-md">
+      <Input
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => table.setGlobalFilter(event.target.value)}
+        className={value ? 'pr-9' : undefined}
+        delay={delay}
+      />
+      {value && (
+        <button
+          type="button"
+          aria-label="Clear search"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground hover:cursor-pointer"
+          onClick={() => table.setGlobalFilter('')}
+        >
+          <XIcon className="size-4" />
+        </button>
+      )}
+    </div>
   );
 };
 

--- a/libs/design-system/src/lib/Table/InfiniteScrollFooter/InfiniteScrollFooter.spec.tsx
+++ b/libs/design-system/src/lib/Table/InfiniteScrollFooter/InfiniteScrollFooter.spec.tsx
@@ -1,0 +1,94 @@
+import { act, render, screen } from '@testing-library/react';
+import { DataTable } from '../DataTable/DataTable';
+import { DataTableColumn } from '../hooks';
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  callback: IntersectionObserverCallback;
+  observedElements = new Set<Element>();
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe = (element: Element) => {
+    this.observedElements.add(element);
+  };
+
+  disconnect = () => {
+    this.observedElements.clear();
+  };
+
+  unobserve = (element: Element) => {
+    this.observedElements.delete(element);
+  };
+}
+
+const emitIntersection = () => {
+  const observer = MockIntersectionObserver.instances.at(-1);
+
+  if (!observer) {
+    throw new Error('No IntersectionObserver instance was created.');
+  }
+
+  const target = observer.observedElements.values().next().value as Element;
+  act(() => {
+    observer.callback(
+      [{ target, isIntersecting: true } as IntersectionObserverEntry],
+      observer as unknown as IntersectionObserver,
+    );
+  });
+};
+
+type Row = { uuid: string; title: string };
+
+const columns: DataTableColumn<Row>[] = [
+  {
+    id: 'title',
+    accessorKey: 'title',
+    header: () => 'Title',
+  },
+];
+
+const rows: Row[] = Array.from({ length: 120 }, (_, i) => ({
+  uuid: `uuid-${i}`,
+  title: `Work ${i}`,
+}));
+
+const countBodyRows = () => screen.getAllByRole('row').length - 1;
+
+describe('DataTable with infiniteScroll', () => {
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    window.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  });
+
+  it('renders more rows as the sentinel intersects and stops at the end', () => {
+    render(
+      <DataTable name="works" data={rows} columns={columns} infiniteScroll />,
+    );
+
+    expect(countBodyRows()).toBe(50);
+
+    emitIntersection();
+    expect(countBodyRows()).toBe(100);
+
+    emitIntersection();
+    expect(countBodyRows()).toBe(120);
+
+    const observer = MockIntersectionObserver.instances.at(-1);
+    expect(observer?.observedElements.size).toBe(0);
+  });
+
+  it('does not render numbered pagination', () => {
+    render(
+      <DataTable name="works" data={rows} columns={columns} infiniteScroll />,
+    );
+
+    expect(screen.queryByText('Next')).toBeNull();
+    expect(screen.queryByText('Previous')).toBeNull();
+  });
+});

--- a/libs/design-system/src/lib/Table/InfiniteScrollFooter/InfiniteScrollFooter.tsx
+++ b/libs/design-system/src/lib/Table/InfiniteScrollFooter/InfiniteScrollFooter.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { RowData, Table } from '@tanstack/react-table';
+import { useEffect, useRef } from 'react';
+
+const DEFAULT_STEP = 50;
+
+/**
+ * Sentinel that grows the table's page size as it scrolls into view,
+ * turning client-side pagination into infinite scroll. Renders nothing
+ * once every row is visible.
+ */
+export const InfiniteScrollFooter = <T extends RowData>({
+  table,
+  step = DEFAULT_STEP,
+}: {
+  table: Table<T>;
+  step?: number;
+}) => {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const totalRows = table.getPrePaginationRowModel().rows.length;
+  const { pageSize } = table.getState().pagination;
+  const hasMore = pageSize < totalRows;
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasMore || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          table.setPageSize(pageSize + step);
+        }
+      },
+      { rootMargin: '400px' },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [table, pageSize, step, hasMore]);
+
+  return hasMore ? <div ref={sentinelRef} className="h-px" /> : null;
+};

--- a/libs/design-system/src/lib/Table/hooks/useDataTable.ts
+++ b/libs/design-system/src/lib/Table/hooks/useDataTable.ts
@@ -3,6 +3,7 @@
 import {
   Cell,
   ColumnDef,
+  ColumnFiltersState,
   PaginationState,
   RowData,
   SortingState,
@@ -15,13 +16,18 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { fuzzyFilterFn } from '../FuzzyGlobalFilter/FuzzyGlobalFilter';
 
 export type DataTableRow = RowData & { uuid: string };
 export type DataTableColumn<T extends DataTableRow> = ColumnDef<T> & {
   className?: string;
   onCellClick?: (row: Cell<T, unknown>) => void;
+};
+export type DataTableState = {
+  globalFilter: string;
+  sorting: SortingState;
+  columnFilters: ColumnFiltersState;
 };
 
 export const useDataTable = <T extends DataTableRow>({
@@ -31,6 +37,8 @@ export const useDataTable = <T extends DataTableRow>({
   sorting: sortingInput = [],
   pagination: paginationInput = { pageIndex: 0, pageSize: 12 },
   globalFilter: globalFilterInput = '',
+  columnFilters: columnFiltersInput = [],
+  onStateChange,
 }: {
   data: T[];
   columns: DataTableColumn<T>[];
@@ -38,6 +46,8 @@ export const useDataTable = <T extends DataTableRow>({
   sorting?: SortingState;
   pagination?: PaginationState;
   globalFilter?: string;
+  columnFilters?: ColumnFiltersState;
+  onStateChange?: (state: DataTableState) => void;
 }) => {
   const [rowSelection, setRowSelection] = useState({});
   const [columnVisibility, setColumnVisibility] =
@@ -45,6 +55,12 @@ export const useDataTable = <T extends DataTableRow>({
   const [globalFilter, setGlobalFilter] = useState(globalFilterInput);
   const [sorting, setSorting] = useState<SortingState>(sortingInput);
   const [pagination, setPagination] = useState(paginationInput);
+  const [columnFilters, setColumnFilters] =
+    useState<ColumnFiltersState>(columnFiltersInput);
+
+  useEffect(() => {
+    onStateChange?.({ globalFilter, sorting, columnFilters });
+  }, [onStateChange, globalFilter, sorting, columnFilters]);
 
   const table = useReactTable({
     data,
@@ -55,6 +71,7 @@ export const useDataTable = <T extends DataTableRow>({
       globalFilter,
       rowSelection,
       pagination,
+      columnFilters,
     },
     getRowId: (row) => row.uuid,
     enableRowSelection: true,
@@ -63,6 +80,7 @@ export const useDataTable = <T extends DataTableRow>({
     onColumnVisibilityChange: setColumnVisibility,
     onGlobalFilterChange: setGlobalFilter,
     onPaginationChange: setPagination,
+    onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/libs/design-system/src/lib/Table/index.ts
+++ b/libs/design-system/src/lib/Table/index.ts
@@ -5,6 +5,7 @@ export * from './PaginationEllipsis/PaginationEllipsis';
 export * from './FilterDropdown/FilterDropdown';
 export * from './FilterPopover/FilterPopover';
 export * from './FilterResultsBanner/FilterResultsBanner';
+export * from './InfiniteScrollFooter/InfiniteScrollFooter';
 export * from './SortableHeader/SortableHeader';
 export * from './SortIcon/SortIcon';
 export * from './Table';

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
@@ -14,6 +14,7 @@ jest.mock('next/navigation', () => ({
 beforeEach(() => {
   mockSearchParams = new URLSearchParams();
   window.history.replaceState(null, '', '/translations/reader');
+  window.localStorage.clear();
 });
 
 const work = (overrides: Partial<Work>): Work => ({
@@ -165,7 +166,7 @@ describe('TranslationsTable', () => {
     ]);
   });
 
-  it('writes search and filter state back to the URL', async () => {
+  it('writes search and filter state back to the URL and localStorage', async () => {
     renderTable();
     search('toh95');
     fireEvent.click(screen.getByRole('switch', { name: 'Published only' }));
@@ -174,6 +175,59 @@ describe('TranslationsTable', () => {
       const params = new URLSearchParams(window.location.search);
       expect(params.get('q')).toBe('toh95');
       expect(params.get('published')).toBe('1');
+    });
+    expect(
+      window.localStorage.getItem('translations-table:/translations/reader'),
+    ).toBe('q=toh95&published=1');
+  });
+
+  it('restores state from localStorage when the URL has none', () => {
+    window.localStorage.setItem(
+      'translations-table:/translations/reader',
+      'q=toh95&published=1',
+    );
+    renderTable();
+
+    expect(bodyRowTitles()).toEqual([
+      expect.stringContaining('The Play in Full'),
+    ]);
+  });
+
+  it('prefers URL state over localStorage', () => {
+    window.localStorage.setItem(
+      'translations-table:/translations/reader',
+      'q=toh95',
+    );
+    mockSearchParams = new URLSearchParams('q=toh12');
+    renderTable();
+
+    expect(bodyRowTitles()).toEqual([
+      expect.stringContaining('A Multitude of Buddhas'),
+      expect.stringContaining('Ornament of the Light of Awareness'),
+    ]);
+  });
+
+  it('clears the search when the clear button is clicked', async () => {
+    renderTable();
+    search('toh95');
+
+    await waitFor(() => {
+      expect(bodyRowTitles()).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+
+    await waitFor(() => {
+      expect(bodyRowTitles()).toHaveLength(4);
+    });
+    const input = screen.getByPlaceholderText(
+      'Search translations...',
+    ) as HTMLInputElement;
+    expect(input.value).toBe('');
+    await waitFor(() => {
+      expect(
+        window.localStorage.getItem('translations-table:/translations/reader'),
+      ).toBeNull();
     });
   });
 });

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { TooltipProvider } from '@eightyfourthousand/design-system';
+import { Work } from '@eightyfourthousand/data-access';
+import { TranslationsTable } from './TranslationTable';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => '/translations/reader',
+}));
+
+const work = (overrides: Partial<Work>): Work => ({
+  uuid: crypto.randomUUID(),
+  title: 'Untitled',
+  toh: ['toh1'],
+  publicationDate: new Date('2024-01-15'),
+  publicationVersion: '1.0.0',
+  pages: 10,
+  restriction: false,
+  section: 'Discourses',
+  ...overrides,
+});
+
+const WORKS: Work[] = [
+  work({
+    title: 'The Play in Full',
+    toh: ['toh95'],
+    tibetanTitle: 'རྒྱ་ཆེར་རོལ་པ།',
+    wylieTitle: 'rgya cher rol pa',
+    sanskritTitle: 'Lalitavistara',
+  }),
+  work({
+    title: 'A Multitude of Buddhas',
+    toh: ['toh12'],
+  }),
+  work({
+    title: 'Ornament of the Light of Awareness',
+    toh: ['toh1206'],
+  }),
+  work({
+    title: 'Unfinished Draft',
+    toh: ['toh44'],
+    publicationDate: undefined,
+  }),
+];
+
+const renderTable = () =>
+  render(
+    <TooltipProvider>
+      <TranslationsTable works={WORKS} />
+    </TooltipProvider>,
+  );
+
+// the search input is debounced; callers should waitFor the filtered result
+const search = (value: string) => {
+  fireEvent.change(screen.getByPlaceholderText('Search translations...'), {
+    target: { value },
+  });
+};
+
+const bodyRowTitles = () =>
+  screen
+    .getAllByRole('row')
+    .slice(1)
+    .map((row) => row.querySelector('td')?.textContent ?? '');
+
+describe('TranslationsTable', () => {
+  it('displays toh numbers in "Toh #" format', () => {
+    renderTable();
+    expect(screen.getAllByText('Toh 95').length).toBeGreaterThan(0);
+  });
+
+  it('displays Tibetan and Sanskrit titles under the main title', () => {
+    renderTable();
+    expect(
+      screen.getAllByText('རྒྱ་ཆེར་རོལ་པ། · Lalitavistara').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('sorts titles ignoring leading articles', () => {
+    renderTable();
+    expect(bodyRowTitles()).toEqual([
+      expect.stringContaining('A Multitude of Buddhas'),
+      expect.stringContaining('Ornament of the Light of Awareness'),
+      expect.stringContaining('The Play in Full'),
+      expect.stringContaining('Unfinished Draft'),
+    ]);
+  });
+
+  it('finds works by "Toh #" search with exact matches first', async () => {
+    renderTable();
+    search('Toh 12');
+
+    await waitFor(() => {
+      const titles = bodyRowTitles();
+      expect(titles).toHaveLength(2);
+      expect(titles[0]).toContain('A Multitude of Buddhas');
+      expect(titles[1]).toContain('Ornament of the Light of Awareness');
+    });
+  });
+
+  it('finds works by raw toh format', async () => {
+    renderTable();
+    search('toh95');
+
+    await waitFor(() => {
+      expect(bodyRowTitles()).toEqual([
+        expect.stringContaining('The Play in Full'),
+      ]);
+    });
+  });
+
+  it('finds works by Wylie title', async () => {
+    renderTable();
+    search('rgya cher rol pa');
+
+    await waitFor(() => {
+      expect(bodyRowTitles()).toEqual([
+        expect.stringContaining('The Play in Full'),
+      ]);
+    });
+  });
+
+  it('finds works by Sanskrit title', async () => {
+    renderTable();
+    search('Lalitavistara');
+
+    await waitFor(() => {
+      expect(bodyRowTitles()).toEqual([
+        expect.stringContaining('The Play in Full'),
+      ]);
+    });
+  });
+
+  it('hides unpublished works when the published-only switch is on', async () => {
+    renderTable();
+    expect(screen.getAllByText('Unpublished').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Published only' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Unpublished')).toBeNull();
+    });
+    expect(bodyRowTitles()).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Published only' }));
+    await waitFor(() => {
+      expect(bodyRowTitles()).toHaveLength(4);
+    });
+  });
+});

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
@@ -3,10 +3,18 @@ import { TooltipProvider } from '@eightyfourthousand/design-system';
 import { Work } from '@eightyfourthousand/data-access';
 import { TranslationsTable } from './TranslationTable';
 
+let mockSearchParams: URLSearchParams;
+
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
   usePathname: () => '/translations/reader',
+  useSearchParams: () => mockSearchParams,
 }));
+
+beforeEach(() => {
+  mockSearchParams = new URLSearchParams();
+  window.history.replaceState(null, '', '/translations/reader');
+});
 
 const work = (overrides: Partial<Work>): Work => ({
   uuid: crypto.randomUUID(),
@@ -145,6 +153,27 @@ describe('TranslationsTable', () => {
     fireEvent.click(screen.getByRole('switch', { name: 'Published only' }));
     await waitFor(() => {
       expect(bodyRowTitles()).toHaveLength(4);
+    });
+  });
+
+  it('initializes search and filter state from the URL', () => {
+    mockSearchParams = new URLSearchParams('q=toh95&published=1');
+    renderTable();
+
+    expect(bodyRowTitles()).toEqual([
+      expect.stringContaining('The Play in Full'),
+    ]);
+  });
+
+  it('writes search and filter state back to the URL', async () => {
+    renderTable();
+    search('toh95');
+    fireEvent.click(screen.getByRole('switch', { name: 'Published only' }));
+
+    await waitFor(() => {
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get('q')).toBe('toh95');
+      expect(params.get('published')).toBe('1');
     });
   });
 });

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
@@ -79,6 +79,8 @@ const SORTABLE_COLUMNS = [
   'publicationDate',
   'publicationVersion',
 ];
+const STATE_KEYS = ['q', 'published', 'sort'];
+const STORAGE_PREFIX = 'translations-table:';
 
 const sortFromParam = (param: string | null): SortingState => {
   const [id, direction] = param?.split('.') ?? [];
@@ -86,6 +88,40 @@ const sortFromParam = (param: string | null): SortingState => {
     return DEFAULT_SORT;
   }
   return [{ id, desc: direction === 'desc' }];
+};
+
+// table state serializes to `q`/`published`/`sort` params, shared by the
+// URL query string and localStorage
+const stateFromParams = (params: URLSearchParams): DataTableState => ({
+  globalFilter: params.get('q') || '',
+  columnFilters:
+    params.get('published') === '1'
+      ? [{ id: 'publicationDate', value: true }]
+      : [],
+  sorting: sortFromParam(params.get('sort')),
+});
+
+const stateToParams = ({
+  globalFilter,
+  sorting,
+  columnFilters,
+}: DataTableState): URLSearchParams => {
+  const params = new URLSearchParams();
+  if (globalFilter) {
+    params.set('q', globalFilter);
+  }
+  if (
+    columnFilters.some(
+      (filter) => filter.id === 'publicationDate' && filter.value,
+    )
+  ) {
+    params.set('published', '1');
+  }
+  const [sort] = sorting;
+  if (sort && !(sort.id === 'title' && !sort.desc)) {
+    params.set('sort', `${sort.id}.${sort.desc ? 'desc' : 'asc'}`);
+  }
+  return params;
 };
 
 export const TranslationsTable = ({ works }: { works: Work[] }) => {
@@ -96,47 +132,36 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
     router.push(`${pathname}/${cell.row.original.uuid}`);
   };
 
-  // search, filter, and sort state initialize from — and write back to — the
-  // URL so they survive opening a work and navigating back
-  const initialState: DataTableState = useMemo(
-    () => ({
-      globalFilter: searchParams.get('q') || '',
-      columnFilters:
-        searchParams.get('published') === '1'
-          ? [{ id: 'publicationDate', value: true }]
-          : [],
-      sorting: sortFromParam(searchParams.get('sort')),
-    }),
-    [searchParams],
-  );
+  // search, filter, and sort state initialize from the URL, then
+  // localStorage, and write back to both — so they survive opening a work
+  // and navigating back, or leaving the page entirely
+  const initialState: DataTableState = useMemo(() => {
+    if (STATE_KEYS.some((key) => searchParams.has(key))) {
+      return stateFromParams(new URLSearchParams(searchParams));
+    }
+    const stored =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem(`${STORAGE_PREFIX}${pathname}`)
+        : null;
+    return stateFromParams(new URLSearchParams(stored || ''));
+  }, [searchParams, pathname]);
 
   const onStateChange = useCallback(
-    ({ globalFilter, sorting, columnFilters }: DataTableState) => {
-      const params = new URLSearchParams(window.location.search);
+    (state: DataTableState) => {
+      const stateParams = stateToParams(state);
+      const serialized = stateParams.toString();
 
-      if (globalFilter) {
-        params.set('q', globalFilter);
+      if (serialized) {
+        window.localStorage.setItem(`${STORAGE_PREFIX}${pathname}`, serialized);
       } else {
-        params.delete('q');
+        window.localStorage.removeItem(`${STORAGE_PREFIX}${pathname}`);
       }
 
-      const publishedOnly = columnFilters.some(
-        (filter) => filter.id === 'publicationDate' && filter.value,
-      );
-      if (publishedOnly) {
-        params.set('published', '1');
-      } else {
-        params.delete('published');
-      }
+      const urlParams = new URLSearchParams(window.location.search);
+      STATE_KEYS.forEach((key) => urlParams.delete(key));
+      stateParams.forEach((value, key) => urlParams.set(key, value));
 
-      const [sort] = sorting;
-      if (sort && !(sort.id === 'title' && !sort.desc)) {
-        params.set('sort', `${sort.id}.${sort.desc ? 'desc' : 'asc'}`);
-      } else {
-        params.delete('sort');
-      }
-
-      const query = params.toString();
+      const query = urlParams.toString();
       const url = query
         ? `${window.location.pathname}?${query}`
         : window.location.pathname;
@@ -146,7 +171,7 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
         window.history.replaceState(null, '', url);
       }
     },
-    [],
+    [pathname],
   );
 
   const data: TableWork[] = useMemo(

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Cell, SortingFn } from '@tanstack/react-table';
+import { Cell, SortingFn, SortingState } from '@tanstack/react-table';
 import {
   SortableHeader,
   TooltipCell,
   DataTableColumn,
   DataTable,
+  DataTableState,
   FuzzyGlobalFilter,
   DebounceLevel,
   Label,
@@ -17,9 +18,9 @@ import {
   compareIgnoringArticles,
   parseToh,
 } from '@eightyfourthousand/lib-utils';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { TriangleAlertIcon } from 'lucide-react';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 const CLASSNAME_FOR_COL: { [key: string]: string } = {
   title: 'xl:w-[920px] lg:w-[740px] md:w-[490px] w-[246px]',
@@ -70,12 +71,83 @@ const tohSort: SortingFn<TableWork> = (rowA, rowB) =>
   firstTohNumber(rowA.original.tohSearch) -
   firstTohNumber(rowB.original.tohSearch);
 
+const DEFAULT_SORT: SortingState = [{ id: 'title', desc: false }];
+const SORTABLE_COLUMNS = [
+  'title',
+  'toh',
+  'pages',
+  'publicationDate',
+  'publicationVersion',
+];
+
+const sortFromParam = (param: string | null): SortingState => {
+  const [id, direction] = param?.split('.') ?? [];
+  if (!id || !SORTABLE_COLUMNS.includes(id)) {
+    return DEFAULT_SORT;
+  }
+  return [{ id, desc: direction === 'desc' }];
+};
+
 export const TranslationsTable = ({ works }: { works: Work[] }) => {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const onCellClick = (cell: Cell<TableWork, unknown>) => {
     router.push(`${pathname}/${cell.row.original.uuid}`);
   };
+
+  // search, filter, and sort state initialize from — and write back to — the
+  // URL so they survive opening a work and navigating back
+  const initialState: DataTableState = useMemo(
+    () => ({
+      globalFilter: searchParams.get('q') || '',
+      columnFilters:
+        searchParams.get('published') === '1'
+          ? [{ id: 'publicationDate', value: true }]
+          : [],
+      sorting: sortFromParam(searchParams.get('sort')),
+    }),
+    [searchParams],
+  );
+
+  const onStateChange = useCallback(
+    ({ globalFilter, sorting, columnFilters }: DataTableState) => {
+      const params = new URLSearchParams(window.location.search);
+
+      if (globalFilter) {
+        params.set('q', globalFilter);
+      } else {
+        params.delete('q');
+      }
+
+      const publishedOnly = columnFilters.some(
+        (filter) => filter.id === 'publicationDate' && filter.value,
+      );
+      if (publishedOnly) {
+        params.set('published', '1');
+      } else {
+        params.delete('published');
+      }
+
+      const [sort] = sorting;
+      if (sort && !(sort.id === 'title' && !sort.desc)) {
+        params.set('sort', `${sort.id}.${sort.desc ? 'desc' : 'asc'}`);
+      } else {
+        params.delete('sort');
+      }
+
+      const query = params.toString();
+      const url = query
+        ? `${window.location.pathname}?${query}`
+        : window.location.pathname;
+      if (`${window.location.pathname}${window.location.search}` !== url) {
+        // replaceState instead of router.replace to skip a server round-trip
+        // on every debounced keystroke
+        window.history.replaceState(null, '', url);
+      }
+    },
+    [],
+  );
 
   const data: TableWork[] = useMemo(
     () =>
@@ -208,7 +280,10 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
         wylieTitle: false,
         sanskritTitle: false,
       }}
-      sorting={[{ id: 'title', desc: false }]}
+      sorting={initialState.sorting}
+      globalFilter={initialState.globalFilter}
+      columnFilters={initialState.columnFilters}
+      onStateChange={onStateChange}
       infiniteScroll
       filters={(table) => (
         <div className="flex items-center gap-6 py-4">

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
@@ -1,15 +1,23 @@
 'use client';
 
-import { Cell } from '@tanstack/react-table';
+import { Cell, SortingFn } from '@tanstack/react-table';
 import {
   SortableHeader,
   TooltipCell,
   DataTableColumn,
   DataTable,
   FuzzyGlobalFilter,
+  DebounceLevel,
+  Label,
+  Switch,
+  globalFilterRank,
 } from '@eightyfourthousand/design-system';
 import { Work } from '@eightyfourthousand/data-access';
-import { useEffect, useState } from 'react';
+import {
+  compareIgnoringArticles,
+  parseToh,
+} from '@eightyfourthousand/lib-utils';
+import { useMemo } from 'react';
 import { TriangleAlertIcon } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 
@@ -22,10 +30,16 @@ const CLASSNAME_FOR_COL: { [key: string]: string } = {
   restriction: 'w-5 h-6',
 };
 
+const UNPUBLISHED = 'Unpublished';
+
 type TableWork = {
   uuid: string;
   title: string;
+  tibetanTitle: string;
+  wylieTitle: string;
+  sanskritTitle: string;
   toh: string;
+  tohSearch: string;
   publicationDate: string;
   publicationVersion: string;
   pages: number;
@@ -34,23 +48,48 @@ type TableWork = {
 
 const TranslationHeader = SortableHeader<TableWork>;
 
-export const TranslationsTable = ({ works }: { works: Work[] }) => {
-  const [data, setData] = useState<TableWork[]>([]);
+// When a search is active, rows with better fuzzy matches sort first (so an
+// exact "Toh 12" beats "Toh 1206"); ties fall back to title order ignoring
+// leading articles. Flipping to descending inverts match order too — an
+// acceptable trade-off for keeping the default sorting pipeline.
+const titleSort: SortingFn<TableWork> = (rowA, rowB, columnId) => {
+  const rankDiff = globalFilterRank(rowB) - globalFilterRank(rowA);
+  if (rankDiff !== 0) {
+    return Math.sign(rankDiff);
+  }
+  return compareIgnoringArticles(
+    rowA.getValue<string>(columnId),
+    rowB.getValue<string>(columnId),
+  );
+};
 
+const firstTohNumber = (tohSearch: string) =>
+  parseInt(tohSearch.replace('toh', ''), 10) || 0;
+
+const tohSort: SortingFn<TableWork> = (rowA, rowB) =>
+  firstTohNumber(rowA.original.tohSearch) -
+  firstTohNumber(rowB.original.tohSearch);
+
+export const TranslationsTable = ({ works }: { works: Work[] }) => {
   const router = useRouter();
   const pathname = usePathname();
   const onCellClick = (cell: Cell<TableWork, unknown>) => {
     router.push(`${pathname}/${cell.row.original.uuid}`);
   };
 
-  useEffect(() => {
-    const tableWorks: TableWork[] = works.map((w) => ({
-      ...w,
-      toh: w.toh.join(', '),
-      publicationDate: w.publicationDate?.toLocaleDateString() || 'Unpublished',
-    }));
-    setData(tableWorks);
-  }, [works]);
+  const data: TableWork[] = useMemo(
+    () =>
+      works.map((w) => ({
+        ...w,
+        tibetanTitle: w.tibetanTitle || '',
+        wylieTitle: w.wylieTitle || '',
+        sanskritTitle: w.sanskritTitle || '',
+        toh: parseToh(w.toh.join(',')),
+        tohSearch: w.toh.join(' '),
+        publicationDate: w.publicationDate?.toLocaleDateString() || UNPUBLISHED,
+      })),
+    [works],
+  );
 
   const columns: DataTableColumn<TableWork>[] = [
     {
@@ -60,12 +99,20 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
         <TranslationHeader column={column} name="Work Title" />
       ),
       cell: ({ row }) => (
-        <TooltipCell
-          className={CLASSNAME_FOR_COL.title}
-          content={row.original.title}
-        />
+        <div className={CLASSNAME_FOR_COL.title}>
+          <TooltipCell content={row.original.title} />
+          {(row.original.tibetanTitle || row.original.sanskritTitle) && (
+            <TooltipCell
+              className="text-xs text-muted-foreground"
+              content={[row.original.tibetanTitle, row.original.sanskritTitle]
+                .filter(Boolean)
+                .join(' · ')}
+            />
+          )}
+        </div>
       ),
       className: CLASSNAME_FOR_COL.title,
+      sortingFn: titleSort,
       onCellClick,
     },
     {
@@ -79,11 +126,13 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
         />
       ),
       className: CLASSNAME_FOR_COL.toh,
+      sortingFn: tohSort,
       onCellClick,
     },
     {
       id: 'pages',
       accessorKey: 'pages',
+      enableGlobalFilter: false,
       header: ({ column }) => (
         <TranslationHeader column={column} name="Pages" />
       ),
@@ -96,6 +145,9 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
     {
       id: 'publicationDate',
       accessorKey: 'publicationDate',
+      enableGlobalFilter: false,
+      filterFn: (row, _columnId, publishedOnly: boolean) =>
+        !publishedOnly || row.original.publicationDate !== UNPUBLISHED,
       header: ({ column }) => (
         <TranslationHeader column={column} name="Published" />
       ),
@@ -110,6 +162,7 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
     {
       id: 'publicationVersion',
       accessorKey: 'publicationVersion',
+      enableGlobalFilter: false,
       header: ({ column }) => (
         <TranslationHeader column={column} name="Version" />
       ),
@@ -124,6 +177,7 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
     {
       id: 'restriction',
       accessorKey: 'restriction',
+      enableGlobalFilter: false,
       header: () => '',
       cell: ({ row }) => (
         <div className={CLASSNAME_FOR_COL.restriction}>
@@ -135,6 +189,12 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
       className: CLASSNAME_FOR_COL.restriction,
       onCellClick,
     },
+    // search-only columns; kept after the visible ones so a visible match is
+    // the one that records the row's rank
+    { id: 'tohSearch', accessorKey: 'tohSearch' },
+    { id: 'tibetanTitle', accessorKey: 'tibetanTitle' },
+    { id: 'wylieTitle', accessorKey: 'wylieTitle' },
+    { id: 'sanskritTitle', accessorKey: 'sanskritTitle' },
   ];
 
   return (
@@ -142,12 +202,33 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
       name="translations"
       columns={columns}
       data={data}
+      visibility={{
+        tohSearch: false,
+        tibetanTitle: false,
+        wylieTitle: false,
+        sanskritTitle: false,
+      }}
+      sorting={[{ id: 'title', desc: false }]}
+      infiniteScroll
       filters={(table) => (
-        <div className="flex items-center py-4">
+        <div className="flex items-center gap-6 py-4">
           <FuzzyGlobalFilter
             table={table}
             placeholder="Search translations..."
+            delay={DebounceLevel.LOW}
           />
+          <div className="flex items-center gap-2">
+            <Switch
+              id="published-only"
+              checked={!!table.getColumn('publicationDate')?.getFilterValue()}
+              onCheckedChange={(checked) =>
+                table
+                  .getColumn('publicationDate')
+                  ?.setFilterValue(checked || undefined)
+              }
+            />
+            <Label htmlFor="published-only">Published only</Label>
+          </div>
         </div>
       )}
     />

--- a/libs/lib-utils/src/lib/string.spec.ts
+++ b/libs/lib-utils/src/lib/string.spec.ts
@@ -1,0 +1,65 @@
+import {
+  compareIgnoringArticles,
+  parseToh,
+  stripLeadingArticles,
+} from './string';
+
+describe('parseToh', () => {
+  it('formats a single toh', () => {
+    expect(parseToh('toh417')).toBe('Toh 417');
+  });
+
+  it('formats a comma-separated list', () => {
+    expect(parseToh('toh417,toh418')).toBe('Toh 417, Toh 418');
+  });
+});
+
+describe('stripLeadingArticles', () => {
+  it('strips leading articles', () => {
+    expect(stripLeadingArticles('The Play in Full')).toBe('Play in Full');
+    expect(stripLeadingArticles('A Multitude of Buddhas')).toBe(
+      'Multitude of Buddhas',
+    );
+    expect(stripLeadingArticles('An Analysis of Action')).toBe(
+      'Analysis of Action',
+    );
+    expect(stripLeadingArticles('And So It Was')).toBe('So It Was');
+  });
+
+  it('is case-insensitive', () => {
+    expect(stripLeadingArticles('the play in full')).toBe('play in full');
+  });
+
+  it('only strips whole words at the start', () => {
+    expect(stripLeadingArticles('Analysis of Action')).toBe(
+      'Analysis of Action',
+    );
+    expect(stripLeadingArticles('Theft of the Jewel')).toBe(
+      'Theft of the Jewel',
+    );
+    expect(stripLeadingArticles('Play in Full, The')).toBe(
+      'Play in Full, The',
+    );
+  });
+});
+
+describe('compareIgnoringArticles', () => {
+  it('sorts as if leading articles were absent', () => {
+    const titles = [
+      'The Zebra Sutra',
+      'A Banana Sutra',
+      'Candle Sutra',
+      'The Apple Sutra',
+    ];
+    expect([...titles].sort(compareIgnoringArticles)).toEqual([
+      'The Apple Sutra',
+      'A Banana Sutra',
+      'Candle Sutra',
+      'The Zebra Sutra',
+    ]);
+  });
+
+  it('ignores case and diacritics', () => {
+    expect(compareIgnoringArticles('āpple', 'Apple')).toBe(0);
+  });
+});

--- a/libs/lib-utils/src/lib/string.ts
+++ b/libs/lib-utils/src/lib/string.ts
@@ -23,6 +23,14 @@ export const toSlug = (str: string) =>
 export const parseToh = (toh: string) =>
   toh.replace(/,/g, ', ').replace(/toh/g, 'Toh ');
 
+export const stripLeadingArticles = (str: string) =>
+  str.replace(/^(?:a|an|and|the)\s+/i, '');
+
+export const compareIgnoringArticles = (a: string, b: string) =>
+  stripLeadingArticles(a).localeCompare(stripLeadingArticles(b), 'en', {
+    sensitivity: 'base',
+  });
+
 export const isUuid = (str: string) =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(str);
 


### PR DESCRIPTION
### Summary

Improves the translations table (reader and editor): Toh numbers display and search as `Toh #` with exact matches ranked first, title sorting ignores leading articles, Tibetan/Sanskrit titles display under the main title and are searchable (along with Wylie), a Published-only filter, and infinite scroll in place of numbered pagination. Search/filter/sort state persists in the URL so it survives opening a work and navigating back.

### Linear

- [DEV-659](https://linear.app/84000/issue/DEV-659)

### Notes

- Tibetan/Wylie/Sanskrit titles come from the existing `Work.imprint.mainTitles` GraphQL field — no API changes. The per-work `get_imprint` RPC adds ~2s per 200-item page during ISR revalidation (server-side, every 60s); a batched loader is a follow-up if that becomes a problem.
- Fixes a mapper bug where a null `publicationDate` became the epoch, so unpublished works never displayed "Unpublished".
- `DataTable` infinite scroll is opt-in; the library pages keep numbered pagination unchanged.