### PR TITLE
Expose library assistant via studio MCP endpoint

### DIFF
--- a/apps/web-main/src/app/mcp/route.ts
+++ b/apps/web-main/src/app/mcp/route.ts
@@ -1,6 +1,8 @@
 import {
   MCP_CORS_HEADERS,
   corsPreflightResponse,
+  createAgentPrompts,
+  createAgentTools,
   createMcpHandler,
   createReadTools,
   validateBearerToken,
@@ -49,8 +51,17 @@ export async function POST(req: Request) {
     return auth.response;
   }
 
-  const tools = createReadTools(auth.client);
-  const handler = createMcpHandler({ description, instructions, tools });
+  const tools = [
+    ...createReadTools(auth.client),
+    ...createAgentTools(auth.role),
+  ];
+  const prompts = createAgentPrompts(auth.role);
+  const handler = createMcpHandler({
+    description,
+    instructions,
+    tools,
+    prompts,
+  });
   return withCorsHeaders(await handler.POST(req));
 }
 

--- a/libs/lib-agent/src/index.ts
+++ b/libs/lib-agent/src/index.ts
@@ -1,10 +1,15 @@
 export { createMcpHandler } from './lib/server';
-export type { McpToolDefinition, McpHandlerOptions } from './lib/types';
+export type {
+  McpToolDefinition,
+  McpPromptDefinition,
+  McpHandlerOptions,
+} from './lib/types';
 export { createReadTools } from './lib/tools/read';
 export {
   validateBearerToken,
   requirePermission,
   decodeRole,
+  hasRole,
   ROLE_HIERARCHY,
 } from './lib/auth';
 export {
@@ -28,4 +33,6 @@ export {
   resolveAgentTools,
   resolveAgentHandlerOptions,
   createAgentTools,
+  createAgentPrompts,
+  buildAgentInstructions,
 } from './lib/agents';

--- a/libs/lib-agent/src/lib/agents/create-agent-prompts.spec.ts
+++ b/libs/lib-agent/src/lib/agents/create-agent-prompts.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ */
+import type { AgentDefinition } from './types';
+import { registerAgent, clearAgents } from './registry';
+import { createAgentPrompts } from './create-agent-prompts';
+
+const translatorAgent: AgentDefinition = {
+  name: 'test-translator',
+  description: 'A translator-level agent',
+  systemPrompt: 'You are a translator agent.',
+  tools: ['tool-a'],
+  requiredRole: 'translator',
+};
+
+const editorAgent: AgentDefinition = {
+  name: 'test-editor',
+  description: 'An editor-level agent',
+  systemPrompt: 'You are an editor agent.',
+  tools: ['tool-c'],
+  requiredRole: 'editor',
+};
+
+beforeEach(() => {
+  clearAgents();
+  registerAgent(translatorAgent);
+  registerAgent(editorAgent);
+});
+
+describe('createAgentPrompts', () => {
+  it('returns prompts for agents the user role can access', () => {
+    const prompts = createAgentPrompts('admin');
+    expect(prompts.map((p) => p.name)).toEqual([
+      'test-translator',
+      'test-editor',
+    ]);
+  });
+
+  it('excludes agents above the user role', () => {
+    const prompts = createAgentPrompts('translator');
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].name).toBe('test-translator');
+  });
+
+  it('excludes all agents below the required role', () => {
+    const prompts = createAgentPrompts('reader');
+    expect(prompts).toHaveLength(0);
+  });
+
+  it('handler returns the system prompt as a user message', () => {
+    const prompt = createAgentPrompts('translator')[0];
+    const result = prompt.handler(
+      {},
+      {} as Parameters<typeof prompt.handler>[1],
+    );
+    const message = (
+      result as { messages: { role: string; content: { text: string } }[] }
+    ).messages[0];
+
+    expect(message.role).toBe('user');
+    expect(message.content.text).toContain('You are a translator agent.');
+  });
+
+  it('handler embeds the query when provided', () => {
+    const prompt = createAgentPrompts('translator')[0];
+    const result = prompt.handler(
+      { query: 'Summarize toh44' },
+      {} as Parameters<typeof prompt.handler>[1],
+    );
+    const message = (result as { messages: { content: { text: string } }[] })
+      .messages[0];
+
+    expect(message.content.text).toContain('Summarize toh44');
+    expect(message.content.text).toContain('Current request');
+  });
+});

--- a/libs/lib-agent/src/lib/agents/create-agent-prompts.ts
+++ b/libs/lib-agent/src/lib/agents/create-agent-prompts.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import type { UserRole } from '@eightyfourthousand/data-access';
+import type { McpPromptDefinition } from '../types';
+import { hasRole } from '../auth';
+import { listAgents } from './registry';
+import { buildAgentInstructions } from './invocation';
+
+/**
+ * Exposes each role-permitted agent as an MCP prompt. Selecting the prompt in
+ * the connected client injects the agent's instructions (and an optional
+ * `query`) into the current conversation, so the chat itself acts as the agent
+ * using the read tools already on the connection.
+ */
+export function createAgentPrompts(userRole: UserRole): McpPromptDefinition[] {
+  return listAgents()
+    .filter((agent) => hasRole(userRole, agent.requiredRole))
+    .map((agent) => ({
+      name: agent.name,
+      title: agent.name,
+      description: agent.description,
+      argsSchema: {
+        query: z
+          .string()
+          .optional()
+          .describe('Optional request to pass to the agent'),
+      },
+      handler: ({ query }) => ({
+        messages: [
+          {
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: buildAgentInstructions(agent, query),
+            },
+          },
+        ],
+      }),
+    }));
+}

--- a/libs/lib-agent/src/lib/agents/create-agent-tools.spec.ts
+++ b/libs/lib-agent/src/lib/agents/create-agent-tools.spec.ts
@@ -58,7 +58,7 @@ describe('createAgentTools', () => {
     expect(tools[0].name).toBe('ask_my_hyphenated_agent');
   });
 
-  it('handler returns agent config without requiredRole', async () => {
+  it('handler returns activation text with the agent system prompt', async () => {
     const tools = createAgentTools('reader');
     const tool = tools[0];
     const result = await tool.handler(
@@ -66,28 +66,23 @@ describe('createAgentTools', () => {
       {} as Parameters<typeof tool.handler>[1],
     );
     const content = result.content as { type: string; text: string }[];
-    const config = JSON.parse(content[0].text);
 
-    expect(config).toEqual({
-      name: 'test-reader',
-      description: 'A reader-level agent',
-      systemPrompt: 'You are a test agent.',
-      tools: ['tool-a', 'tool-b'],
-      model: 'claude-sonnet-4-20250514',
-    });
-    expect(config).not.toHaveProperty('requiredRole');
+    expect(content[0].text).toContain('Adopt the following role');
+    expect(content[0].text).toContain('You are a test agent.');
+    expect(result.isError).toBeUndefined();
   });
 
-  it('handler omits model when undefined', async () => {
-    const tools = createAgentTools('admin');
-    const editorTool = tools.find((t) => t.name === 'ask_test_editor')!;
-    const result = await editorTool.handler(
-      {},
-      {} as Parameters<typeof editorTool.handler>[1],
+  it('handler appends the query when provided', async () => {
+    const tools = createAgentTools('reader');
+    const tool = tools[0];
+    const result = await tool.handler(
+      { query: 'What is toh1?' },
+      {} as Parameters<typeof tool.handler>[1],
     );
     const content = result.content as { type: string; text: string }[];
-    const config = JSON.parse(content[0].text);
 
-    expect(config.model).toBeUndefined();
+    expect(content[0].text).toContain('You are a test agent.');
+    expect(content[0].text).toContain('Current request');
+    expect(content[0].text).toContain('What is toh1?');
   });
 });

--- a/libs/lib-agent/src/lib/agents/create-agent-tools.ts
+++ b/libs/lib-agent/src/lib/agents/create-agent-tools.ts
@@ -1,32 +1,39 @@
+import { z } from 'zod';
 import type { UserRole } from '@eightyfourthousand/data-access';
 import type { McpToolDefinition } from '../types';
-import { jsonResult } from '../tools/read/util';
-import { ROLE_HIERARCHY } from '../auth';
+import { textResult } from '../tools/read/util';
+import { hasRole } from '../auth';
 import { listAgents } from './registry';
+import { buildAgentInstructions } from './invocation';
 
-function hasRole(userRole: UserRole, requiredRole: UserRole): boolean {
-  return ROLE_HIERARCHY.indexOf(userRole) >= ROLE_HIERARCHY.indexOf(requiredRole);
-}
+const ACTIVATION_PREAMBLE =
+  'Adopt the following role for the remainder of this conversation, and use the connected 84000 library tools to fulfil the request.';
 
+/**
+ * Fallback for clients that do not surface MCP prompts. Each role-permitted
+ * agent becomes an `ask_<name>` tool whose result steers the current chat into
+ * the agent's role (optionally scoped to a `query`).
+ */
 export function createAgentTools(userRole: UserRole): McpToolDefinition[] {
   return listAgents()
     .filter((agent) => hasRole(userRole, agent.requiredRole))
     .map((agent) => ({
       name: `ask_${agent.name.replace(/-/g, '_')}`,
       description: agent.description,
-      inputSchema: {},
+      inputSchema: {
+        query: z
+          .string()
+          .optional()
+          .describe('Optional request to pass to the agent'),
+      },
       annotations: {
         title: agent.name,
         readOnlyHint: true,
         openWorldHint: false,
       },
-      handler: async () =>
-        jsonResult({
-          name: agent.name,
-          description: agent.description,
-          systemPrompt: agent.systemPrompt,
-          tools: agent.tools,
-          model: agent.model,
-        }),
+      handler: async ({ query }) =>
+        textResult(
+          `${ACTIVATION_PREAMBLE}\n\n${buildAgentInstructions(agent, query)}`,
+        ),
     }));
 }

--- a/libs/lib-agent/src/lib/agents/index.ts
+++ b/libs/lib-agent/src/lib/agents/index.ts
@@ -11,6 +11,8 @@ export {
   resolveAgentHandlerOptions,
 } from './resolve';
 export { createAgentTools } from './create-agent-tools';
+export { createAgentPrompts } from './create-agent-prompts';
+export { buildAgentInstructions } from './invocation';
 
 import { registerAgent } from './registry';
 import { libraryAssistant } from './library-assistant/definition';

--- a/libs/lib-agent/src/lib/agents/invocation.ts
+++ b/libs/lib-agent/src/lib/agents/invocation.ts
@@ -1,0 +1,19 @@
+import type { AgentDefinition } from './types';
+
+/**
+ * Builds the instruction text that turns the calling chat into the agent.
+ * Both the MCP prompt and the fallback tool return this so an agent is
+ * "invoked" simply by steering the current conversation — no server-side
+ * agent loop or model call is involved.
+ */
+export function buildAgentInstructions(
+  agent: AgentDefinition,
+  query?: string,
+): string {
+  const base = agent.systemPrompt.trim();
+  const trimmedQuery = query?.trim();
+  if (!trimmedQuery) {
+    return base;
+  }
+  return `${base}\n\n## Current request\n\n${trimmedQuery}`;
+}

--- a/libs/lib-agent/src/lib/agents/library-assistant/definition.ts
+++ b/libs/lib-agent/src/lib/agents/library-assistant/definition.ts
@@ -23,5 +23,4 @@ export const libraryAssistant: AgentDefinition = {
     'get-work-titles',
   ],
   requiredRole: 'translator',
-  model: 'claude-sonnet-4-20250514',
 };

--- a/libs/lib-agent/src/lib/agents/library-assistant/definition.ts
+++ b/libs/lib-agent/src/lib/agents/library-assistant/definition.ts
@@ -22,6 +22,6 @@ export const libraryAssistant: AgentDefinition = {
     'lookup-entity',
     'get-work-titles',
   ],
-  requiredRole: 'reader',
+  requiredRole: 'translator',
   model: 'claude-sonnet-4-20250514',
 };

--- a/libs/lib-agent/src/lib/auth.ts
+++ b/libs/lib-agent/src/lib/auth.ts
@@ -35,6 +35,9 @@ export const ROLE_HIERARCHY: UserRole[] = [
   'admin',
 ];
 
+export const hasRole = (userRole: UserRole, requiredRole: UserRole): boolean =>
+  ROLE_HIERARCHY.indexOf(userRole) >= ROLE_HIERARCHY.indexOf(requiredRole);
+
 const createUnauthorizedResponse = (
   resourceMetadataUrl: string,
   message = 'Authentication required',

--- a/libs/lib-agent/src/lib/server.spec.ts
+++ b/libs/lib-agent/src/lib/server.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+import { z } from 'zod';
+import { createMcpHandler } from './server';
+import type { McpPromptDefinition, McpToolDefinition } from './types';
+
+const askTool: McpToolDefinition = {
+  name: 'ask_test',
+  description: 'A test tool',
+  inputSchema: { query: z.string().optional() },
+  handler: async () => ({ content: [{ type: 'text', text: 'hi' }] }),
+};
+
+const askPrompt: McpPromptDefinition = {
+  name: 'test-agent',
+  title: 'test-agent',
+  description: 'A test agent prompt',
+  argsSchema: { query: z.string().optional() },
+  handler: () => ({
+    messages: [
+      { role: 'user', content: { type: 'text', text: 'You are a test agent.' } },
+    ],
+  }),
+};
+
+async function rpc(
+  handler: ReturnType<typeof createMcpHandler>,
+  body: unknown,
+): Promise<Record<string, unknown>> {
+  const res = await handler.POST(
+    new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+  const text = await res.text();
+  // Response is either JSON or an SSE frame ("event: message\ndata: {...}")
+  const dataLine = text
+    .split('\n')
+    .find((l) => l.startsWith('data: '));
+  return JSON.parse(dataLine ? dataLine.slice(6) : text);
+}
+
+const init = {
+  jsonrpc: '2.0',
+  id: 0,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'test', version: '0.0.0' },
+  },
+};
+
+describe('createMcpHandler prompt + tool surface', () => {
+  it('lists registered prompts over JSON-RPC', async () => {
+    const handler = createMcpHandler({ tools: [askTool], prompts: [askPrompt] });
+    await rpc(handler, init);
+    const listed = await rpc(handler, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'prompts/list',
+      params: {},
+    });
+    const prompts = (listed.result as { prompts: { name: string }[] }).prompts;
+    expect(prompts.map((p) => p.name)).toContain('test-agent');
+  });
+
+  it('returns prompt messages on prompts/get', async () => {
+    const handler = createMcpHandler({ tools: [askTool], prompts: [askPrompt] });
+    await rpc(handler, init);
+    const got = await rpc(handler, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'prompts/get',
+      params: { name: 'test-agent', arguments: {} },
+    });
+    const messages = (got.result as { messages: { content: { text: string } }[] })
+      .messages;
+    expect(messages[0].content.text).toContain('You are a test agent.');
+  });
+
+  it('lists the agent tool alongside prompts', async () => {
+    const handler = createMcpHandler({ tools: [askTool], prompts: [askPrompt] });
+    await rpc(handler, init);
+    const listed = await rpc(handler, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/list',
+      params: {},
+    });
+    const tools = (listed.result as { tools: { name: string }[] }).tools;
+    expect(tools.map((t) => t.name)).toContain('ask_test');
+  });
+});

--- a/libs/lib-agent/src/lib/server.ts
+++ b/libs/lib-agent/src/lib/server.ts
@@ -9,6 +9,7 @@ export function createMcpHandler(options: McpHandlerOptions) {
     description,
     instructions,
     tools,
+    prompts = [],
   } = options;
 
   function buildServer(): McpServer {
@@ -38,7 +39,12 @@ export function createMcpHandler(options: McpHandlerOptions) {
       );
     }
 
-    if (tools.length === 0) {
+    for (const prompt of prompts) {
+      const { name, title, description, argsSchema, handler } = prompt;
+      server.registerPrompt(name, { title, description, argsSchema }, handler);
+    }
+
+    if (tools.length === 0 && prompts.length === 0) {
       const placeholder = server.registerTool(
         '_init',
         { description: 'placeholder' },

--- a/libs/lib-agent/src/lib/tools/read/util.ts
+++ b/libs/lib-agent/src/lib/tools/read/util.ts
@@ -6,6 +6,12 @@ export function jsonResult(data: unknown): CallToolResult {
   };
 }
 
+export function textResult(text: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text }],
+  };
+}
+
 export function errorResult(message: string): CallToolResult {
   return {
     content: [{ type: 'text', text: message }],

--- a/libs/lib-agent/src/lib/types.ts
+++ b/libs/lib-agent/src/lib/types.ts
@@ -1,4 +1,7 @@
-import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  ToolCallback,
+  PromptCallback,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ZodRawShapeCompat } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types';
 
@@ -14,10 +17,21 @@ export interface McpToolDefinition<
   handler: ToolCallback<T>;
 }
 
+export interface McpPromptDefinition<
+  Args extends ZodRawShapeCompat = ZodRawShapeCompat,
+> {
+  name: string;
+  title?: string;
+  description?: string;
+  argsSchema?: Args;
+  handler: PromptCallback<Args>;
+}
+
 export interface McpHandlerOptions {
   name?: string;
   version?: string;
   description?: string;
   instructions?: string;
   tools: McpToolDefinition[];
+  prompts?: McpPromptDefinition[];
 }


### PR DESCRIPTION
### Summary

Exposes the `lib-agent` library assistant to authenticated studio MCP clients so it can be invoked from the current chat.

### Linear

- [DEV-618](https://linear.app/84000/issue/DEV-618)

### Notes

- Primary path is a MCP prompt that injects the agent's system prompt into the chat. This then uses the read tools already on the connection. `ask_<agent>` tools are a fallback for clients that don't surface prompts.
- Whether the claude.ai web connector surfaces MCP prompts in its UI is unconfirmed by official docs — the tool fallback covers that case.
