### PR TITLE
Fix: Abbreviation Display

### DIFF
--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -15,6 +15,10 @@
     @apply mb-1 mt-2 @c/sidebar:pt-1;
   }
 
+  .paragraph:has(> [type='abbreviation']) {
+    @apply grid grid-cols-[5rem_minmax(0,1fr)] items-baseline gap-x-2;
+  }
+
   a {
     @apply text-primary underline decoration-primary underline-offset-[3px] transition-colors cursor-pointer;
   }

--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -83,10 +83,11 @@ const paragraphTemplate = (passage: Passage): TranslationEditorContentItem => {
 const abbreviationTemplate = (
   passage: Passage,
 ): TranslationEditorContentItem => {
+  // The two-column key | explanation layout is applied at render time via the
+  // `.paragraph:has(> [type='abbreviation'])` rule in the design-system.
   const block: TranslationEditorContentItem = {
     type: 'paragraph',
     attrs: {
-      class: 'flex flex-row gap-2',
       start: 0,
       end: passage.content.length,
       uuid: passage.uuid,

--- a/libs/lib-editing/src/lib/components/editor/extensions/Abbreviation/Abbreviation.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Abbreviation/Abbreviation.ts
@@ -78,7 +78,7 @@ export const Abbreviation = Node.create<AbbreviationOptions>({
   addOptions() {
     return {
       HTMLAttributes: {
-        class: 'italic min-w-8',
+        class: 'italic break-words',
       },
     };
   },
@@ -121,7 +121,11 @@ export const HasAbbreviation = Node.create<AbbreviationOptions>({
 
   addOptions() {
     return {
-      HTMLAttributes: {},
+      // break-words lets long, unbreakable tokens in the explanation wrap
+      // rather than overflow the column and force horizontal scroll.
+      HTMLAttributes: {
+        class: 'break-words',
+      },
     };
   },
 

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -267,6 +267,47 @@ describe('TranslationSSRContent', () => {
     expect(html).not.toContain('abbreviation="undefined"');
   });
 
+  it('renders the abbreviation key as a direct child of the paragraph so the two-column layout applies', () => {
+    // The Abbreviations tab renders each entry as a two-column grid via the
+    // `.paragraph:has(> [type='abbreviation'])` rule in the design-system
+    // stylesheet. That selector requires the key span to be an immediate child
+    // of the `.paragraph`, and it keys off the `type="abbreviation"` attribute.
+    // Pin both here (ED-1340).
+    const abbrDoc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'abbreviation', content: [{ type: 'text', text: 'Mvy' }] },
+                {
+                  type: 'hasAbbreviation',
+                  content: [{ type: 'text', text: 'Mahāvyutpatti' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const el = TranslationSSRContent({
+      content: abbrDoc,
+    }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+
+    // Key span is styled and immediately follows the opening paragraph tag
+    // (the paragraph carries the `paragraph` class among others).
+    expect(html).toMatch(
+      /<p[^>]*class="[^"]*\bparagraph\b[^"]*"[^>]*>\s*<span[^>]*type="abbreviation"/,
+    );
+    expect(html).toContain('class="italic break-words"');
+    expect(html).toContain('type="hasAbbreviation"');
+  });
+
   it('accepts an array of nodes and wraps them as a doc', () => {
     const el = TranslationSSRContent({
       content: passageDoc.content as JSONContent[],


### PR DESCRIPTION
### Summary

Restore the expected presentation of abbreviation passages. They display as two columns.

### Linear

- [ED-1340](https://linear.app/84000/issue/ED-1340)

### Screenshots

<img width="558" height="386" alt="Screenshot 2026-07-13 at 10 36 46 AM" src="https://github.com/user-attachments/assets/08948fb5-24e1-4329-9deb-b2e6cb5ca4e9" />