### PR TITLE
Batched work imprint loader

### DIFF
--- a/apps/api-graphql/src/graphql/loaders.ts
+++ b/apps/api-graphql/src/graphql/loaders.ts
@@ -5,6 +5,7 @@ import { createPassageReferencesLoader } from './schema/passage/passage-referenc
 import { createWorkTitleLoader } from './schema/work/work-title.loader';
 import { createFolioLoader } from './schema/folio/folio.loader';
 import { createBibliographyLabelLoader } from './schema/bibliography/bibliography-label.loader';
+import { createImprintLoader } from './schema/imprint/imprint.loader';
 
 export interface Loaders {
   /**
@@ -62,6 +63,12 @@ export interface Loaders {
    * bibliography entries.
    */
   bibliographyLabelsByUuid: ReturnType<typeof createBibliographyLabelLoader>;
+
+  /**
+   * Load imprints by (work uuid, toh) pair.
+   * Batches the per-work imprint RPC into a single query for list results.
+   */
+  imprintsByWorkToh: ReturnType<typeof createImprintLoader>;
 }
 
 export function createLoaders(supabase: DataClient): Loaders {
@@ -72,5 +79,6 @@ export function createLoaders(supabase: DataClient): Loaders {
     glossaryNamesByUuid: createGlossaryNameLoader(supabase),
     foliosByUuid: createFolioLoader(supabase),
     bibliographyLabelsByUuid: createBibliographyLabelLoader(supabase),
+    imprintsByWorkToh: createImprintLoader(supabase),
   };
 }

--- a/apps/api-graphql/src/graphql/schema/imprint/imprint.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/imprint/imprint.loader.ts
@@ -1,0 +1,26 @@
+import DataLoader from 'dataloader';
+import {
+  getTranslationImprints,
+  imprintKey,
+  type DataClient,
+  type Imprint,
+  type ImprintKey,
+} from '@eightyfourthousand/data-access';
+
+/**
+ * Creates a DataLoader for batch-fetching imprints by (work uuid, toh) pair.
+ * Collapses the per-work `get_imprint` RPC into a single `get_imprints` call
+ * per request, so list queries that select `imprint` avoid N+1 round-trips.
+ */
+export function createImprintLoader(supabase: DataClient) {
+  return new DataLoader<ImprintKey, Imprint | null, string>(
+    async (keys) => {
+      const imprintsByKey = await getTranslationImprints({
+        client: supabase,
+        keys,
+      });
+      return keys.map((key) => imprintsByKey.get(imprintKey(key)) ?? null);
+    },
+    { cacheKeyFn: imprintKey },
+  );
+}

--- a/apps/api-graphql/src/graphql/schema/imprint/imprint.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/imprint/imprint.resolver.ts
@@ -1,4 +1,3 @@
-import { getTranslationImprint } from '@eightyfourthousand/data-access';
 import type { GraphQLContext } from '../../context';
 import type { WorkParent } from '../work/work.types';
 import { parseToh } from '@eightyfourthousand/lib-utils';
@@ -15,8 +14,7 @@ export const imprintResolver = async (
     return null;
   }
 
-  const imprint = await getTranslationImprint({
-    client: ctx.supabase,
+  const imprint = await ctx.loaders.imprintsByWorkToh.load({
     uuid: parent.uuid,
     toh,
   });

--- a/libs/data-access/src/lib/imprint.spec.ts
+++ b/libs/data-access/src/lib/imprint.spec.ts
@@ -1,0 +1,95 @@
+import { getTranslationImprints, imprintKey } from './imprint';
+import { DataClient } from './types';
+
+const createMockClient = (result: { data: unknown; error: unknown }) => {
+  const rpc = jest.fn(() => Promise.resolve(result));
+  return { client: { rpc } as unknown as DataClient, rpc };
+};
+
+const imprintRow = (uuid: string, toh: string) => ({
+  work_uuid: uuid,
+  toh,
+  imprint: {
+    work_uuid: uuid,
+    toh: `Toh ${toh.replace('toh', '')}`,
+    isAuthorContested: false,
+    license: { name: 'CC BY-NC-ND 4.0' },
+    mainTitles: { en: `Title for ${toh}` },
+  },
+});
+
+describe('getTranslationImprints', () => {
+  it('batches keys into a single get_imprints call', async () => {
+    const { client, rpc } = createMockClient({
+      data: [imprintRow('uuid-1', 'toh1'), imprintRow('uuid-2', 'toh2')],
+      error: null,
+    });
+
+    const keys = [
+      { uuid: 'uuid-1', toh: 'toh1' },
+      { uuid: 'uuid-2', toh: 'toh2' },
+    ];
+    const imprints = await getTranslationImprints({ client, keys });
+
+    expect(rpc).toHaveBeenCalledTimes(1);
+    expect(rpc).toHaveBeenCalledWith('get_imprints', {
+      work_uuids: ['uuid-1', 'uuid-2'],
+      tohs: ['toh1', 'toh2'],
+    });
+    expect(imprints.size).toBe(2);
+    const first = imprints.get(imprintKey({ uuid: 'uuid-1', toh: 'toh1' }));
+    expect(first?.uuid).toBe('uuid-1');
+    expect(first?.mainTitles?.en).toBe('Title for toh1');
+  });
+
+  it('skips rows with no imprint', async () => {
+    const { client } = createMockClient({
+      data: [
+        imprintRow('uuid-1', 'toh1'),
+        { work_uuid: 'uuid-2', toh: 'toh2', imprint: null },
+      ],
+      error: null,
+    });
+
+    const imprints = await getTranslationImprints({
+      client,
+      keys: [
+        { uuid: 'uuid-1', toh: 'toh1' },
+        { uuid: 'uuid-2', toh: 'toh2' },
+      ],
+    });
+
+    expect(imprints.size).toBe(1);
+    expect(imprints.get(imprintKey({ uuid: 'uuid-2', toh: 'toh2' }))).toBe(
+      undefined,
+    );
+  });
+
+  it('returns an empty map without querying when there are no keys', async () => {
+    const { client, rpc } = createMockClient({ data: [], error: null });
+
+    const imprints = await getTranslationImprints({ client, keys: [] });
+
+    expect(imprints.size).toBe(0);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty map on error', async () => {
+    const { client } = createMockClient({
+      data: null,
+      error: new Error('boom'),
+    });
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const imprints = await getTranslationImprints({
+      client,
+      keys: [{ uuid: 'uuid-1', toh: 'toh1' }],
+    });
+
+    expect(imprints.size).toBe(0);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/libs/data-access/src/lib/imprint.ts
+++ b/libs/data-access/src/lib/imprint.ts
@@ -1,4 +1,10 @@
-import { DataClient, imprintFromDTO, tocFromDTO } from './types';
+import {
+  DataClient,
+  Imprint,
+  ImprintDTO,
+  imprintFromDTO,
+  tocFromDTO,
+} from './types';
 
 export const getTranslationToc = async ({
   client,
@@ -39,4 +45,47 @@ export const getTranslationImprint = async ({
   }
 
   return imprintFromDTO(data);
+};
+
+export type ImprintKey = { uuid: string; toh: string };
+
+export const imprintKey = ({ uuid, toh }: ImprintKey) => `${uuid}:${toh}`;
+
+export const getTranslationImprints = async ({
+  client,
+  keys,
+}: {
+  client: DataClient;
+  keys: readonly ImprintKey[];
+}): Promise<Map<string, Imprint>> => {
+  const imprintsByKey = new Map<string, Imprint>();
+  if (keys.length === 0) {
+    return imprintsByKey;
+  }
+
+  const { data, error } = await client.rpc('get_imprints', {
+    work_uuids: keys.map(({ uuid }) => uuid),
+    tohs: keys.map(({ toh }) => toh),
+  });
+
+  if (error || !data) {
+    console.error('Error batch fetching imprints:', error);
+    return imprintsByKey;
+  }
+
+  const rows = data as {
+    work_uuid: string;
+    toh: string;
+    imprint: ImprintDTO | null;
+  }[];
+  for (const row of rows) {
+    if (row.imprint) {
+      imprintsByKey.set(
+        imprintKey({ uuid: row.work_uuid, toh: row.toh }),
+        imprintFromDTO(row.imprint),
+      );
+    }
+  }
+
+  return imprintsByKey;
 };


### PR DESCRIPTION
## Summary

Fixes a N+1 query for work imprints, batching `Work.imprint` resolution so list queries no longer issue one `get_imprint` RPC per work. It relies on a new `get_imprints(work_uuids, tohs)` db function resolves a batch of (work uuid, toh) pairs and a DataLoader in GraphQL.

## Linear

[DEV-659](https://linear.app/84000/issue/DEV-659)
