### PR TITLE
Studio MCP OAuth Flow

### DIFF
--- a/apps/web-main/src/app/(auth)/oauth/authorize/page.tsx
+++ b/apps/web-main/src/app/(auth)/oauth/authorize/page.tsx
@@ -3,7 +3,7 @@ import { OAuthConsent } from '@lib-user';
 
 const OAuthAuthorizePage = () => {
   return (
-    <div className="w-screen h-screen flex">
+    <div className="w-screen h-screen flex bg-surface">
       <Suspense>
         <OAuthConsent />
       </Suspense>

--- a/apps/web-main/src/app/(auth)/oauth/authorize/page.tsx
+++ b/apps/web-main/src/app/(auth)/oauth/authorize/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react';
+import { OAuthConsent } from '@lib-user';
+
+const OAuthAuthorizePage = () => {
+  return (
+    <div className="w-screen h-screen flex">
+      <Suspense>
+        <OAuthConsent />
+      </Suspense>
+    </div>
+  );
+};
+
+export default OAuthAuthorizePage;

--- a/apps/web-main/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/web-main/src/app/.well-known/oauth-authorization-server/route.ts
@@ -3,20 +3,33 @@ const headers = {
   'Cache-Control': 'public, max-age=3600',
 };
 
+// Older MCP clients look for authorization-server metadata on the resource
+// origin, so mirror Supabase's discovery document rather than hardcoding
+// endpoints that can drift.
 export async function GET() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const authBase = `${supabaseUrl}/auth/v1`;
 
-  return new Response(
-    JSON.stringify({
-      issuer: authBase,
-      authorization_endpoint: `${authBase}/authorize`,
-      token_endpoint: `${authBase}/token?grant_type=pkce`,
-      response_types_supported: ['code'],
-      grant_types_supported: ['authorization_code'],
-      code_challenge_methods_supported: ['S256'],
-      token_endpoint_auth_methods_supported: ['none'],
-    }),
-    { headers },
-  );
+  try {
+    const res = await fetch(
+      `${supabaseUrl}/auth/v1/.well-known/oauth-authorization-server`,
+      { next: { revalidate: 3600 } },
+    );
+    if (!res.ok) {
+      console.error(
+        `Failed to fetch Supabase OAuth discovery metadata: ${res.status}`,
+      );
+      return new Response(JSON.stringify({ error: 'metadata_unavailable' }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify(await res.json()), { headers });
+  } catch (err) {
+    console.error('Failed to fetch Supabase OAuth discovery metadata:', err);
+    return new Response(JSON.stringify({ error: 'metadata_unavailable' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
 }

--- a/apps/web-main/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/web-main/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,7 +1,17 @@
+import {
+  MCP_CORS_HEADERS,
+  corsPreflightResponse,
+} from '@eightyfourthousand/lib-agent';
+
 const headers = {
+  ...MCP_CORS_HEADERS,
   'Content-Type': 'application/json',
   'Cache-Control': 'public, max-age=3600',
 };
+
+export async function OPTIONS() {
+  return corsPreflightResponse();
+}
 
 // Older MCP clients look for authorization-server metadata on the resource
 // origin, so mirror Supabase's discovery document rather than hardcoding

--- a/apps/web-main/src/app/.well-known/oauth-protected-resource/mcp/route.ts
+++ b/apps/web-main/src/app/.well-known/oauth-protected-resource/mcp/route.ts
@@ -1,0 +1,3 @@
+// RFC 9728 path-suffixed discovery: clients request the metadata for the
+// /mcp resource at /.well-known/oauth-protected-resource/mcp.
+export { GET, OPTIONS } from '../route';

--- a/apps/web-main/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/web-main/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,15 +1,25 @@
+import {
+  MCP_CORS_HEADERS,
+  corsPreflightResponse,
+} from '@eightyfourthousand/lib-agent';
+
 const headers = {
+  ...MCP_CORS_HEADERS,
   'Content-Type': 'application/json',
   'Cache-Control': 'public, max-age=3600',
 };
 
+export async function OPTIONS() {
+  return corsPreflightResponse();
+}
+
 export async function GET(req: Request) {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const resource = new URL(req.url).origin;
+  const { origin } = new URL(req.url);
 
   return new Response(
     JSON.stringify({
-      resource,
+      resource: `${origin}/mcp`,
       authorization_servers: [`${supabaseUrl}/auth/v1`],
       bearer_methods_supported: ['header'],
       scopes_supported: [],

--- a/apps/web-main/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/web-main/src/app/.well-known/oauth-protected-resource/route.ts
@@ -22,7 +22,11 @@ export async function GET(req: Request) {
       resource: `${origin}/mcp`,
       authorization_servers: [`${supabaseUrl}/auth/v1`],
       bearer_methods_supported: ['header'],
-      scopes_supported: [],
+      // openid is deliberately absent: ID-token signing requires asymmetric
+      // JWT keys, and this project still signs with the legacy HS256 secret.
+      // Clients that fall back to the authorization server's scopes_supported
+      // would request openid and get a 500 at the token endpoint.
+      scopes_supported: ['email', 'profile'],
     }),
     { headers },
   );

--- a/apps/web-main/src/app/mcp/route.ts
+++ b/apps/web-main/src/app/mcp/route.ts
@@ -1,7 +1,10 @@
 import {
+  MCP_CORS_HEADERS,
+  corsPreflightResponse,
   createMcpHandler,
   createReadTools,
   validateBearerToken,
+  withCorsHeaders,
 } from '@eightyfourthousand/lib-agent';
 
 const description =
@@ -29,8 +32,15 @@ Works can be looked up by **UUID** or **Tohoku catalog number** (e.g. "toh1", "t
 
 Start with \`get-translation\` to retrieve metadata for a work, then drill into passages, glossary terms, or bibliographies. Use \`search-translation\` for full-text search within a specific work. Use \`search-glossary-terms\` to find terms across the entire library.`;
 
+export async function OPTIONS() {
+  return corsPreflightResponse();
+}
+
 export async function GET() {
-  return new Response('Method not allowed', { status: 405 });
+  return new Response('Method not allowed', {
+    status: 405,
+    headers: MCP_CORS_HEADERS,
+  });
 }
 
 export async function POST(req: Request) {
@@ -41,9 +51,12 @@ export async function POST(req: Request) {
 
   const tools = createReadTools(auth.client);
   const handler = createMcpHandler({ description, instructions, tools });
-  return handler.POST(req);
+  return withCorsHeaders(await handler.POST(req));
 }
 
 export async function DELETE() {
-  return new Response('Method not allowed', { status: 405 });
+  return new Response('Method not allowed', {
+    status: 405,
+    headers: MCP_CORS_HEADERS,
+  });
 }

--- a/apps/web-main/src/app/mcp/route.ts
+++ b/apps/web-main/src/app/mcp/route.ts
@@ -34,7 +34,7 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
-  const auth = validateBearerToken(req);
+  const auth = await validateBearerToken(req);
   if (!auth.ok) {
     return auth.response;
   }

--- a/apps/web-main/src/proxy.ts
+++ b/apps/web-main/src/proxy.ts
@@ -21,9 +21,16 @@ try {
 }
 
 // /mcp does its own bearer-token auth; /.well-known serves public OAuth
-// discovery metadata. Neither uses cookie sessions, so both must bypass the
-// login redirect.
-const BASE_PUBLIC_ROUTES = ['/login', '/auth', '/mcp', '/.well-known'];
+// discovery metadata; /oauth/authorize is the consent screen, which handles
+// the signed-out state itself so the authorization_id survives login.
+// None of these use cookie sessions, so all must bypass the login redirect.
+const BASE_PUBLIC_ROUTES = [
+  '/login',
+  '/auth',
+  '/mcp',
+  '/.well-known',
+  '/oauth/authorize',
+];
 const BASE_RESTRICTED_ROUTES: Record<string, string[]> = {
   '/publications/editor': ['admin', 'editor', 'translator'],
   '/project': ['admin', 'editor', 'translator'],

--- a/apps/web-main/src/proxy.ts
+++ b/apps/web-main/src/proxy.ts
@@ -20,7 +20,10 @@ try {
   // File doesn't exist - use empty defaults
 }
 
-const BASE_PUBLIC_ROUTES = ['/login', '/auth'];
+// /mcp does its own bearer-token auth; /.well-known serves public OAuth
+// discovery metadata. Neither uses cookie sessions, so both must bypass the
+// login redirect.
+const BASE_PUBLIC_ROUTES = ['/login', '/auth', '/mcp', '/.well-known'];
 const BASE_RESTRICTED_ROUTES: Record<string, string[]> = {
   '/publications/editor': ['admin', 'editor', 'translator'],
   '/project': ['admin', 'editor', 'translator'],

--- a/libs/lib-agent/src/index.ts
+++ b/libs/lib-agent/src/index.ts
@@ -7,6 +7,11 @@ export {
   decodeRole,
   ROLE_HIERARCHY,
 } from './lib/auth';
+export {
+  MCP_CORS_HEADERS,
+  corsPreflightResponse,
+  withCorsHeaders,
+} from './lib/cors';
 export type {
   AuthResult,
   AuthSuccess,

--- a/libs/lib-agent/src/lib/auth.spec.ts
+++ b/libs/lib-agent/src/lib/auth.spec.ts
@@ -29,16 +29,19 @@ const mockedCreateTokenClient = jest.mocked(createTokenClient);
 const mockedHasPermission = jest.mocked(hasPermission);
 
 const makeRequest = (authHeader?: string) =>
-  new Request('http://localhost/api/mcp', {
+  new Request('http://localhost/mcp', {
     method: 'POST',
     headers: authHeader ? { Authorization: authHeader } : {},
   });
 
+const makeClient = (getUser: jest.Mock) =>
+  ({ auth: { getUser } }) as unknown as DataClient;
+
 describe('validateBearerToken', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('returns 401 when Authorization header is missing', () => {
-    const result = validateBearerToken(makeRequest());
+  it('returns 401 when Authorization header is missing', async () => {
+    const result = await validateBearerToken(makeRequest());
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -47,13 +50,13 @@ describe('validateBearerToken', () => {
         'Bearer',
       );
       expect(result.response.headers.get('WWW-Authenticate')).toContain(
-        'resource_metadata',
+        'resource_metadata="http://localhost/.well-known/oauth-protected-resource"',
       );
     }
   });
 
-  it('returns 401 for non-Bearer auth scheme', () => {
-    const result = validateBearerToken(makeRequest('Basic dXNlcjpwYXNz'));
+  it('returns 401 for non-Bearer auth scheme', async () => {
+    const result = await validateBearerToken(makeRequest('Basic dXNlcjpwYXNz'));
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -64,12 +67,29 @@ describe('validateBearerToken', () => {
     }
   });
 
-  it('returns 401 when JWT is invalid', () => {
-    mockedJwtDecode.mockImplementation(() => {
-      throw new Error('Invalid token');
+  it('returns 401 when the token fails server-side verification', async () => {
+    const getUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: { message: 'invalid JWT' },
     });
+    mockedCreateTokenClient.mockReturnValue(makeClient(getUser));
 
-    const result = validateBearerToken(makeRequest('Bearer bad.token.here'));
+    const result = await validateBearerToken(
+      makeRequest('Bearer forged.jwt.token'),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+    expect(getUser).toHaveBeenCalledWith('forged.jwt.token');
+  });
+
+  it('returns 401 when verification throws', async () => {
+    const getUser = jest.fn().mockRejectedValue(new Error('network error'));
+    mockedCreateTokenClient.mockReturnValue(makeClient(getUser));
+
+    const result = await validateBearerToken(makeRequest('Bearer bad.token'));
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -77,16 +97,18 @@ describe('validateBearerToken', () => {
     }
   });
 
-  it('returns auth context for valid JWT', () => {
-    mockedJwtDecode.mockReturnValue({
-      sub: 'user-123',
-      email: 'test@84000.co',
-      user_role: 'editor',
+  it('returns auth context for a verified token', async () => {
+    const getUser = jest.fn().mockResolvedValue({
+      data: { user: { id: 'user-123', email: 'test@84000.co' } },
+      error: null,
     });
-    const mockClient = {} as DataClient;
+    const mockClient = makeClient(getUser);
     mockedCreateTokenClient.mockReturnValue(mockClient);
+    mockedJwtDecode.mockReturnValue({ user_role: 'editor' });
 
-    const result = validateBearerToken(makeRequest('Bearer valid.jwt.token'));
+    const result = await validateBearerToken(
+      makeRequest('Bearer valid.jwt.token'),
+    );
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -96,13 +118,20 @@ describe('validateBearerToken', () => {
       expect(result.role).toBe('editor');
     }
     expect(mockedCreateTokenClient).toHaveBeenCalledWith('valid.jwt.token');
+    expect(getUser).toHaveBeenCalledWith('valid.jwt.token');
   });
 
-  it('defaults role to reader when user_role is missing', () => {
-    mockedJwtDecode.mockReturnValue({ sub: 'user-456' });
-    mockedCreateTokenClient.mockReturnValue({} as DataClient);
+  it('defaults role to reader when user_role is missing', async () => {
+    const getUser = jest.fn().mockResolvedValue({
+      data: { user: { id: 'user-456' } },
+      error: null,
+    });
+    mockedCreateTokenClient.mockReturnValue(makeClient(getUser));
+    mockedJwtDecode.mockReturnValue({});
 
-    const result = validateBearerToken(makeRequest('Bearer valid.jwt.token'));
+    const result = await validateBearerToken(
+      makeRequest('Bearer valid.jwt.token'),
+    );
 
     expect(result.ok).toBe(true);
     if (result.ok) {

--- a/libs/lib-agent/src/lib/auth.ts
+++ b/libs/lib-agent/src/lib/auth.ts
@@ -8,6 +8,7 @@ import type {
   UserRole,
   UserPermission,
 } from '@eightyfourthousand/data-access';
+import { MCP_CORS_HEADERS } from './cors';
 
 export type AuthSuccess = {
   ok: true;
@@ -41,6 +42,7 @@ const createUnauthorizedResponse = (
   new Response(JSON.stringify({ error: 'unauthorized', message }), {
     status: 401,
     headers: {
+      ...MCP_CORS_HEADERS,
       'Content-Type': 'application/json',
       'WWW-Authenticate': `Bearer realm="84000-mcp", resource_metadata="${resourceMetadataUrl}"`,
     },
@@ -51,7 +53,7 @@ const createForbiddenResponse = (
 ): Response =>
   new Response(JSON.stringify({ error: 'forbidden', message }), {
     status: 403,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { ...MCP_CORS_HEADERS, 'Content-Type': 'application/json' },
   });
 
 export const validateBearerToken = async (

--- a/libs/lib-agent/src/lib/auth.ts
+++ b/libs/lib-agent/src/lib/auth.ts
@@ -1,5 +1,8 @@
 import { jwtDecode } from 'jwt-decode';
-import { createTokenClient, hasPermission } from '@eightyfourthousand/data-access';
+import {
+  createTokenClient,
+  hasPermission,
+} from '@eightyfourthousand/data-access';
 import type {
   DataClient,
   UserRole,
@@ -32,14 +35,14 @@ export const ROLE_HIERARCHY: UserRole[] = [
 ];
 
 const createUnauthorizedResponse = (
+  resourceMetadataUrl: string,
   message = 'Authentication required',
 ): Response =>
   new Response(JSON.stringify({ error: 'unauthorized', message }), {
     status: 401,
     headers: {
       'Content-Type': 'application/json',
-      'WWW-Authenticate':
-        'Bearer realm="84000-mcp", resource_metadata="/.well-known/oauth-protected-resource"',
+      'WWW-Authenticate': `Bearer realm="84000-mcp", resource_metadata="${resourceMetadataUrl}"`,
     },
   });
 
@@ -51,35 +54,55 @@ const createForbiddenResponse = (
     headers: { 'Content-Type': 'application/json' },
   });
 
-export const validateBearerToken = (req: Request): AuthResult => {
+export const validateBearerToken = async (
+  req: Request,
+): Promise<AuthResult> => {
+  // RFC 9728 requires resource_metadata to be an absolute URI
+  const resourceMetadataUrl = new URL(
+    '/.well-known/oauth-protected-resource',
+    req.url,
+  ).toString();
+
   const authHeader = req.headers.get('authorization');
   if (!authHeader?.startsWith('Bearer ')) {
-    return { ok: false, response: createUnauthorizedResponse() };
+    return {
+      ok: false,
+      response: createUnauthorizedResponse(resourceMetadataUrl),
+    };
   }
 
   const token = authHeader.substring(7);
 
   try {
-    const decoded = jwtDecode<{
-      sub: string;
-      email?: string;
-      user_role?: UserRole;
-    }>(token);
-
     const client = createTokenClient(token);
-    const role = decoded.user_role ?? 'reader';
+
+    // Verify the token server-side; jwtDecode alone would accept forged or
+    // expired tokens.
+    const { data, error } = await client.auth.getUser(token);
+    if (error || !data?.user) {
+      return {
+        ok: false,
+        response: createUnauthorizedResponse(
+          resourceMetadataUrl,
+          'Invalid token',
+        ),
+      };
+    }
 
     return {
       ok: true,
       client,
-      userId: decoded.sub,
-      email: decoded.email ?? '',
-      role: ROLE_HIERARCHY.includes(role) ? role : 'reader',
+      userId: data.user.id,
+      email: data.user.email ?? '',
+      role: decodeRole(token),
     };
   } catch {
     return {
       ok: false,
-      response: createUnauthorizedResponse('Invalid token'),
+      response: createUnauthorizedResponse(
+        resourceMetadataUrl,
+        'Invalid token',
+      ),
     };
   }
 };

--- a/libs/lib-agent/src/lib/cors.ts
+++ b/libs/lib-agent/src/lib/cors.ts
@@ -1,0 +1,29 @@
+/**
+ * CORS headers for MCP and OAuth discovery endpoints. Browser-based MCP
+ * clients (MCP Inspector, claude.ai) fetch these cross-origin; bearer-token
+ * auth means wildcard origins are safe. 'Access-Control-Allow-Headers' must
+ * list Authorization explicitly — the '*' wildcard doesn't cover it.
+ */
+export const MCP_CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Authorization, Content-Type, Mcp-Protocol-Version, Mcp-Session-Id, Last-Event-Id',
+  'Access-Control-Expose-Headers': 'WWW-Authenticate, Mcp-Session-Id',
+  'Access-Control-Max-Age': '3600',
+};
+
+export const corsPreflightResponse = (): Response =>
+  new Response(null, { status: 204, headers: MCP_CORS_HEADERS });
+
+export const withCorsHeaders = (res: Response): Response => {
+  const headers = new Headers(res.headers);
+  Object.entries(MCP_CORS_HEADERS).forEach(([key, value]) =>
+    headers.set(key, value),
+  );
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+};

--- a/libs/lib-user/src/index.ts
+++ b/libs/lib-user/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/LibraryPassagesPage';
 export * from './lib/LibraryPublicationsPage';
 export * from './lib/LibrarySearchesPage';
 export * from './lib/Login';
+export * from './lib/OAuthConsent';
 export * from './lib/ProfileDropdown';
 export * from './lib/ProfileLayout';
 export * from './lib/ProfilePage';

--- a/libs/lib-user/src/lib/OAuthConsent.tsx
+++ b/libs/lib-user/src/lib/OAuthConsent.tsx
@@ -114,7 +114,7 @@ export const OAuthConsent = () => {
   );
 
   return (
-    <div className="w-full max-w-100 m-auto p-8 flex flex-col items-center gap-4 text-center">
+    <div className="w-full max-w-100 m-auto p-8 flex flex-col items-center gap-4 text-center bg-background rounded-lg border border-border shadow-sm">
       <MainLogo width={140} />
       {state.status === 'loading' && (
         <p className="text-sm text-muted-foreground">

--- a/libs/lib-user/src/lib/OAuthConsent.tsx
+++ b/libs/lib-user/src/lib/OAuthConsent.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import {
+  createBrowserClient,
+  getUser,
+  loginWithGoogle,
+} from '@eightyfourthousand/data-access';
+import {
+  Button,
+  GoogleLogo,
+  H4,
+  MainLogo,
+} from '@eightyfourthousand/design-system';
+
+type ConsentState =
+  | { status: 'loading' }
+  | { status: 'signed-out' }
+  | { status: 'error'; message: string }
+  | { status: 'redirecting' }
+  | {
+      status: 'consent';
+      clientName: string;
+      email: string;
+      scopes: string[];
+    };
+
+export const OAuthConsent = () => {
+  const searchParams = useSearchParams();
+  const authorizationId = searchParams.get('authorization_id');
+  const [client] = useState(createBrowserClient());
+  const [state, setState] = useState<ConsentState>({ status: 'loading' });
+
+  useEffect(() => {
+    (async () => {
+      if (!authorizationId) {
+        setState({
+          status: 'error',
+          message:
+            'Missing authorization request. Retry from the connecting app.',
+        });
+        return;
+      }
+
+      const user = await getUser({ client });
+      if (!user) {
+        setState({ status: 'signed-out' });
+        return;
+      }
+
+      const { data, error } =
+        await client.auth.oauth.getAuthorizationDetails(authorizationId);
+      if (error || !data) {
+        console.error('Failed to fetch authorization details:', error);
+        setState({
+          status: 'error',
+          message:
+            'This authorization request is invalid or has expired. Retry from the connecting app.',
+        });
+        return;
+      }
+
+      if ('redirect_url' in data) {
+        setState({ status: 'redirecting' });
+        window.location.assign(data.redirect_url);
+        return;
+      }
+
+      setState({
+        status: 'consent',
+        clientName: data.client.name,
+        email: data.user.email,
+        scopes: data.scope ? data.scope.split(' ') : [],
+      });
+    })();
+  }, [authorizationId, client]);
+
+  const signIn = useCallback(() => {
+    const next = encodeURIComponent(
+      `${window.location.pathname}${window.location.search}`,
+    );
+    loginWithGoogle({
+      client,
+      redirectTo: `${window.location.origin}/auth/callback?next=${next}`,
+    });
+  }, [client]);
+
+  const decide = useCallback(
+    async (approve: boolean) => {
+      if (!authorizationId) {
+        return;
+      }
+      setState({ status: 'redirecting' });
+      const action = approve
+        ? client.auth.oauth.approveAuthorization
+        : client.auth.oauth.denyAuthorization;
+      const { data, error } = await action.call(
+        client.auth.oauth,
+        authorizationId,
+        { skipBrowserRedirect: true },
+      );
+      if (error || !data) {
+        console.error('Failed to submit consent decision:', error);
+        setState({
+          status: 'error',
+          message: 'Something went wrong. Retry from the connecting app.',
+        });
+        return;
+      }
+      window.location.assign(data.redirect_url);
+    },
+    [authorizationId, client],
+  );
+
+  return (
+    <div className="w-full max-w-100 m-auto p-8 flex flex-col items-center gap-4 text-center">
+      <MainLogo width={140} />
+      {state.status === 'loading' && (
+        <p className="text-sm text-muted-foreground">
+          Loading authorization request…
+        </p>
+      )}
+      {state.status === 'redirecting' && (
+        <p className="text-sm text-muted-foreground">Redirecting…</p>
+      )}
+      {state.status === 'error' && (
+        <>
+          <H4 className="font-sans font-bold">Authorization Failed</H4>
+          <p className="text-sm text-muted-foreground">{state.message}</p>
+        </>
+      )}
+      {state.status === 'signed-out' && (
+        <>
+          <H4 className="font-sans font-bold">Sign In to Continue</H4>
+          <p className="text-sm text-muted-foreground">
+            An application is requesting access to 84000 Studio. Sign in to
+            review the request.
+          </p>
+          <div
+            onClick={signIn}
+            className="px-4 py-2 border-border border flex gap-3 items-center rounded-full text-sm justify-center cursor-pointer"
+          >
+            <GoogleLogo />
+            <span>Sign in with Google</span>
+          </div>
+        </>
+      )}
+      {state.status === 'consent' && (
+        <>
+          <H4 className="font-sans font-bold">Authorize {state.clientName}</H4>
+          <p className="text-sm text-muted-foreground">
+            <span className="font-semibold">{state.clientName}</span> wants to
+            access 84000 Studio as{' '}
+            <span className="font-semibold">{state.email}</span>
+            {state.scopes.length ? ` with: ${state.scopes.join(', ')}` : ''}.
+          </p>
+          <div className="flex gap-2 w-full justify-center">
+            <Button variant="outline" onClick={() => decide(false)}>
+              Deny
+            </Button>
+            <Button onClick={() => decide(true)}>Approve</Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
### Summary

Makes the studio MCP endpoint reachable and completes the OAuth 2.1 authorization flow against Supabase's OAuth server. The endpoint shipped previously was unreachable, tokens weren't verified server-side, and the flow had never been fully tested.

- Bearer tokens are now verified via `auth.getUser()` (previously decode-only).
- New consent screen at `/oauth/authorize`.
### Linear

- [DEV-609](https://linear.app/84000/issue/DEV-609)

### Notes

A known limitation is that the Claude Code CLI can't connect using `claude mcp` since it uses a random localhost callback port each session. Supabase auth redirects URIs by exact string with no exception for localhost. claude.ai connectors work, though.
