### PR TITLE
Resizable table columns

### DIFF
--- a/libs/design-system/src/lib/Table/ColumnResizeHandle/ColumnResizeHandle.spec.tsx
+++ b/libs/design-system/src/lib/Table/ColumnResizeHandle/ColumnResizeHandle.spec.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DataTable } from '../DataTable/DataTable';
+import { DataTableColumn } from '../hooks';
+import { resizePair } from './ColumnResizeHandle';
+
+describe('resizePair', () => {
+  it('moves size between neighbors, keeping the total constant', () => {
+    expect(
+      resizePair({ size: 50, neighborSize: 30, delta: 10, minSize: 5 }),
+    ).toEqual({ size: 60, neighborSize: 20 });
+    expect(
+      resizePair({ size: 50, neighborSize: 30, delta: -10, minSize: 5 }),
+    ).toEqual({ size: 40, neighborSize: 40 });
+  });
+
+  it('clamps both columns to the minimum size', () => {
+    expect(
+      resizePair({ size: 50, neighborSize: 30, delta: 100, minSize: 5 }),
+    ).toEqual({ size: 75, neighborSize: 5 });
+    expect(
+      resizePair({ size: 50, neighborSize: 30, delta: -100, minSize: 5 }),
+    ).toEqual({ size: 5, neighborSize: 75 });
+  });
+
+  it('does nothing when there is no room to resize', () => {
+    expect(
+      resizePair({ size: 5, neighborSize: 5, delta: 10, minSize: 5 }),
+    ).toEqual({ size: 5, neighborSize: 5 });
+  });
+});
+
+type Row = { uuid: string; name: string; count: number };
+
+const columns: DataTableColumn<Row>[] = [
+  { id: 'name', accessorKey: 'name', size: 60, header: () => 'Name' },
+  { id: 'count', accessorKey: 'count', size: 40, header: () => 'Count' },
+];
+
+const rows: Row[] = [
+  { uuid: '1', name: 'first', count: 1 },
+  { uuid: '2', name: 'second', count: 2 },
+];
+
+const headerWidths = () =>
+  screen
+    .getAllByRole('columnheader')
+    .map((th) => (th as HTMLElement).style.width);
+
+describe('DataTable with resizableColumns', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(HTMLTableElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({ width: 1000 } as DOMRect);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sizes columns as percentages of the table', () => {
+    render(
+      <DataTable name="things" data={rows} columns={columns} resizableColumns />,
+    );
+    expect(headerWidths()).toEqual(['60%', '40%']);
+  });
+
+  it('redistributes width between neighbors on drag, keeping 100% total', () => {
+    render(
+      <DataTable name="things" data={rows} columns={columns} resizableColumns />,
+    );
+    const handle = screen.getByRole('separator', {
+      name: 'Resize name column',
+    });
+
+    // drag 100px right on a 1000px-wide table: 10 share units. jsdom cannot
+    // construct PointerEvents with coordinates, so dispatch MouseEvents with
+    // pointer types — React handlers listen by event type.
+    const pointer = (type: string, clientX: number) =>
+      fireEvent(handle, new MouseEvent(type, { clientX, bubbles: true }));
+    pointer('pointerdown', 0);
+    pointer('pointermove', 100);
+    pointer('pointerup', 100);
+
+    expect(headerWidths()).toEqual(['70%', '30%']);
+  });
+
+  it('does not render handles or width styles by default', () => {
+    render(<DataTable name="things" data={rows} columns={columns} />);
+    expect(screen.queryByRole('separator')).toBeNull();
+    expect(headerWidths()).toEqual(['', '']);
+  });
+});

--- a/libs/design-system/src/lib/Table/ColumnResizeHandle/ColumnResizeHandle.tsx
+++ b/libs/design-system/src/lib/Table/ColumnResizeHandle/ColumnResizeHandle.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { Header, RowData, Table } from '@tanstack/react-table';
+import { PointerEvent as ReactPointerEvent, useRef } from 'react';
+
+/**
+ * Redistribute size between a column and its right-hand neighbor, keeping
+ * their combined share — and therefore the table's total width — constant.
+ */
+export const resizePair = ({
+  size,
+  neighborSize,
+  delta,
+  minSize,
+}: {
+  size: number;
+  neighborSize: number;
+  delta: number;
+  minSize: number;
+}): { size: number; neighborSize: number } => {
+  const total = size + neighborSize;
+  if (total <= 2 * minSize) {
+    return { size, neighborSize };
+  }
+  const next = Math.min(Math.max(size + delta, minSize), total - minSize);
+  return { size: next, neighborSize: total - next };
+};
+
+// minimum column width in pixels, converted to share units per drag
+const MIN_COLUMN_PX = 48;
+
+/**
+ * Drag handle on a header's right edge that resizes the column against its
+ * right-hand neighbor. Pair-wise redistribution keeps the table's total
+ * width fixed, so columns stay percentage-sized and never overflow.
+ */
+export const ColumnResizeHandle = <T extends RowData>({
+  table,
+  header,
+  neighborId,
+}: {
+  table: Table<T>;
+  header: Header<T, unknown>;
+  neighborId: string;
+}) => {
+  const dragState = useRef<{
+    startX: number;
+    size: number;
+    neighborSize: number;
+    sharePerPx: number;
+  } | null>(null);
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = dragState.current;
+    if (!drag) {
+      return;
+    }
+    const delta = (event.clientX - drag.startX) * drag.sharePerPx;
+    const resized = resizePair({
+      size: drag.size,
+      neighborSize: drag.neighborSize,
+      delta,
+      minSize: MIN_COLUMN_PX * drag.sharePerPx,
+    });
+    table.setColumnSizing((previous) => ({
+      ...previous,
+      [header.column.id]: resized.size,
+      [neighborId]: resized.neighborSize,
+    }));
+  };
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const tableEl = event.currentTarget.closest('table');
+    const tableWidth = tableEl?.getBoundingClientRect().width || 0;
+    if (!tableWidth) {
+      return;
+    }
+    event.preventDefault();
+    try {
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    } catch {
+      // inactive pointer id (e.g. synthetic events); the drag still works
+      // while the pointer stays over the handle
+    }
+    dragState.current = {
+      startX: event.clientX,
+      size: header.column.getSize(),
+      neighborSize: table.getColumn(neighborId)?.getSize() ?? 0,
+      sharePerPx: table.getTotalSize() / tableWidth,
+    };
+  };
+
+  const onPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    dragState.current = null;
+    try {
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    } catch {
+      // capture was never taken
+    }
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={`Resize ${header.column.id} column`}
+      className="group/resize absolute -right-1 top-0 h-full w-2 cursor-col-resize touch-none select-none"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="mx-auto h-full w-px bg-border/20 group-hover/resize:bg-border group-active/resize:bg-border" />
+    </div>
+  );
+};

--- a/libs/design-system/src/lib/Table/DataTable/DataTable.stories.tsx
+++ b/libs/design-system/src/lib/Table/DataTable/DataTable.stories.tsx
@@ -162,4 +162,19 @@ export const InfiniteScroll: Story = {
   ),
 };
 
+export const ResizableColumns: Story = {
+  render: (_props) => (
+    <DataTable
+      name="invoices"
+      data={DATA}
+      columns={COLUMNS.map((column) => ({
+        ...column,
+        size: column.id === 'invoice' ? 40 : 20,
+      }))}
+      visibility={{ uuid: false }}
+      resizableColumns
+    />
+  ),
+};
+
 export default meta;

--- a/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
+++ b/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
@@ -3,6 +3,8 @@
 import {
   Cell,
   ColumnFiltersState,
+  ColumnSizingState,
+  Header,
   Table as HeadlessTable,
   PaginationState,
   SortingState,
@@ -17,6 +19,7 @@ import {
   DataTableState,
   useDataTable,
 } from '../hooks';
+import { ColumnResizeHandle } from '../ColumnResizeHandle/ColumnResizeHandle';
 import { FilterResultsBanner } from '../FilterResultsBanner/FilterResultsBanner';
 import { InfiniteScrollFooter } from '../InfiniteScrollFooter/InfiniteScrollFooter';
 import {
@@ -38,10 +41,12 @@ export const DataTable = <T extends DataTableRow>({
   pagination,
   globalFilter,
   columnFilters,
+  columnSizing,
   onStateChange,
   className,
   filters,
   infiniteScroll = false,
+  resizableColumns = false,
 }: {
   name: string;
   data: T[];
@@ -51,10 +56,12 @@ export const DataTable = <T extends DataTableRow>({
   pagination?: PaginationState;
   globalFilter?: string;
   columnFilters?: ColumnFiltersState;
+  columnSizing?: ColumnSizingState;
   onStateChange?: (state: DataTableState) => void;
   className?: string;
   filters?: (table: HeadlessTable<T>) => ReactElement;
   infiniteScroll?: boolean;
+  resizableColumns?: boolean;
 }) => {
   const [columnClasses, setColumnClasses] = useState<{ [key: string]: string }>(
     {},
@@ -89,8 +96,25 @@ export const DataTable = <T extends DataTableRow>({
       (infiniteScroll ? { pageIndex: 0, pageSize: 50 } : undefined),
     globalFilter,
     columnFilters,
+    columnSizing,
     onStateChange,
   });
+
+  // percentage widths keep the resizable table filling — and never
+  // overflowing — its container at any viewport size
+  const headerWidth = (header: Header<T, unknown>) =>
+    resizableColumns
+      ? { width: `${(header.getSize() / table.getTotalSize()) * 100}%` }
+      : undefined;
+
+  const resizeNeighbor = (header: Header<T, unknown>) => {
+    if (!resizableColumns || !header.column.getCanResize()) {
+      return undefined;
+    }
+    const headers = header.headerGroup.headers;
+    const neighbor = headers[header.index + 1];
+    return neighbor?.column.getCanResize() ? neighbor.column.id : undefined;
+  };
 
   return (
     <div className="w-full flex flex-col gap-4">
@@ -106,23 +130,37 @@ export const DataTable = <T extends DataTableRow>({
           className,
         )}
       >
-        <Table className="bg-background">
+        <Table className={cn('bg-background', resizableColumns && 'table-fixed')}>
           <TableHeader className="sticky top-0">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead
-                    className={columnClasses[header.id]}
-                    key={header.id}
-                  >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                ))}
+                {headerGroup.headers.map((header) => {
+                  const neighborId = resizeNeighbor(header);
+                  return (
+                    <TableHead
+                      className={cn(
+                        columnClasses[header.id],
+                        resizableColumns && 'relative',
+                      )}
+                      style={headerWidth(header)}
+                      key={header.id}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {neighborId && (
+                        <ColumnResizeHandle
+                          table={table}
+                          header={header}
+                          neighborId={neighborId}
+                        />
+                      )}
+                    </TableHead>
+                  );
+                })}
               </TableRow>
             ))}
           </TableHeader>
@@ -137,6 +175,7 @@ export const DataTable = <T extends DataTableRow>({
                         className={cn(
                           'py-3 hover:cursor-pointer',
                           columnClasses[cell.column.id],
+                          resizableColumns && 'overflow-hidden',
                         )}
                         onClick={() => columnActions[cell.column.id]?.(cell)}
                       >

--- a/libs/design-system/src/lib/Table/InfiniteScrollFooter/InfiniteScrollFooter.tsx
+++ b/libs/design-system/src/lib/Table/InfiniteScrollFooter/InfiniteScrollFooter.tsx
@@ -22,6 +22,14 @@ export const InfiniteScrollFooter = <T extends RowData>({
   const { pageSize } = table.getState().pagination;
   const hasMore = pageSize < totalRows;
 
+  // shrink back to one page whenever the filters change: the user wants the
+  // top matches, and re-rendering hundreds of grown rows on every keystroke
+  // makes search feel sluggish
+  const { globalFilter, columnFilters } = table.getState();
+  useEffect(() => {
+    table.setPageSize(step);
+  }, [table, step, globalFilter, columnFilters]);
+
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel || !hasMore || typeof IntersectionObserver === 'undefined') {

--- a/libs/design-system/src/lib/Table/hooks/useDataTable.ts
+++ b/libs/design-system/src/lib/Table/hooks/useDataTable.ts
@@ -4,6 +4,7 @@ import {
   Cell,
   ColumnDef,
   ColumnFiltersState,
+  ColumnSizingState,
   PaginationState,
   RowData,
   SortingState,
@@ -28,6 +29,7 @@ export type DataTableState = {
   globalFilter: string;
   sorting: SortingState;
   columnFilters: ColumnFiltersState;
+  columnSizing: ColumnSizingState;
 };
 
 export const useDataTable = <T extends DataTableRow>({
@@ -38,6 +40,7 @@ export const useDataTable = <T extends DataTableRow>({
   pagination: paginationInput = { pageIndex: 0, pageSize: 12 },
   globalFilter: globalFilterInput = '',
   columnFilters: columnFiltersInput = [],
+  columnSizing: columnSizingInput = {},
   onStateChange,
 }: {
   data: T[];
@@ -47,6 +50,7 @@ export const useDataTable = <T extends DataTableRow>({
   pagination?: PaginationState;
   globalFilter?: string;
   columnFilters?: ColumnFiltersState;
+  columnSizing?: ColumnSizingState;
   onStateChange?: (state: DataTableState) => void;
 }) => {
   const [rowSelection, setRowSelection] = useState({});
@@ -57,10 +61,12 @@ export const useDataTable = <T extends DataTableRow>({
   const [pagination, setPagination] = useState(paginationInput);
   const [columnFilters, setColumnFilters] =
     useState<ColumnFiltersState>(columnFiltersInput);
+  const [columnSizing, setColumnSizing] =
+    useState<ColumnSizingState>(columnSizingInput);
 
   useEffect(() => {
-    onStateChange?.({ globalFilter, sorting, columnFilters });
-  }, [onStateChange, globalFilter, sorting, columnFilters]);
+    onStateChange?.({ globalFilter, sorting, columnFilters, columnSizing });
+  }, [onStateChange, globalFilter, sorting, columnFilters, columnSizing]);
 
   const table = useReactTable({
     data,
@@ -72,15 +78,21 @@ export const useDataTable = <T extends DataTableRow>({
       rowSelection,
       pagination,
       columnFilters,
+      columnSizing,
     },
     getRowId: (row) => row.uuid,
     enableRowSelection: true,
+    enableColumnResizing: true,
+    // column sizes are relative share units, not pixels; without this,
+    // TanStack's default 20px minimum inflates small columns
+    defaultColumn: { minSize: 1 },
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     onColumnVisibilityChange: setColumnVisibility,
     onGlobalFilterChange: setGlobalFilter,
     onPaginationChange: setPagination,
     onColumnFiltersChange: setColumnFilters,
+    onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/libs/design-system/src/lib/Table/index.ts
+++ b/libs/design-system/src/lib/Table/index.ts
@@ -1,4 +1,5 @@
 export * from './hooks';
+export * from './ColumnResizeHandle/ColumnResizeHandle';
 export * from './DataTable/DataTable';
 export * from './FuzzyGlobalFilter/FuzzyGlobalFilter';
 export * from './PaginationEllipsis/PaginationEllipsis';

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
@@ -207,6 +207,37 @@ describe('TranslationsTable', () => {
     ]);
   });
 
+  it('restores column widths from localStorage', () => {
+    window.localStorage.setItem(
+      'translations-table:/translations/reader',
+      'widths=title:40,toh:28',
+    );
+    renderTable();
+
+    const headers = screen.getAllByRole('columnheader');
+    // 40 + 28 + pages 7 + date 10 + version 7 + restriction 4 = 96 shares
+    expect((headers[0] as HTMLElement).style.width).toBe(
+      `${(40 / 96) * 100}%`,
+    );
+    expect((headers[1] as HTMLElement).style.width).toBe(
+      `${(28 / 96) * 100}%`,
+    );
+  });
+
+  it('ignores unknown columns in stored widths', () => {
+    window.localStorage.setItem(
+      'translations-table:/translations/reader',
+      'widths=bogus:40,title:junk',
+    );
+    renderTable();
+
+    const headers = screen.getAllByRole('columnheader');
+    // defaults: title 58 of 96 total shares
+    expect((headers[0] as HTMLElement).style.width).toBe(
+      `${(58 / 96) * 100}%`,
+    );
+  });
+
   it('clears the search when the clear button is clicked', async () => {
     renderTable();
     search('toh95');

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { Cell, SortingFn, SortingState } from '@tanstack/react-table';
+import {
+  Cell,
+  ColumnSizingState,
+  SortingFn,
+  SortingState,
+} from '@tanstack/react-table';
 import {
   SortableHeader,
   TooltipCell,
@@ -22,13 +27,15 @@ import { useCallback, useMemo } from 'react';
 import { TriangleAlertIcon } from 'lucide-react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
-const CLASSNAME_FOR_COL: { [key: string]: string } = {
-  title: 'xl:w-[920px] lg:w-[740px] md:w-[490px] w-[246px]',
-  toh: 'xl:w-[100px] md:w-[60px] w-[40px]',
-  pages: 'w-[60px]',
-  publicationVersion: 'w-[40px]',
-  publicationDate: 'w-[80px]',
-  restriction: 'w-5 h-6',
+// relative column width shares; the table renders them as percentages of
+// its container, so they scale with the viewport
+const SIZE_FOR_COL: { [key: string]: number } = {
+  title: 58,
+  toh: 10,
+  pages: 7,
+  publicationDate: 10,
+  publicationVersion: 7,
+  restriction: 4,
 };
 
 const UNPUBLISHED = 'Unpublished';
@@ -90,8 +97,25 @@ const sortFromParam = (param: string | null): SortingState => {
   return [{ id, desc: direction === 'desc' }];
 };
 
-// table state serializes to `q`/`published`/`sort` params, shared by the
-// URL query string and localStorage
+const sizingFromParam = (param: string | null): ColumnSizingState => {
+  const sizing: ColumnSizingState = {};
+  param?.split(',').forEach((entry) => {
+    const [id, share] = entry.split(':');
+    const size = parseFloat(share);
+    if (id in SIZE_FOR_COL && size > 0) {
+      sizing[id] = size;
+    }
+  });
+  return sizing;
+};
+
+const sizingToParam = (sizing: ColumnSizingState): string =>
+  Object.entries(sizing)
+    .map(([id, share]) => `${id}:${Math.round(share * 10) / 10}`)
+    .join(',');
+
+// table state serializes to `q`/`published`/`sort`/`widths` params; all are
+// stored in localStorage, and all but `widths` mirror to the URL
 const stateFromParams = (params: URLSearchParams): DataTableState => ({
   globalFilter: params.get('q') || '',
   columnFilters:
@@ -99,12 +123,14 @@ const stateFromParams = (params: URLSearchParams): DataTableState => ({
       ? [{ id: 'publicationDate', value: true }]
       : [],
   sorting: sortFromParam(params.get('sort')),
+  columnSizing: sizingFromParam(params.get('widths')),
 });
 
 const stateToParams = ({
   globalFilter,
   sorting,
   columnFilters,
+  columnSizing,
 }: DataTableState): URLSearchParams => {
   const params = new URLSearchParams();
   if (globalFilter) {
@@ -121,6 +147,9 @@ const stateToParams = ({
   if (sort && !(sort.id === 'title' && !sort.desc)) {
     params.set('sort', `${sort.id}.${sort.desc ? 'desc' : 'asc'}`);
   }
+  if (Object.keys(columnSizing).length > 0) {
+    params.set('widths', sizingToParam(columnSizing));
+  }
   return params;
 };
 
@@ -134,16 +163,21 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
 
   // search, filter, and sort state initialize from the URL, then
   // localStorage, and write back to both — so they survive opening a work
-  // and navigating back, or leaving the page entirely
+  // and navigating back, or leaving the page entirely. Column widths only
+  // round-trip through localStorage.
   const initialState: DataTableState = useMemo(() => {
-    if (STATE_KEYS.some((key) => searchParams.has(key))) {
-      return stateFromParams(new URLSearchParams(searchParams));
-    }
     const stored =
       typeof window !== 'undefined'
         ? window.localStorage.getItem(`${STORAGE_PREFIX}${pathname}`)
         : null;
-    return stateFromParams(new URLSearchParams(stored || ''));
+    const storedParams = new URLSearchParams(stored || '');
+    const state = STATE_KEYS.some((key) => searchParams.has(key))
+      ? stateFromParams(new URLSearchParams(searchParams))
+      : stateFromParams(storedParams);
+    return {
+      ...state,
+      columnSizing: sizingFromParam(storedParams.get('widths')),
+    };
   }, [searchParams, pathname]);
 
   const onStateChange = useCallback(
@@ -159,6 +193,7 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
 
       const urlParams = new URLSearchParams(window.location.search);
       STATE_KEYS.forEach((key) => urlParams.delete(key));
+      stateParams.delete('widths');
       stateParams.forEach((value, key) => urlParams.set(key, value));
 
       const query = urlParams.toString();
@@ -192,11 +227,12 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
     {
       id: 'title',
       accessorKey: 'title',
+      size: SIZE_FOR_COL.title,
       header: ({ column }) => (
         <TranslationHeader column={column} name="Work Title" />
       ),
       cell: ({ row }) => (
-        <div className={CLASSNAME_FOR_COL.title}>
+        <div>
           <TooltipCell content={row.original.title} />
           {(row.original.tibetanTitle || row.original.sanskritTitle) && (
             <TooltipCell
@@ -208,40 +244,33 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
           )}
         </div>
       ),
-      className: CLASSNAME_FOR_COL.title,
       sortingFn: titleSort,
       onCellClick,
     },
     {
       id: 'toh',
       accessorKey: 'toh',
+      size: SIZE_FOR_COL.toh,
       header: ({ column }) => <TranslationHeader column={column} name="Toh" />,
-      cell: ({ row }) => (
-        <TooltipCell
-          className={CLASSNAME_FOR_COL.toh}
-          content={row.original.toh}
-        />
-      ),
-      className: CLASSNAME_FOR_COL.toh,
+      cell: ({ row }) => <TooltipCell content={row.original.toh} />,
       sortingFn: tohSort,
       onCellClick,
     },
     {
       id: 'pages',
       accessorKey: 'pages',
+      size: SIZE_FOR_COL.pages,
       enableGlobalFilter: false,
       header: ({ column }) => (
         <TranslationHeader column={column} name="Pages" />
       ),
-      cell: ({ row }) => (
-        <div className={CLASSNAME_FOR_COL.pages}>{row.original.pages}</div>
-      ),
-      className: CLASSNAME_FOR_COL.pages,
+      cell: ({ row }) => <div>{row.original.pages}</div>,
       onCellClick,
     },
     {
       id: 'publicationDate',
       accessorKey: 'publicationDate',
+      size: SIZE_FOR_COL.publicationDate,
       enableGlobalFilter: false,
       filterFn: (row, _columnId, publishedOnly: boolean) =>
         !publishedOnly || row.original.publicationDate !== UNPUBLISHED,
@@ -249,41 +278,35 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
         <TranslationHeader column={column} name="Published" />
       ),
       cell: ({ row }) => (
-        <div className={CLASSNAME_FOR_COL.publicationDate}>
-          {row.original.publicationDate}
-        </div>
+        <div className="truncate">{row.original.publicationDate}</div>
       ),
-      className: CLASSNAME_FOR_COL.publicationDate,
       onCellClick,
     },
     {
       id: 'publicationVersion',
       accessorKey: 'publicationVersion',
+      size: SIZE_FOR_COL.publicationVersion,
       enableGlobalFilter: false,
       header: ({ column }) => (
         <TranslationHeader column={column} name="Version" />
       ),
-      cell: ({ row }) => (
-        <div className={CLASSNAME_FOR_COL.publicationVersion}>
-          {row.original.publicationVersion}
-        </div>
-      ),
-      className: CLASSNAME_FOR_COL.publicationVersion,
+      cell: ({ row }) => <div>{row.original.publicationVersion}</div>,
       onCellClick,
     },
     {
       id: 'restriction',
       accessorKey: 'restriction',
+      size: SIZE_FOR_COL.restriction,
       enableGlobalFilter: false,
+      enableResizing: false,
       header: () => '',
       cell: ({ row }) => (
-        <div className={CLASSNAME_FOR_COL.restriction}>
+        <div className="w-5 h-6">
           {row.original.restriction ? (
             <TriangleAlertIcon className="text-warning" />
           ) : null}
         </div>
       ),
-      className: CLASSNAME_FOR_COL.restriction,
       onCellClick,
     },
     // search-only columns; kept after the visible ones so a visible match is
@@ -308,8 +331,10 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
       sorting={initialState.sorting}
       globalFilter={initialState.globalFilter}
       columnFilters={initialState.columnFilters}
+      columnSizing={initialState.columnSizing}
       onStateChange={onStateChange}
       infiniteScroll
+      resizableColumns
       filters={(table) => (
         <div className="flex items-center gap-6 py-4">
           <FuzzyGlobalFilter

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
@@ -340,7 +340,7 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
           <FuzzyGlobalFilter
             table={table}
             placeholder="Search translations..."
-            delay={DebounceLevel.LOW}
+            delay={DebounceLevel.MEDIUM}
           />
           <div className="flex items-center gap-2">
             <Switch


### PR DESCRIPTION
### Summary

Adds opt-in resizable columns to `DataTable`, adopted by the translations table. Columns are sized as relative shares rendered as percentages of the container on a fixed table layout, so the table always fills its width, scales with the viewport, and never scrolls horizontally. Dragging a header edge redistributes width between the two adjacent columns; widths persist in localStorage. Also fixes search sluggishness after deep infinite scrolling: filter changes collapse the scroll window back to one page and the search debounce is raised.

### Linear

- [DEV-659](https://linear.app/84000/issue/DEV-659)

### Notes

- The old fixed responsive width classes. are replaced by share-based sizing; `defaultColumn.minSize` is lowered since sizes are shares, not pixels.
- The restriction icon column is not resizable; drag clamps both columns of a pair to a 48px minimum.