### PR TITLE
Fix Leading Space Annotations

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/LeadingSpace.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/LeadingSpace.ts
@@ -30,7 +30,7 @@ export const LeadingSpace = Extension.create<LeadingSpaceOptions>({
   name: 'leadingSpace',
   addOptions() {
     return {
-      types: ['paragraph', 'heading', 'lineGroup'],
+      types: ['paragraph', 'heading', 'lineGroup', 'blockquote'],
       defaultHasLeadingSpace: false,
     };
   },

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/ParagraphButtons.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/ParagraphButtons.tsx
@@ -32,10 +32,14 @@ export const ParagraphButtons = ({ editor }: { editor: Editor }) => {
   const editorState = useEditorState<SelectorResult>({
     editor,
     selector: (instance) => {
+      // isActive with an attributes-only argument checks whichever block type
+      // holds the cursor (paragraph, heading, lineGroup, blockquote, list), so
+      // the toggles light up on every host type — not just paragraphs. This
+      // mirrors the check inside toggleLeadingSpace/toggleIndent, keeping the
+      // button state and the commands in sync.
       const atts = {
-        hasIndent: !!instance.editor.getAttributes('paragraph')['hasIndent'],
-        hasLeadingSpace:
-          !!instance.editor.getAttributes('paragraph')['hasLeadingSpace'],
+        hasIndent: instance.editor.isActive({ hasIndent: true }),
+        hasLeadingSpace: instance.editor.isActive({ hasLeadingSpace: true }),
       };
       return atts;
     },

--- a/libs/lib-editing/src/lib/transformers/leading-space.spec.ts
+++ b/libs/lib-editing/src/lib/transformers/leading-space.spec.ts
@@ -1,10 +1,8 @@
 import {
-  Annotation,
   annotationsFromDTO,
   PassageDTO,
   passageFromDTO,
 } from '@eightyfourthousand/data-access';
-import { leadingSpace } from './leading-space';
 import { blockFromPassage } from '../block';
 
 const dto: PassageDTO = {
@@ -50,6 +48,73 @@ describe('leadingSpace transformer', () => {
     expect(paragraphBlock?.attrs?.hasLeadingSpace).toBe(true);
     expect(paragraphBlock?.attrs?.leadingSpaceUuid).toBe(
       'leading-space-uuid-1',
+    );
+  });
+});
+
+describe('leadingSpace transformer at a paragraph boundary', () => {
+  // "First paragraph." is 16 chars; the second paragraph and the leading-space
+  // both start at 16, in the middle of the passage.
+  const boundaryDto: PassageDTO = {
+    sort: 1,
+    type: 'root',
+    uuid: 'passage-uuid-1234',
+    label: '',
+    xmlId: 'test-passage',
+    parent: 'test-parent',
+    content: 'First paragraph.Second paragraph.',
+    work_uuid: 'work-uuid-5678',
+    annotations: [
+      {
+        end: 16,
+        type: 'paragraph',
+        uuid: 'paragraph-uuid-1',
+        start: 0,
+        content: [],
+        passage_uuid: 'passage-uuid-1234',
+      },
+      {
+        end: 33,
+        type: 'paragraph',
+        uuid: 'paragraph-uuid-2',
+        start: 16,
+        content: [],
+        passage_uuid: 'passage-uuid-1234',
+      },
+      {
+        end: 16,
+        type: 'leading-space',
+        uuid: 'leading-space-uuid-2',
+        start: 16,
+        content: [],
+        passage_uuid: 'passage-uuid-1234',
+      },
+    ],
+  };
+
+  const passage = passageFromDTO(
+    boundaryDto,
+    annotationsFromDTO(
+      boundaryDto.annotations || [],
+      boundaryDto.content.length,
+    ),
+  );
+  const block = blockFromPassage(passage);
+
+  if (!block?.content) {
+    throw new Error('Block conversion failed');
+  }
+
+  it('applies the leading space to the block at the insertion point, not the preceding block', () => {
+    const [firstParagraph, secondParagraph] = block.content ?? [];
+
+    expect(firstParagraph?.attrs?.uuid).toBe('paragraph-uuid-1');
+    expect(firstParagraph?.attrs?.hasLeadingSpace).toBeFalsy();
+
+    expect(secondParagraph?.attrs?.uuid).toBe('paragraph-uuid-2');
+    expect(secondParagraph?.attrs?.hasLeadingSpace).toBe(true);
+    expect(secondParagraph?.attrs?.leadingSpaceUuid).toBe(
+      'leading-space-uuid-2',
     );
   });
 });

--- a/libs/lib-editing/src/lib/transformers/leading-space.ts
+++ b/libs/lib-editing/src/lib/transformers/leading-space.ts
@@ -1,17 +1,68 @@
+import { AnnotationType } from '@eightyfourthousand/data-access';
 import { recurse } from './recurse';
 import { Transformer } from './transformer';
+import { TranslationEditorContentItem } from '../components';
+
+const HOST_TYPES: AnnotationType[] = [
+  'blockquote',
+  'heading',
+  'lineGroup',
+  'paragraph',
+];
+
+/**
+ * A leading-space is a zero-width annotation marking the point that should be
+ * preceded by extra vertical space. It must land on the host block that *begins*
+ * at that point — the block the space precedes — not the block that ends there.
+ *
+ * `recurse` matches the first block whose range contains the annotation, so at a
+ * boundary between two paragraphs (e.g. a leading-space at 40 between paragraphs
+ * (0, 40) and (40, 80)) it would attach to the preceding paragraph, which
+ * renders no gap and round-trips back to the wrong position. Prefer the block
+ * whose start equals the insertion point instead.
+ */
+const findInsertionBlock = (
+  block: TranslationEditorContentItem,
+  position: number,
+): TranslationEditorContentItem | undefined => {
+  for (const child of block.content || []) {
+    if (
+      HOST_TYPES.includes((child.type || 'unknown') as AnnotationType) &&
+      child.attrs?.start === position
+    ) {
+      return child;
+    }
+
+    const nested = findInsertionBlock(child, position);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return undefined;
+};
 
 export const leadingSpace: Transformer = (ctx) => {
   const leadingSpaceUuid = ctx.annotation.uuid;
+  const applyLeadingSpace = (block: TranslationEditorContentItem) => {
+    block.attrs = {
+      ...block.attrs,
+      hasLeadingSpace: true,
+      leadingSpaceUuid,
+    };
+  };
+
+  const insertionBlock = findInsertionBlock(ctx.block, ctx.annotation.start);
+  if (insertionBlock) {
+    applyLeadingSpace(insertionBlock);
+    return;
+  }
+
+  // Fallback: no host block begins exactly at the insertion point (e.g. the
+  // annotation sits inside a block's text). Attach to the containing block.
   recurse({
     ...ctx,
-    until: ['paragraph', 'lineGroup', 'heading'],
-    transform: ({ block }) => {
-      block.attrs = {
-        ...block.attrs,
-        hasLeadingSpace: true,
-        leadingSpaceUuid,
-      };
-    },
+    until: HOST_TYPES,
+    transform: ({ block }) => applyLeadingSpace(block),
   });
 };


### PR DESCRIPTION
### Summary

The initial implementation of the `leading-space` annotation applied it as a passage attribute. It is meant to be applicable to most block types, such as heading, paragraphs, etc.

### Linear

- [ED-1105](https://linear.app/84000/issue/ED-1105)
