### PR TITLE
Editor cursor details

### DIFF
--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -54,7 +54,7 @@
   }
 
   .mention-link[entity-type='folio'] {
-    @apply ps-px pe-1;
+    @apply px-px;
   }
 
   .mention-link[entity-type='work']:not([lang='bo'], [lang='ja'], [lang='zh']) {

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteCursor.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteCursor.spec.ts
@@ -1,0 +1,179 @@
+import { Schema } from '@tiptap/pm/model';
+import { EditorState, Plugin, TextSelection } from '@tiptap/pm/state';
+import { DecorationSet, EditorView } from '@tiptap/pm/view';
+import {
+  createEndNoteCursorPlugin,
+  endNoteCursorKey,
+  findEndNoteBoundary,
+  type EndNoteLinkNote,
+} from './EndNoteCursor';
+import { createEndNoteLinkDecorations } from './EndNoteLinkMark';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: {
+      content: 'text*',
+      group: 'block',
+      toDOM: () => ['p', 0],
+    },
+    text: { group: 'inline' },
+  },
+  marks: {
+    endNoteLink: {
+      attrs: { notes: { default: undefined } },
+      toDOM: () => ['span', 0],
+    },
+  },
+});
+
+const notes: EndNoteLinkNote[] = [
+  { uuid: 'n1', endNote: 'e1', location: 'end', label: '1.1' },
+  { uuid: 'n2', endNote: 'e2', location: 'end', label: '1.2' },
+];
+
+const createView = (selectionPos: number) => {
+  const endNoteMark = schema.marks['endNoteLink'].create({ notes });
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', null, [
+      schema.text('word', [endNoteMark]),
+      schema.text(' next'),
+    ]),
+  ]);
+  const cursorPlugin = createEndNoteCursorPlugin('endNoteLink');
+  const decorationPlugin = new Plugin({
+    props: {
+      decorations: (state) =>
+        DecorationSet.create(
+          state.doc,
+          createEndNoteLinkDecorations(state.doc, 'endNoteLink', (note) => {
+            const marker = document.createElement('sup');
+            marker.setAttribute('data-end-note-marker', '');
+            marker.setAttribute('uuid', note.uuid);
+            marker.textContent = note.label || '';
+            return marker;
+          }),
+        ),
+    },
+  });
+  const state = EditorState.create({
+    schema,
+    doc,
+    selection: TextSelection.create(doc, selectionPos),
+    plugins: [cursorPlugin, decorationPlugin],
+  });
+  const view = new EditorView(document.body, { state });
+
+  return { cursorPlugin, view };
+};
+
+const press = (
+  view: EditorView,
+  cursorPlugin: Plugin,
+  key: 'ArrowLeft' | 'ArrowRight' | 'Backspace' | 'Delete',
+) =>
+  cursorPlugin.props.handleKeyDown?.(
+    view,
+    new KeyboardEvent('keydown', { key }),
+  ) || false;
+
+const typeText = (view: EditorView, cursorPlugin: Plugin, text: string) =>
+  cursorPlugin.props.handleTextInput?.(
+    view,
+    view.state.selection.from,
+    view.state.selection.to,
+    text,
+    () => view.state.tr,
+  ) || false;
+
+describe('EndNoteCursor', () => {
+  it('traverses every superscript from left to right', () => {
+    const { cursorPlugin, view } = createView(4);
+
+    expect(press(view, cursorPlugin, 'ArrowRight')).toBe(true);
+    expect(endNoteCursorKey.getState(view.state)).toEqual({ pos: 5, slot: 0 });
+
+    expect(press(view, cursorPlugin, 'ArrowRight')).toBe(true);
+    expect(endNoteCursorKey.getState(view.state)).toEqual({ pos: 5, slot: 1 });
+    const domSelection = document.getSelection();
+    const renderedMarkers = Array.from(
+      view.dom.querySelectorAll<HTMLElement>('[data-end-note-marker]'),
+    );
+    const firstMarkerIndex = Array.prototype.indexOf.call(
+      renderedMarkers[0].parentNode?.childNodes,
+      renderedMarkers[0],
+    );
+    expect(domSelection?.focusNode).toBe(renderedMarkers[0].parentNode);
+    expect(domSelection?.focusOffset).toBe(firstMarkerIndex + 1);
+
+    expect(press(view, cursorPlugin, 'ArrowRight')).toBe(true);
+    expect(endNoteCursorKey.getState(view.state)).toEqual({ pos: 5, slot: 2 });
+
+    expect(press(view, cursorPlugin, 'ArrowRight')).toBe(false);
+    expect(endNoteCursorKey.getState(view.state)).toBeNull();
+    view.destroy();
+  });
+
+  it('traverses every superscript from right to left', () => {
+    const { cursorPlugin, view } = createView(6);
+
+    expect(press(view, cursorPlugin, 'ArrowLeft')).toBe(true);
+    expect(endNoteCursorKey.getState(view.state)).toEqual({ pos: 5, slot: 2 });
+
+    expect(press(view, cursorPlugin, 'ArrowLeft')).toBe(true);
+    expect(endNoteCursorKey.getState(view.state)).toEqual({ pos: 5, slot: 1 });
+
+    expect(press(view, cursorPlugin, 'ArrowLeft')).toBe(true);
+    expect(endNoteCursorKey.getState(view.state)).toEqual({ pos: 5, slot: 0 });
+
+    expect(press(view, cursorPlugin, 'ArrowLeft')).toBe(false);
+    expect(endNoteCursorKey.getState(view.state)).toBeNull();
+    view.destroy();
+  });
+
+  it('removes only the superscript immediately beside the cursor', () => {
+    const { cursorPlugin, view } = createView(4);
+    press(view, cursorPlugin, 'ArrowRight');
+    press(view, cursorPlugin, 'ArrowRight');
+
+    expect(press(view, cursorPlugin, 'Backspace')).toBe(true);
+    expect(view.state.doc.textContent).toBe('word next');
+    expect(
+      findEndNoteBoundary(view.state.doc, 5, 'endNoteLink')?.notes,
+    ).toEqual([notes[1]]);
+    expect(endNoteCursorKey.getState(view.state)).toEqual({ pos: 5, slot: 0 });
+
+    expect(press(view, cursorPlugin, 'Delete')).toBe(true);
+    expect(view.state.doc.textContent).toBe('word next');
+    expect(findEndNoteBoundary(view.state.doc, 5, 'endNoteLink')).toBeNull();
+    view.destroy();
+  });
+
+  it('inserts marked text before the superscript cluster', () => {
+    const { cursorPlugin, view } = createView(4);
+    press(view, cursorPlugin, 'ArrowRight');
+
+    expect(typeText(view, cursorPlugin, ' ')).toBe(true);
+    expect(view.state.doc.textContent).toBe('word  next');
+    expect(
+      findEndNoteBoundary(view.state.doc, 6, 'endNoteLink')?.notes,
+    ).toEqual(notes);
+    expect(endNoteCursorKey.getState(view.state)).toEqual({ pos: 6, slot: 0 });
+    view.destroy();
+  });
+
+  it('inserts unmarked text after the superscript cluster', () => {
+    const { cursorPlugin, view } = createView(4);
+    press(view, cursorPlugin, 'ArrowRight');
+    press(view, cursorPlugin, 'ArrowRight');
+    press(view, cursorPlugin, 'ArrowRight');
+
+    expect(typeText(view, cursorPlugin, ' ')).toBe(true);
+    expect(view.state.doc.textContent).toBe('word  next');
+    expect(
+      findEndNoteBoundary(view.state.doc, 5, 'endNoteLink')?.notes,
+    ).toEqual(notes);
+    expect(endNoteCursorKey.getState(view.state)).toBeNull();
+    view.destroy();
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteCursor.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteCursor.ts
@@ -1,0 +1,357 @@
+import type { Mark, Node as PMNode } from '@tiptap/pm/model';
+import {
+  Plugin,
+  PluginKey,
+  TextSelection,
+  type EditorState,
+  type Transaction,
+} from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+
+export interface EndNoteLinkNote {
+  uuid: string;
+  location?: string;
+  toh?: string;
+  endNote: string;
+  label?: string;
+}
+
+export interface EndNoteBoundary {
+  pos: number;
+  from: number;
+  mark: Mark;
+  notes: EndNoteLinkNote[];
+  textMarks: readonly Mark[];
+}
+
+export interface EndNoteCursorAffinity {
+  pos: number;
+  /** Caret slot: 0 before all markers, notes.length after all markers. */
+  slot: number;
+}
+
+export const endNoteCursorKey = new PluginKey<EndNoteCursorAffinity | null>(
+  'endNoteLinkCursor',
+);
+
+const sortedEndNotes = (mark: Mark): EndNoteLinkNote[] =>
+  [...((mark.attrs.notes || []) as EndNoteLinkNote[])]
+    .filter((note) => note.location !== 'start')
+    .sort((a, b) => (a.label || '').localeCompare(b.label || ''));
+
+export const findEndNoteBoundary = (
+  doc: PMNode,
+  pos: number,
+  markName: string,
+): EndNoteBoundary | null => {
+  if (pos < 0 || pos > doc.content.size) return null;
+
+  const $pos = doc.resolve(pos);
+  const before = $pos.nodeBefore;
+  if (!before?.isText) return null;
+
+  const mark = before.marks.find(
+    (candidate) => candidate.type.name === markName,
+  );
+  if (!mark) return null;
+
+  // A text offset inside the same marked run is not its end boundary.
+  const afterHasSameMark = $pos.nodeAfter?.marks.some((candidate) =>
+    candidate.eq(mark),
+  );
+  if (afterHasSameMark) return null;
+
+  const notes = sortedEndNotes(mark);
+  if (notes.length === 0) return null;
+
+  return {
+    pos,
+    from: pos - before.nodeSize,
+    mark,
+    notes,
+    textMarks: before.marks,
+  };
+};
+
+const marksForSlot = (
+  boundary: EndNoteBoundary,
+  slot: number,
+): readonly Mark[] => {
+  const withoutEndNote = boundary.mark.removeFromSet(boundary.textMarks);
+  return slot === 0 ? boundary.mark.addToSet(withoutEndNote) : withoutEndNote;
+};
+
+const dispatchAffinity = (
+  view: EditorView,
+  boundary: EndNoteBoundary,
+  slot: number,
+) => {
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, boundary.pos))
+      .setStoredMarks(marksForSlot(boundary, slot))
+      .setMeta(endNoteCursorKey, { pos: boundary.pos, slot }),
+  );
+  return true;
+};
+
+const markerElements = (
+  view: EditorView,
+  boundary: EndNoteBoundary,
+): HTMLElement[] => {
+  const allMarkers = Array.from(
+    view.dom.querySelectorAll<HTMLElement>('[data-end-note-marker]'),
+  );
+
+  return boundary.notes
+    .map((note) =>
+      allMarkers.find((element) => element.getAttribute('uuid') === note.uuid),
+    )
+    .filter((element): element is HTMLElement => !!element);
+};
+
+export const placeEndNoteCursor = (
+  view: EditorView,
+  affinity: EndNoteCursorAffinity,
+  markName: string,
+) => {
+  const boundary = findEndNoteBoundary(view.state.doc, affinity.pos, markName);
+  if (!boundary) return false;
+
+  const markers = markerElements(view, boundary);
+  if (markers.length !== boundary.notes.length) return false;
+
+  const marker = markers[Math.max(0, affinity.slot - 1)];
+  const parent = marker?.parentNode;
+  if (!parent) return false;
+
+  const markerIndex = Array.prototype.indexOf.call(parent.childNodes, marker);
+  const offset = affinity.slot === 0 ? markerIndex : markerIndex + 1;
+  const domSelection = (view.root as Document).getSelection();
+  if (!domSelection) return false;
+
+  domSelection.collapse(parent, offset);
+  return true;
+};
+
+const removeBoundaryNote = (
+  view: EditorView,
+  boundary: EndNoteBoundary,
+  noteIndex: number,
+  nextSlot: number,
+) => {
+  const note = boundary.notes[noteIndex];
+  if (!note) return false;
+
+  const remainingNotes = (
+    (boundary.mark.attrs.notes || []) as EndNoteLinkNote[]
+  ).filter((candidate) => candidate.uuid !== note.uuid);
+  const tr = view.state.tr.removeMark(
+    boundary.from,
+    boundary.pos,
+    boundary.mark.type,
+  );
+
+  if (remainingNotes.length > 0) {
+    const nextMark = boundary.mark.type.create({
+      ...boundary.mark.attrs,
+      notes: remainingNotes,
+    });
+    tr.addMark(boundary.from, boundary.pos, nextMark);
+
+    const nextBoundary: EndNoteBoundary = {
+      ...boundary,
+      mark: nextMark,
+      notes: sortedEndNotes(nextMark),
+      textMarks: nextMark.addToSet(
+        boundary.mark.removeFromSet(boundary.textMarks),
+      ),
+    };
+    tr.setStoredMarks(marksForSlot(nextBoundary, nextSlot)).setMeta(
+      endNoteCursorKey,
+      { pos: boundary.pos, slot: nextSlot },
+    );
+  } else {
+    tr.setStoredMarks(boundary.mark.removeFromSet(boundary.textMarks)).setMeta(
+      endNoteCursorKey,
+      null,
+    );
+  }
+
+  view.dispatch(tr);
+  return true;
+};
+
+const applyCursorMeta = (
+  tr: Transaction,
+  value: EndNoteCursorAffinity | null,
+  _oldState: EditorState,
+  newState: EditorState,
+) => {
+  const meta = tr.getMeta(endNoteCursorKey) as
+    | EndNoteCursorAffinity
+    | null
+    | undefined;
+  if (meta !== undefined) return meta;
+  if (!value || !newState.selection.empty || tr.selectionSet) return null;
+
+  const mappedPos = tr.docChanged
+    ? tr.mapping.map(value.pos, value.slot === 0 ? 1 : -1)
+    : value.pos;
+  return newState.selection.from === mappedPos
+    ? { ...value, pos: mappedPos }
+    : null;
+};
+
+export const createEndNoteCursorPlugin = (markName: string) =>
+  new Plugin<EndNoteCursorAffinity | null>({
+    key: endNoteCursorKey,
+    state: {
+      init: () => null,
+      apply(tr, value, oldState, newState) {
+        const affinity = applyCursorMeta(tr, value, oldState, newState);
+        return affinity &&
+          findEndNoteBoundary(newState.doc, affinity.pos, markName)
+          ? affinity
+          : null;
+      },
+    },
+    props: {
+      handleKeyDown(view, event) {
+        if (
+          event.shiftKey ||
+          event.altKey ||
+          event.ctrlKey ||
+          event.metaKey ||
+          !view.state.selection.empty
+        ) {
+          return false;
+        }
+
+        const { from } = view.state.selection;
+        const affinity = endNoteCursorKey.getState(view.state);
+        const activeBoundary = affinity
+          ? findEndNoteBoundary(view.state.doc, affinity.pos, markName)
+          : null;
+
+        if (event.key === 'ArrowRight') {
+          if (affinity && activeBoundary) {
+            if (affinity.slot < activeBoundary.notes.length) {
+              return dispatchAffinity(view, activeBoundary, affinity.slot + 1);
+            }
+            view.dispatch(
+              view.state.tr
+                .setStoredMarks(null)
+                .setMeta(endNoteCursorKey, null),
+            );
+            return false;
+          }
+
+          const nextBoundary = findEndNoteBoundary(
+            view.state.doc,
+            from + 1,
+            markName,
+          );
+          return nextBoundary ? dispatchAffinity(view, nextBoundary, 0) : false;
+        }
+
+        if (event.key === 'ArrowLeft') {
+          if (affinity && activeBoundary) {
+            if (affinity.slot > 0) {
+              return dispatchAffinity(view, activeBoundary, affinity.slot - 1);
+            }
+            view.dispatch(
+              view.state.tr
+                .setStoredMarks(null)
+                .setMeta(endNoteCursorKey, null),
+            );
+            return false;
+          }
+
+          const currentBoundary = findEndNoteBoundary(
+            view.state.doc,
+            from,
+            markName,
+          );
+          if (currentBoundary) {
+            return dispatchAffinity(
+              view,
+              currentBoundary,
+              currentBoundary.notes.length - 1,
+            );
+          }
+
+          const previousBoundary = findEndNoteBoundary(
+            view.state.doc,
+            from - 1,
+            markName,
+          );
+          return previousBoundary
+            ? dispatchAffinity(
+                view,
+                previousBoundary,
+                previousBoundary.notes.length,
+              )
+            : false;
+        }
+
+        if (event.key === 'Backspace' && affinity && activeBoundary) {
+          return affinity.slot > 0
+            ? removeBoundaryNote(
+                view,
+                activeBoundary,
+                affinity.slot - 1,
+                affinity.slot - 1,
+              )
+            : false;
+        }
+
+        if (event.key === 'Delete' && affinity && activeBoundary) {
+          return affinity.slot < activeBoundary.notes.length
+            ? removeBoundaryNote(
+                view,
+                activeBoundary,
+                affinity.slot,
+                affinity.slot,
+              )
+            : false;
+        }
+
+        return false;
+      },
+
+      handleTextInput(view, from, to, text) {
+        const affinity = endNoteCursorKey.getState(view.state);
+        if (!affinity || from !== to || from !== affinity.pos) return false;
+
+        const boundary = findEndNoteBoundary(
+          view.state.doc,
+          affinity.pos,
+          markName,
+        );
+        if (!boundary) return false;
+
+        const insertBeforeMarkers = affinity.slot === 0;
+        const tr = view.state.tr
+          .setStoredMarks(
+            insertBeforeMarkers
+              ? boundary.textMarks
+              : boundary.mark.removeFromSet(boundary.textMarks),
+          )
+          .insertText(text, from, to);
+
+        tr.setMeta(
+          endNoteCursorKey,
+          insertBeforeMarkers ? { pos: from + text.length, slot: 0 } : null,
+        );
+        view.dispatch(tr);
+        return true;
+      },
+    },
+    view: () => ({
+      update(view) {
+        const affinity = endNoteCursorKey.getState(view.state);
+        if (affinity) placeEndNoteCursor(view, affinity, markName);
+      },
+    }),
+  });

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.spec.ts
@@ -1,12 +1,20 @@
 import { Schema } from '@tiptap/pm/model';
 import { EditorState, Plugin } from '@tiptap/pm/state';
-import { EndNoteLinkMark } from './EndNoteLinkMark';
+import { DecorationSet, EditorView } from '@tiptap/pm/view';
+import {
+  createEndNoteLinkDecorations,
+  EndNoteLinkMark,
+} from './EndNoteLinkMark';
 
 // Minimal schema containing just what we need to exercise the dedup plugin.
 const schema = new Schema({
   nodes: {
     doc: { content: 'paragraph+' },
-    paragraph: { content: 'text*', group: 'block' },
+    paragraph: {
+      content: 'text*',
+      group: 'block',
+      toDOM: () => ['p', 0],
+    },
     text: { group: 'inline' },
   },
   marks: {
@@ -27,12 +35,98 @@ const other = schema.marks['other'];
 
 const getPlugin = (): Plugin => {
   const ext = EndNoteLinkMark as unknown as {
-    config: { addProseMirrorPlugins?: (this: { name: string }) => Plugin[] };
+    config: {
+      addProseMirrorPlugins?: (this: {
+        name: string;
+        options: { HTMLAttributes: Record<string, unknown> };
+        editor: { isEditable: boolean };
+      }) => Plugin[];
+    };
   };
   const plugins =
-    ext.config.addProseMirrorPlugins?.call({ name: 'endNoteLink' }) ?? [];
-  return plugins[0];
+    ext.config.addProseMirrorPlugins?.call({
+      name: 'endNoteLink',
+      options: { HTMLAttributes: {} },
+      editor: { isEditable: true },
+    }) ?? [];
+  const dedupPlugin = plugins.find((plugin) => plugin.spec.appendTransaction);
+  if (!dedupPlugin) {
+    throw new Error('EndNoteLink did not register its dedup plugin');
+  }
+  return dedupPlugin;
 };
+
+describe('EndNoteLink decorations', () => {
+  it('places an end marker before the cursor at the mark boundary', () => {
+    const mark = endNoteLink.create({
+      notes: [{ uuid: 'n1', endNote: 'e1', location: 'end', label: '1.1' }],
+    });
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [
+        schema.text('word', [mark]),
+        schema.text(' next'),
+      ]),
+    ]);
+
+    const decorations = createEndNoteLinkDecorations(doc, 'endNoteLink', () =>
+      document.createElement('sup'),
+    );
+
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(5);
+    expect(decorations[0].spec.side).toBeLessThan(0);
+    expect(decorations[0].spec.marks).toEqual([]);
+  });
+
+  it('maps the mark boundary to the right of the end marker DOM', () => {
+    const mark = endNoteLink.create({
+      notes: [{ uuid: 'n1', endNote: 'e1', location: 'end', label: '1.1' }],
+    });
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [
+        schema.text('word', [mark]),
+        schema.text(' next'),
+      ]),
+    ]);
+    const marker = document.createElement('sup');
+    const decorations = createEndNoteLinkDecorations(
+      doc,
+      'endNoteLink',
+      () => marker,
+    );
+    const decorationSet = DecorationSet.create(doc, decorations);
+    const state = EditorState.create({
+      schema,
+      doc,
+      plugins: [new Plugin({ props: { decorations: () => decorationSet } })],
+    });
+    const view = new EditorView(document.createElement('div'), { state });
+
+    const caret = view.domAtPos(5, -1);
+
+    expect(caret.node.childNodes[caret.offset - 1]).toBe(marker);
+    expect(marker.contentEditable).toBe('false');
+    view.destroy();
+  });
+
+  it('places a start marker after the cursor at the mark boundary', () => {
+    const mark = endNoteLink.create({
+      notes: [{ uuid: 'n1', endNote: 'e1', location: 'start', label: '1.1' }],
+    });
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('word', [mark])]),
+    ]);
+
+    const decorations = createEndNoteLinkDecorations(doc, 'endNoteLink', () =>
+      document.createElement('sup'),
+    );
+
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(1);
+    expect(decorations[0].spec.side).toBeGreaterThan(0);
+    expect(decorations[0].spec.marks).toEqual([]);
+  });
+});
 
 describe('EndNoteLink dedup plugin', () => {
   it('removes the endNoteLink mark from all but the last fragment after a sub-range mark splits the text node', () => {
@@ -45,7 +139,11 @@ describe('EndNoteLink dedup plugin', () => {
     ]);
 
     const plugin = getPlugin();
-    const state = EditorState.create({ schema, doc: initialDoc, plugins: [plugin] });
+    const state = EditorState.create({
+      schema,
+      doc: initialDoc,
+      plugins: [plugin],
+    });
 
     // Apply "other" mark to "def" (positions 4..7 inside the paragraph; doc
     // positions 4..7 because paragraph open tag is at 0). This splits the
@@ -158,7 +256,9 @@ describe('EndNoteLink dedup plugin', () => {
     const notes = [{ uuid: 'n1', endNote: 'e1', location: 'end' }];
     const endMark = endNoteLink.create({ notes });
     const initialDoc = schema.node('doc', null, [
-      schema.node('paragraph', null, [schema.text('wordWithEndNote', [endMark])]),
+      schema.node('paragraph', null, [
+        schema.text('wordWithEndNote', [endMark]),
+      ]),
     ]);
 
     const plugin = getPlugin();
@@ -212,7 +312,11 @@ describe('EndNoteLink dedup plugin', () => {
     ]);
 
     const plugin = getPlugin();
-    const state = EditorState.create({ schema, doc: initialDoc, plugins: [plugin] });
+    const state = EditorState.create({
+      schema,
+      doc: initialDoc,
+      plugins: [plugin],
+    });
 
     // Trigger an appendTransaction by dispatching a no-content-changing edit:
     // insert and then remove a marker. We use addMark/removeMark on `other`

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
@@ -1,10 +1,66 @@
 import { mergeAttributes } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
-import type { Mark as PMMark, MarkType } from '@tiptap/pm/model';
+import type {
+  Mark as PMMark,
+  MarkType,
+  Node as PMNode,
+} from '@tiptap/pm/model';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { v4 as uuidv4 } from 'uuid';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { createUpdateAttributes, registerEditorElement } from '../../util';
 import { EndNoteLinkMarkSSR } from './EndNoteLinkMark.ssr';
+
+interface EndNoteLinkNote {
+  uuid: string;
+  location?: string;
+  toh?: string;
+  endNote: string;
+  label?: string;
+}
+
+export const createEndNoteLinkDecorations = (
+  doc: PMNode,
+  markName: string,
+  renderMarker: (note: EndNoteLinkNote) => HTMLElement,
+  keySuffix = '',
+) => {
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, pos) => {
+    if (!node.isText) return true;
+
+    const mark = node.marks.find(
+      (candidate) => candidate.type.name === markName,
+    );
+    if (!mark) return false;
+
+    const notes = [...((mark.attrs.notes || []) as EndNoteLinkNote[])].sort(
+      (a, b) => (a.label || '').localeCompare(b.label || ''),
+    );
+
+    notes.forEach((note, index) => {
+      const isStart = note.location === 'start';
+      // End markers sit before the cursor at the mark's final document
+      // position; start markers sit after it. This gives the zero-width UI a
+      // defined side instead of leaving the browser to enter untracked DOM.
+      const side = isStart ? index + 1 : index - notes.length;
+      const markerPos = isStart ? pos : pos + node.nodeSize;
+
+      decorations.push(
+        Decoration.widget(markerPos, () => renderMarker(note), {
+          key: `end-note-link:${JSON.stringify(note)}:${keySuffix}`,
+          marks: [],
+          side,
+        }),
+      );
+    });
+
+    return false;
+  });
+
+  return decorations;
+};
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -16,92 +72,6 @@ declare module '@tiptap/core' {
 }
 
 export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
-  addMarkView() {
-    return (props) => {
-      const isEditable = props.editor.isEditable;
-      const className = isEditable
-        ? 'end-note-link select-text'
-        : 'end-note-link select-none';
-
-      const dom = document.createElement('span');
-      const contentDOM = document.createElement('span');
-      dom.appendChild(contentDOM);
-
-      // Define a visible default label when editable to indicate something
-      // _should_ be there.
-      const defaultLabel = isEditable ? '*' : '';
-      const notes: [
-        {
-          uuid: string;
-          location: string;
-          toh?: string;
-          endNote: string;
-          label?: string;
-        },
-      ] = props.mark.attrs.notes || [];
-      notes.sort((a, b) =>
-        (a.label || defaultLabel).localeCompare(b.label || defaultLabel),
-      );
-      notes.forEach(
-        (note: {
-          uuid: string;
-          location: string;
-          toh?: string;
-          endNote: string;
-          label?: string;
-        }) => {
-          const { uuid, location, toh, endNote, label } = note;
-          const isStart = location === 'start';
-
-          const endnoteDOM = document.createElement('sup');
-          const updateAttributes = createUpdateAttributes(endnoteDOM);
-          const attributes = mergeAttributes(this.options.HTMLAttributes, {
-            class: cn(className, isStart ? 'me-0.75' : ''),
-            type: this.name,
-            endNote,
-            uuid,
-            ...(toh ? { 'data-toh': toh } : {}),
-          });
-
-          updateAttributes(attributes);
-
-          // Register editor element for hover card detection in edit mode
-          if (isEditable) {
-            registerEditorElement(endnoteDOM, props.editor);
-          }
-
-          if (isStart) {
-            dom.insertBefore(endnoteDOM, dom.firstChild);
-          } else {
-            dom.appendChild(endnoteDOM);
-          }
-
-          const itemLabel = label?.split('.').pop() || defaultLabel;
-          const text = itemLabel || defaultLabel;
-          // Glue the marker to the text it's attached to with a word joiner
-          // (U+2060) so it never wraps to a new line away from its content:
-          // after the text for start notes, before it for end notes.
-          endnoteDOM.textContent = isStart ? `${text}⁠` : `⁠${text}`;
-
-          endnoteDOM.addEventListener('click', () => {
-            if (!endNote) {
-              return;
-            }
-
-            const query = new URLSearchParams(window.location.search);
-            query.set('right', `open:endnotes:${endNote}`);
-            window.history.pushState({}, '', `?${query.toString()}`);
-          });
-        },
-      );
-
-      return {
-        dom,
-        contentDOM,
-      };
-    };
-  },
-
   addCommands() {
     return {
       setEndNoteLink:
@@ -215,15 +185,74 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
     };
   },
 
-  // When another inline mark (e.g. glossaryInstance) is applied to a sub-range
-  // of an existing endNoteLink span, ProseMirror splits the text node and
-  // preserves the endNoteLink mark on every resulting fragment. That causes
-  // duplicate <sup> renders and duplicate exported annotations on save. This
-  // plugin normalizes adjacent text fragments that carry the same endNoteLink
-  // mark by keeping the mark only on the last fragment in each contiguous run.
   addProseMirrorPlugins() {
+    const editor = this.editor;
     const markName = this.name;
+    const HTMLAttributes = this.options.HTMLAttributes;
+
+    const renderMarker = (note: EndNoteLinkNote) => {
+      const isEditable = editor.isEditable;
+      const className = isEditable
+        ? 'end-note-link select-text'
+        : 'end-note-link select-none';
+      const defaultLabel = isEditable ? '*' : '';
+      const { uuid, location, toh, endNote, label } = note;
+      const isStart = location === 'start';
+      const endnoteDOM = document.createElement('sup');
+      const updateAttributes = createUpdateAttributes(endnoteDOM);
+      const attributes = mergeAttributes(HTMLAttributes, {
+        class: cn(className, isStart ? 'me-0.75' : ''),
+        type: markName,
+        endNote,
+        uuid,
+        ...(toh ? { 'data-toh': toh } : {}),
+      });
+
+      updateAttributes(attributes);
+
+      if (isEditable) {
+        registerEditorElement(endnoteDOM, editor);
+      }
+
+      const itemLabel = label?.split('.').pop() || defaultLabel;
+      const text = itemLabel || defaultLabel;
+      // Glue the marker to the text it's attached to with a word joiner
+      // (U+2060) so it never wraps to a new line away from its content.
+      endnoteDOM.textContent = isStart ? `${text}⁠` : `⁠${text}`;
+
+      endnoteDOM.addEventListener('click', () => {
+        if (!endNote) return;
+
+        const query = new URLSearchParams(window.location.search);
+        query.set('right', `open:endnotes:${endNote}`);
+        window.history.pushState({}, '', `?${query.toString()}`);
+      });
+
+      return endnoteDOM;
+    };
+
+    // When another inline mark (e.g. glossaryInstance) is applied to a sub-range
+    // of an existing endNoteLink span, ProseMirror splits the text node and
+    // preserves the endNoteLink mark on every resulting fragment. That causes
+    // duplicate <sup> renders and duplicate exported annotations on save. This
+    // plugin normalizes adjacent text fragments that carry the same endNoteLink
+    // mark by keeping the mark only on the last fragment in each contiguous run.
     return [
+      new Plugin({
+        key: new PluginKey('endNoteLinkDecorations'),
+        props: {
+          decorations: (state) =>
+            DecorationSet.create(
+              state.doc,
+              createEndNoteLinkDecorations(
+                state.doc,
+                markName,
+                renderMarker,
+                String(editor.isEditable),
+              ),
+            ),
+        },
+      }),
       new Plugin({
         key: new PluginKey('endNoteLinkDedup'),
         appendTransaction(transactions, _oldState, newState) {

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkMark.ts
@@ -9,15 +9,11 @@ import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { v4 as uuidv4 } from 'uuid';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { createUpdateAttributes, registerEditorElement } from '../../util';
+import {
+  createEndNoteCursorPlugin,
+  type EndNoteLinkNote,
+} from './EndNoteCursor';
 import { EndNoteLinkMarkSSR } from './EndNoteLinkMark.ssr';
-
-interface EndNoteLinkNote {
-  uuid: string;
-  location?: string;
-  toh?: string;
-  endNote: string;
-  label?: string;
-}
 
 export const createEndNoteLinkDecorations = (
   doc: PMNode,
@@ -39,18 +35,24 @@ export const createEndNoteLinkDecorations = (
       (a, b) => (a.label || '').localeCompare(b.label || ''),
     );
 
-    notes.forEach((note, index) => {
+    const endNotes = notes.filter((note) => note.location !== 'start');
+    const startNotes = notes.filter((note) => note.location === 'start');
+
+    notes.forEach((note) => {
       const isStart = note.location === 'start';
+      const noteIndex = (isStart ? startNotes : endNotes).indexOf(note);
       // End markers sit before the cursor at the mark's final document
       // position; start markers sit after it. This gives the zero-width UI a
       // defined side instead of leaving the browser to enter untracked DOM.
-      const side = isStart ? index + 1 : index - notes.length;
+      const side = isStart ? noteIndex + 1 : noteIndex - endNotes.length;
       const markerPos = isStart ? pos : pos + node.nodeSize;
 
       decorations.push(
         Decoration.widget(markerPos, () => renderMarker(note), {
           key: `end-note-link:${JSON.stringify(note)}:${keySuffix}`,
+          ignoreSelection: true,
           marks: [],
+          relaxedSide: true,
           side,
         }),
       );
@@ -202,6 +204,7 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
       const updateAttributes = createUpdateAttributes(endnoteDOM);
       const attributes = mergeAttributes(HTMLAttributes, {
         class: cn(className, isStart ? 'me-0.75' : ''),
+        'data-end-note-marker': '',
         type: markName,
         endNote,
         uuid,
@@ -238,6 +241,7 @@ export const EndNoteLinkMark = EndNoteLinkMarkSSR.extend({
     // plugin normalizes adjacent text fragments that carry the same endNoteLink
     // mark by keeping the mark only on the last fragment in each contiguous run.
     return [
+      createEndNoteCursorPlugin(markName),
       new Plugin({
         key: new PluginKey('endNoteLinkDecorations'),
         props: {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.spec.ts
@@ -1,0 +1,30 @@
+import { getSchema, Node } from '@tiptap/core';
+import { NodeSelection } from '@tiptap/pm/state';
+import { MentionSSR } from './Mention.ssr';
+
+const Document = Node.create({
+  name: 'doc',
+  topNode: true,
+  content: 'paragraph+',
+});
+
+const Paragraph = Node.create({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+});
+
+const Text = Node.create({
+  name: 'text',
+  group: 'inline',
+});
+
+describe('MentionSSR', () => {
+  it('does not turn arrow-key caret navigation into a node selection', () => {
+    const schema = getSchema([Document, Paragraph, Text, MentionSSR]);
+    const mention = schema.nodes['mention'].create();
+
+    expect(mention.isAtom).toBe(true);
+    expect(NodeSelection.isSelectable(mention)).toBe(false);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.spec.ts
@@ -20,11 +20,12 @@ const Text = Node.create({
 });
 
 describe('MentionSSR', () => {
-  it('does not turn arrow-key caret navigation into a node selection', () => {
+  it('is draggable without turning caret navigation into a node selection', () => {
     const schema = getSchema([Document, Paragraph, Text, MentionSSR]);
     const mention = schema.nodes['mention'].create();
 
     expect(mention.isAtom).toBe(true);
+    expect(schema.nodes['mention'].spec.draggable).toBe(true);
     expect(NodeSelection.isSelectable(mention)).toBe(false);
   });
 });

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -32,6 +32,7 @@ export const MentionSSR = Node.create<MentionSSROptions>({
   // should be a single navigation step. Mentions remain atomic, but the caret
   // now moves directly from one side to the other.
   selectable: false,
+  draggable: true,
   // Mentions never carry marks. Without this, an inline mark whose range
   // coincides with the mention's position (e.g. an end-location endNoteLink,
   // which is a zero-length annotation at the same start/end) gets stored on

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -27,6 +27,11 @@ export const MentionSSR = Node.create<MentionSSROptions>({
   group: 'inline',
   inline: true,
   atom: true,
+  // A selectable inline atom becomes a NodeSelection when the caret reaches
+  // it with an arrow key. That hides the caret and opens selection UI for what
+  // should be a single navigation step. Mentions remain atomic, but the caret
+  // now moves directly from one side to the other.
+  selectable: false,
   // Mentions never carry marks. Without this, an inline mark whose range
   // coincides with the mention's position (e.g. an end-location endNoteLink,
   // which is a zero-length annotation at the same start/end) gets stored on

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -3,6 +3,7 @@ import Suggestion from '@tiptap/suggestion';
 import { registerEditorElement } from '../../util';
 import { PANEL_FOR_SECTION, TAB_FOR_SECTION } from '../../../shared/types';
 import { MentionSSR, MentionItem } from './Mention.ssr';
+import { mentionDropSelectionPlugin } from './MentionDropSelection';
 import { mentionSuggestion } from './MentionSuggestion';
 
 /** Payload handed to the advanced mention picker overlay. */
@@ -54,6 +55,7 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
         editor: this.editor,
         ...mentionSuggestion,
       }),
+      mentionDropSelectionPlugin(this.name),
     ];
   },
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -62,11 +62,13 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
       const isEditable = props.editor.isEditable;
       const dom = document.createElement('span');
       dom.classList.add('mention-container');
+      dom.draggable = isEditable;
 
       const items: MentionItem[] = props.node.attrs.items || [];
 
       items.forEach((item) => {
         const anchor = document.createElement('a');
+        anchor.draggable = false;
         anchor.classList.add('mention-link');
         if (item.toh) {
           anchor.setAttribute('data-toh', item.toh);

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionDropSelection.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionDropSelection.spec.ts
@@ -1,0 +1,62 @@
+import { getSchema, Node } from '@tiptap/core';
+import { EditorState, TextSelection } from '@tiptap/pm/state';
+import { MentionSSR } from './Mention.ssr';
+import { mentionDropSelectionPlugin } from './MentionDropSelection';
+
+const Document = Node.create({
+  name: 'doc',
+  topNode: true,
+  content: 'paragraph+',
+});
+
+const Paragraph = Node.create({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+});
+
+const Text = Node.create({
+  name: 'text',
+  group: 'inline',
+});
+
+const schema = getSchema([Document, Paragraph, Text, MentionSSR]);
+
+const createState = () =>
+  EditorState.create({
+    schema,
+    doc: schema.node('doc', null, [
+      schema.node('paragraph', null, [
+        schema.node('mention'),
+        schema.text('text'),
+      ]),
+    ]),
+    plugins: [mentionDropSelectionPlugin('mention')],
+  });
+
+describe('mentionDropSelectionPlugin', () => {
+  it('collapses the range around a dropped mention to its right side', () => {
+    const state = createState();
+    const drop = state.tr
+      .setSelection(TextSelection.create(state.doc, 1, 2))
+      .setMeta('uiEvent', 'drop');
+
+    const result = state.applyTransaction(drop).state;
+
+    expect(result.selection.empty).toBe(true);
+    expect(result.selection.from).toBe(2);
+  });
+
+  it('preserves other selections created by a drop', () => {
+    const state = createState();
+    const drop = state.tr
+      .setSelection(TextSelection.create(state.doc, 2, 4))
+      .setMeta('uiEvent', 'drop');
+
+    const result = state.applyTransaction(drop).state;
+
+    expect(result.selection.empty).toBe(false);
+    expect(result.selection.from).toBe(2);
+    expect(result.selection.to).toBe(4);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionDropSelection.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionDropSelection.ts
@@ -1,0 +1,28 @@
+import { Plugin, TextSelection } from '@tiptap/pm/state';
+
+export const mentionDropSelectionPlugin = (mentionName: string) =>
+  new Plugin({
+    appendTransaction(transactions, _oldState, newState) {
+      const isDrop = transactions.some(
+        (transaction) => transaction.getMeta('uiEvent') === 'drop',
+      );
+      const { selection } = newState;
+
+      if (!isDrop || selection.empty) {
+        return null;
+      }
+
+      const droppedNode = newState.doc.nodeAt(selection.from);
+      const selectsOnlyMention =
+        droppedNode?.type.name === mentionName &&
+        selection.to === selection.from + droppedNode.nodeSize;
+
+      if (!selectsOnlyMention) {
+        return null;
+      }
+
+      return newState.tr.setSelection(
+        TextSelection.near(newState.doc.resolve(selection.to), 1),
+      );
+    },
+  });

--- a/libs/lib-editing/src/lib/components/shared/HoverCardProvider.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/HoverCardProvider.spec.tsx
@@ -1,0 +1,60 @@
+import { Editor } from '@tiptap/core';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { registerEditorElement } from '../editor/util';
+import { HoverCardProvider } from './HoverCardProvider';
+
+jest.mock('./TranslationHoverCard', () => ({
+  TranslationHoverCard: ({ children }: { children: ReactNode }) => children,
+}));
+
+jest.mock(
+  '../editor/extensions/GlossaryInstance/GlossaryInstance',
+  () => ({ GlossaryInstance: () => null }),
+);
+jest.mock(
+  '../editor/extensions/EndNoteLink/EndNoteLinkHoverContent',
+  () => ({ EndNoteLinkHoverContent: () => null }),
+);
+jest.mock('../editor/extensions/Link/LinkHoverContent', () => ({
+  LinkHoverContent: () => null,
+}));
+jest.mock(
+  '../editor/extensions/InternalLink/InternalLinkHoverContent',
+  () => ({ InternalLinkHoverContent: () => null }),
+);
+jest.mock('../editor/extensions/Mention/MentionHoverContent', () => ({
+  MentionHoverContent: () => <div>Mention hover card</div>,
+}));
+
+describe('HoverCardProvider', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('dismisses the hover card when a drag starts', () => {
+    jest.useFakeTimers();
+    const { container } = render(
+      <HoverCardProvider openDelay={0} closeDelay={0}>
+        <span className="mention-container" draggable>
+          <a href="/mention" type="mention" uuid="mention-id">
+            Mention
+          </a>
+        </span>
+      </HoverCardProvider>,
+    );
+    const anchor = screen.getByRole('link', { name: 'Mention' });
+    registerEditorElement(anchor, { isEditable: true } as Editor);
+
+    fireEvent.mouseEnter(anchor);
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(screen.getByText('Mention hover card')).not.toBeNull();
+
+    const mention = container.querySelector('.mention-container');
+    expect(mention).not.toBeNull();
+    fireEvent.dragStart(mention as HTMLElement);
+
+    expect(screen.queryByText('Mention hover card')).toBeNull();
+  });
+});

--- a/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/HoverCardProvider.tsx
@@ -166,13 +166,19 @@ export const HoverCardProvider = ({
       }
     };
 
+    const handleDragStart = () => {
+      closeImmediately();
+    };
+
     editorEl.addEventListener('mouseenter', handleMouseOver, true);
     editorEl.addEventListener('mouseleave', handleMouseLeave, true);
+    editorEl.addEventListener('dragstart', handleDragStart, true);
     document.addEventListener('keydown', handleEscape, true);
 
     return () => {
       editorEl.removeEventListener('mouseenter', handleMouseOver, true);
       editorEl.removeEventListener('mouseleave', handleMouseLeave, true);
+      editorEl.removeEventListener('dragstart', handleDragStart, true);
       document.removeEventListener('keydown', handleEscape, true);
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);


### PR DESCRIPTION
### Summary

A little bit of yak shaving to make moving the cursor around the editor easier:

- Allow the cursor to move around and between endnote links
- If the cursor is to the right of an endnote link, typing delete deletes the annotation without changing the text
- If the cursor is to the left of an endnote link, typing delete removes the character while preserving the annotation
- Moving the cursor around a mention does not open the bubble menu anymore
- Mentions are now draggable
- Remove the trailing CSS padding from folio markers. This will require some content changes so that all folio mentions have adequate spaces around them
