### PR TITLE
Dynamic Mention Spacing

### DIFF
--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -54,8 +54,9 @@
   }
 
   /* Conditional visual spacing around mentions: a real space rendered in the
-     current font, added only when an adjacent non-space, non-punctuation
-     character is present (classes set by mentionSpacing logic). `break-spaces`
+     current font (classes set by mentionSpacing logic). The leading gap applies
+     after any non-whitespace character including punctuation; the trailing gap
+     only before a non-whitespace, non-punctuation character. `break-spaces`
      keeps the exact space width while preserving the line-wrap opportunity. */
   .mention-container.mention-space-before::before,
   .mention-container.mention-space-after::after {
@@ -66,9 +67,13 @@
   /* In focus mode, folio links are hidden. When a container holds only folio
      links, drop its spacing so no orphaned whitespace remains. */
   .focus-mode
-    .mention-container:not(:has(.mention-link:not([entity-type='folio'])))::before,
+    .mention-container:not(
+      :has(.mention-link:not([entity-type='folio']))
+    )::before,
   .focus-mode
-    .mention-container:not(:has(.mention-link:not([entity-type='folio'])))::after {
+    .mention-container:not(
+      :has(.mention-link:not([entity-type='folio']))
+    )::after {
     content: none;
   }
 

--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -53,6 +53,25 @@
     @apply text-foreground no-underline cursor-auto;
   }
 
+  /* Conditional visual spacing around mentions: a real space rendered in the
+     current font, added only when an adjacent non-space, non-punctuation
+     character is present (classes set by mentionSpacing logic). `break-spaces`
+     keeps the exact space width while preserving the line-wrap opportunity. */
+  .mention-container.mention-space-before::before,
+  .mention-container.mention-space-after::after {
+    content: ' ';
+    white-space: break-spaces;
+  }
+
+  /* In focus mode, folio links are hidden. When a container holds only folio
+     links, drop its spacing so no orphaned whitespace remains. */
+  .focus-mode
+    .mention-container:not(:has(.mention-link:not([entity-type='folio'])))::before,
+  .focus-mode
+    .mention-container:not(:has(.mention-link:not([entity-type='folio'])))::after {
+    content: none;
+  }
+
   .mention-link[entity-type='folio'] {
     @apply px-px;
   }

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.spec.ts
@@ -1,6 +1,6 @@
 import { getSchema, Node } from '@tiptap/core';
 import { NodeSelection } from '@tiptap/pm/state';
-import { MentionSSR } from './Mention.ssr';
+import { MentionSSR, MentionItem, mentionContainerToh } from './Mention.ssr';
 
 const Document = Node.create({
   name: 'doc',
@@ -27,5 +27,33 @@ describe('MentionSSR', () => {
     expect(mention.isAtom).toBe(true);
     expect(schema.nodes['mention'].spec.draggable).toBe(true);
     expect(NodeSelection.isSelectable(mention)).toBe(false);
+  });
+});
+
+describe('mentionContainerToh', () => {
+  const item = (toh?: string): MentionItem => ({
+    uuid: 'u',
+    entity: 'e',
+    linkType: 'work',
+    ...(toh !== undefined ? { toh } : {}),
+  });
+
+  it('returns undefined when there are no items', () => {
+    expect(mentionContainerToh([])).toBeUndefined();
+  });
+
+  it('returns undefined when any item is unscoped (must stay visible)', () => {
+    expect(mentionContainerToh([item('toh1'), item()])).toBeUndefined();
+  });
+
+  it('unions the toh tokens of all items, de-duplicated', () => {
+    expect(mentionContainerToh([item('toh1'), item('toh2')])).toBe('toh1,toh2');
+    expect(mentionContainerToh([item('toh1,toh2'), item('toh2')])).toBe(
+      'toh1,toh2',
+    );
+  });
+
+  it('handles a single item whose toh is already a comma list', () => {
+    expect(mentionContainerToh([item('toh1,toh3')])).toBe('toh1,toh3');
   });
 });

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -1,4 +1,5 @@
 import { Node, mergeAttributes } from '@tiptap/core';
+import type { DOMOutputSpec, Node as PMNode } from '@tiptap/pm/model';
 import { safeHref } from '@eightyfourthousand/lib-utils';
 
 export interface MentionSSROptions {
@@ -20,6 +21,70 @@ export interface MentionItem {
 
 const isMentionItem = (value: unknown): value is MentionItem => {
   return !!value && typeof value === 'object';
+};
+
+/**
+ * Builds the mention's DOMOutputSpec from a ProseMirror node. Shared by the
+ * node's `renderHTML` and by the static-renderer `nodeMapping.mention`
+ * override (which needs sibling context to add conditional spacing classes).
+ * `HTMLAttributes` are merged onto the outer `span.mention-container` — extra
+ * `class` values (e.g. spacing) concatenate rather than replace.
+ */
+export const mentionDOMOutputSpec = (
+  node: PMNode,
+  HTMLAttributes: Record<string, unknown> = {},
+): DOMOutputSpec => {
+  const raw = node.attrs.items;
+  const items: MentionItem[] = Array.isArray(raw)
+    ? raw.filter(isMentionItem)
+    : [];
+
+  const children = items.map((item) => {
+    const label = item.text || item.displayText || '';
+    // Shared presentational attrs applied to every rendered variant. `lang`
+    // drives the `[lang]` typography rules (e.g. italic work titles).
+    const extraAttrs: Record<string, string> = {
+      ...(item.toh ? { 'data-toh': item.toh } : {}),
+      ...(item.lang ? { lang: item.lang } : {}),
+    };
+
+    if (!label || !item.entity || !item.linkType) {
+      return ['span', { class: 'mention-link', ...extraAttrs }, label] as unknown;
+    }
+
+    const href = safeHref(`/entity/${item.linkType}/${item.entity}`);
+    const attrs: Record<string, string> = {
+      class: 'mention-link',
+      ...extraAttrs,
+    };
+    if (item.uuid) attrs['uuid'] = item.uuid;
+    if (item.entity) attrs['entity'] = item.entity;
+    if (item.linkType) attrs['entity-type'] = item.linkType;
+
+    if (item.isSameWork) {
+      attrs['href'] = '#';
+      attrs['data-same-work'] = 'true';
+      if (item.subtype) attrs['data-subtype'] = item.subtype;
+      if (item.linkToh) attrs['data-link-toh'] = item.linkToh;
+    } else if (href) {
+      attrs['href'] = href;
+      attrs['target'] = '_blank';
+      attrs['rel'] = 'noreferrer noopener';
+    } else {
+      return ['span', { class: 'mention-link', ...extraAttrs }, label] as unknown;
+    }
+
+    return ['a', attrs, label] as unknown;
+  });
+
+  return [
+    'span',
+    mergeAttributes(HTMLAttributes, {
+      class: 'mention-container',
+      'data-type': 'mention',
+    }),
+    ...children,
+  ] as DOMOutputSpec;
 };
 
 export const MentionSSR = Node.create<MentionSSROptions>({
@@ -72,65 +137,10 @@ export const MentionSSR = Node.create<MentionSSROptions>({
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    const raw = node.attrs.items;
-    const items: MentionItem[] = Array.isArray(raw)
-      ? raw.filter(isMentionItem)
-      : [];
-
-    const children = items.map((item) => {
-      const label = item.text || item.displayText || '';
-      // Shared presentational attrs applied to every rendered variant. `lang`
-      // drives the `[lang]` typography rules (e.g. italic work titles).
-      const extraAttrs: Record<string, string> = {
-        ...(item.toh ? { 'data-toh': item.toh } : {}),
-        ...(item.lang ? { lang: item.lang } : {}),
-      };
-
-      if (!label || !item.entity || !item.linkType) {
-        return [
-          'span',
-          { class: 'mention-link', ...extraAttrs },
-          label,
-        ] as unknown;
-      }
-
-      const href = safeHref(`/entity/${item.linkType}/${item.entity}`);
-      const attrs: Record<string, string> = {
-        class: 'mention-link',
-        ...extraAttrs,
-      };
-      if (item.uuid) attrs['uuid'] = item.uuid;
-      if (item.entity) attrs['entity'] = item.entity;
-      if (item.linkType) attrs['entity-type'] = item.linkType;
-
-      if (item.isSameWork) {
-        attrs['href'] = '#';
-        attrs['data-same-work'] = 'true';
-        if (item.subtype) attrs['data-subtype'] = item.subtype;
-        if (item.linkToh) attrs['data-link-toh'] = item.linkToh;
-      } else if (href) {
-        attrs['href'] = href;
-        attrs['target'] = '_blank';
-        attrs['rel'] = 'noreferrer noopener';
-      } else {
-        return [
-          'span',
-          { class: 'mention-link', ...extraAttrs },
-          label,
-        ] as unknown;
-      }
-
-      return ['a', attrs, label] as unknown;
-    });
-
-    return [
-      'span',
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-        class: 'mention-container',
-        'data-type': 'mention',
-      }),
-      ...children,
-    ];
+    return mentionDOMOutputSpec(
+      node,
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+    );
   },
 });
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -24,6 +24,30 @@ const isMentionItem = (value: unknown): value is MentionItem => {
 };
 
 /**
+ * The `data-toh` value for the mention *container* — the union of every item's
+ * toh tokens. The runtime toh-visibility rule (`useTohToggle`) sets
+ * `display: none` on any `[data-toh]` whose tokens exclude the active toh, so
+ * placing the union on the container hides the whole mention (and its spacing
+ * pseudo-elements) exactly when every item would be hidden. Returns undefined
+ * — leaving the container always-visible — if any item is unscoped (no toh),
+ * since an unscoped item must always show. Individual anchors keep their own
+ * `data-toh` for the partial case where some, but not all, items hide.
+ */
+export const mentionContainerToh = (
+  items: MentionItem[],
+): string | undefined => {
+  if (items.length === 0 || !items.every((item) => item.toh)) return undefined;
+  const tohs = new Set<string>();
+  items.forEach((item) => {
+    (item.toh as string).split(',').forEach((token) => {
+      const trimmed = token.trim();
+      if (trimmed) tohs.add(trimmed);
+    });
+  });
+  return tohs.size ? [...tohs].join(',') : undefined;
+};
+
+/**
  * Builds the mention's DOMOutputSpec from a ProseMirror node. Shared by the
  * node's `renderHTML` and by the static-renderer `nodeMapping.mention`
  * override (which needs sibling context to add conditional spacing classes).
@@ -77,12 +101,18 @@ export const mentionDOMOutputSpec = (
     return ['a', attrs, label] as unknown;
   });
 
+  const containerToh = mentionContainerToh(items);
+
   return [
     'span',
-    mergeAttributes(HTMLAttributes, {
-      class: 'mention-container',
-      'data-type': 'mention',
-    }),
+    mergeAttributes(
+      HTMLAttributes,
+      containerToh ? { 'data-toh': containerToh } : {},
+      {
+        class: 'mention-container',
+        'data-type': 'mention',
+      },
+    ),
     ...children,
   ] as DOMOutputSpec;
 };

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -4,6 +4,7 @@ import { registerEditorElement } from '../../util';
 import { PANEL_FOR_SECTION, TAB_FOR_SECTION } from '../../../shared/types';
 import { MentionSSR, MentionItem } from './Mention.ssr';
 import { mentionDropSelectionPlugin } from './MentionDropSelection';
+import { mentionSpacingPlugin } from './MentionSpacingPlugin';
 import { mentionSuggestion } from './MentionSuggestion';
 
 /** Payload handed to the advanced mention picker overlay. */
@@ -56,6 +57,7 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
         ...mentionSuggestion,
       }),
       mentionDropSelectionPlugin(this.name),
+      mentionSpacingPlugin(),
     ];
   },
 
@@ -64,6 +66,11 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
       const isEditable = props.editor.isEditable;
       const dom = document.createElement('span');
       dom.classList.add('mention-container');
+
+      if (isEditable) {
+        dom.classList.add('bg-primary/10', 'rounded-sm');
+      }
+
       dom.draggable = isEditable;
 
       const items: MentionItem[] = props.node.attrs.items || [];

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import Suggestion from '@tiptap/suggestion';
 import { registerEditorElement } from '../../util';
 import { PANEL_FOR_SECTION, TAB_FOR_SECTION } from '../../../shared/types';
-import { MentionSSR, MentionItem } from './Mention.ssr';
+import { MentionSSR, MentionItem, mentionContainerToh } from './Mention.ssr';
 import { mentionDropSelectionPlugin } from './MentionDropSelection';
 import { mentionSpacingPlugin } from './MentionSpacingPlugin';
 import { mentionSuggestion } from './MentionSuggestion';
@@ -74,6 +74,14 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
       dom.draggable = isEditable;
 
       const items: MentionItem[] = props.node.attrs.items || [];
+
+      // Container-level toh union: the runtime toh-visibility rule hides the
+      // whole container (and its spacing pseudo-elements) when every item is
+      // toh-mismatched. Anchors keep their own data-toh for the partial case.
+      const containerToh = mentionContainerToh(items);
+      if (containerToh) {
+        dom.setAttribute('data-toh', containerToh);
+      }
 
       items.forEach((item) => {
         const anchor = document.createElement('a');

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionSpacingPlugin.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionSpacingPlugin.spec.ts
@@ -1,0 +1,110 @@
+import { getSchema, Node } from '@tiptap/core';
+import { EditorState } from '@tiptap/pm/state';
+import type { DecorationSet } from '@tiptap/pm/view';
+import { MentionSSR, MentionItem } from './Mention.ssr';
+import { mentionSpacingPlugin } from './MentionSpacingPlugin';
+import {
+  MENTION_SPACE_AFTER_CLASS,
+  MENTION_SPACE_BEFORE_CLASS,
+} from './mentionSpacing';
+
+const Document = Node.create({
+  name: 'doc',
+  topNode: true,
+  content: 'block+',
+});
+
+const Paragraph = Node.create({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+});
+
+const Text = Node.create({ name: 'text', group: 'inline' });
+
+const schema = getSchema([Document, Paragraph, Text, MentionSSR]);
+
+const item = (): MentionItem => ({
+  uuid: 'u',
+  entity: 'e',
+  linkType: 'work',
+  displayText: 'Ref',
+});
+
+const mention = () => schema.node('mention', { items: [item()] });
+
+/** The class strings of every decoration in the set, in document order. */
+const decoClasses = (set: DecorationSet): string[] =>
+  set
+    .find()
+    // `type.attrs` is where prosemirror-view stores node-decoration attributes.
+    .map((deco) => (deco as unknown as { type: { attrs: { class: string } } }).type.attrs.class);
+
+const stateFor = (doc: PMNodeDoc) => {
+  const plugin = mentionSpacingPlugin();
+  const state = EditorState.create({ schema, doc, plugins: [plugin] });
+  return { plugin, state };
+};
+
+type PMNodeDoc = ReturnType<typeof schema.node>;
+
+const para = (...children: PMNodeDoc[]) => schema.node('paragraph', null, children);
+const doc = (...paragraphs: PMNodeDoc[]) => schema.node('doc', null, paragraphs);
+
+describe('mentionSpacingPlugin', () => {
+  it('decorates a mention flanked by letters with both classes', () => {
+    const { plugin, state } = stateFor(
+      doc(para(schema.text('foo'), mention(), schema.text('bar'))),
+    );
+    expect(decoClasses(plugin.getState(state) as DecorationSet)).toEqual([
+      `${MENTION_SPACE_BEFORE_CLASS} ${MENTION_SPACE_AFTER_CLASS}`,
+    ]);
+  });
+
+  it('adds the after-class when text is typed directly after a mention', () => {
+    const { plugin, state } = stateFor(doc(para(schema.text('foo'), mention())));
+    expect(decoClasses(plugin.getState(state) as DecorationSet)).toEqual([
+      MENTION_SPACE_BEFORE_CLASS,
+    ]);
+
+    // Mention sits at pos 4 (nodeSize 1); pos 5 is just after it, in-block.
+    const next = state.apply(state.tr.insertText('x', 5));
+    expect(decoClasses(plugin.getState(next) as DecorationSet)).toEqual([
+      `${MENTION_SPACE_BEFORE_CLASS} ${MENTION_SPACE_AFTER_CLASS}`,
+    ]);
+  });
+
+  it('removes the before-class when punctuation is typed before a mention', () => {
+    const { plugin, state } = stateFor(doc(para(schema.text('foo'), mention())));
+    expect(decoClasses(plugin.getState(state) as DecorationSet)).toEqual([
+      MENTION_SPACE_BEFORE_CLASS,
+    ]);
+
+    // Insert '.' at pos 4, immediately before the mention.
+    const next = state.apply(state.tr.insertText('.', 4));
+    expect(decoClasses(plugin.getState(next) as DecorationSet)).toEqual([]);
+  });
+
+  it('renders a single gap between two adjacent mentions', () => {
+    const { plugin, state } = stateFor(doc(para(mention(), mention())));
+    expect(decoClasses(plugin.getState(state) as DecorationSet)).toEqual([
+      MENTION_SPACE_AFTER_CLASS,
+    ]);
+  });
+
+  it('leaves decorations untouched when an unrelated paragraph is edited', () => {
+    const { plugin, state } = stateFor(
+      doc(
+        para(schema.text('foo'), mention(), schema.text('bar')),
+        para(schema.text('other')),
+      ),
+    );
+    const before = decoClasses(plugin.getState(state) as DecorationSet);
+
+    // Type in the second paragraph; the first paragraph's mention is unaffected.
+    const secondParaEnd = state.doc.content.size - 1;
+    const next = state.apply(state.tr.insertText('!', secondParaEnd));
+
+    expect(decoClasses(plugin.getState(next) as DecorationSet)).toEqual(before);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionSpacingPlugin.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionSpacingPlugin.spec.ts
@@ -74,14 +74,24 @@ describe('mentionSpacingPlugin', () => {
     ]);
   });
 
-  it('removes the before-class when punctuation is typed before a mention', () => {
+  it('keeps the before-class when punctuation is typed before a mention', () => {
+    const { plugin, state } = stateFor(doc(para(schema.text('foo'), mention())));
+    // Insert '.' at pos 4, immediately before the mention. Punctuation still
+    // gets a leading gap.
+    const next = state.apply(state.tr.insertText('.', 4));
+    expect(decoClasses(plugin.getState(next) as DecorationSet)).toEqual([
+      MENTION_SPACE_BEFORE_CLASS,
+    ]);
+  });
+
+  it('removes the before-class when whitespace is typed before a mention', () => {
     const { plugin, state } = stateFor(doc(para(schema.text('foo'), mention())));
     expect(decoClasses(plugin.getState(state) as DecorationSet)).toEqual([
       MENTION_SPACE_BEFORE_CLASS,
     ]);
 
-    // Insert '.' at pos 4, immediately before the mention.
-    const next = state.apply(state.tr.insertText('.', 4));
+    // Insert a space at pos 4, immediately before the mention.
+    const next = state.apply(state.tr.insertText(' ', 4));
     expect(decoClasses(plugin.getState(next) as DecorationSet)).toEqual([]);
   });
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionSpacingPlugin.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionSpacingPlugin.ts
@@ -1,0 +1,91 @@
+import type { Node as PMNode } from '@tiptap/pm/model';
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+import { mentionSpacingClass } from './mentionSpacing';
+
+const pluginKey = new PluginKey('mentionSpacing');
+
+// Stable spec object so re-created decorations with identical classes compare
+// equal (Decoration `type.eq`) and produce no redundant DOM writes.
+const SPEC = Object.freeze({});
+
+/**
+ * Scans a region for mention nodes and returns a node Decoration carrying the
+ * conditional spacing class for each one that needs it. Decorations are applied
+ * to the mention node view's outer DOM (`span.mention-container`) in place — no
+ * node-view recreation, so no flicker or caret disruption.
+ */
+function findMentionSpacingDecorations(
+  doc: PMNode,
+  from: number,
+  to: number,
+): Decoration[] {
+  const decorations: Decoration[] = [];
+
+  doc.nodesBetween(from, to, (node, pos, parent, index) => {
+    if (node.type.name !== 'mention' || !parent) return;
+    const cls = mentionSpacingClass(node, parent, index);
+    if (cls) {
+      decorations.push(
+        Decoration.node(pos, pos + node.nodeSize, { class: cls }, SPEC),
+      );
+    }
+  });
+
+  return decorations;
+}
+
+export const mentionSpacingPlugin = () =>
+  new Plugin({
+    key: pluginKey,
+
+    state: {
+      init(_, { doc }) {
+        return DecorationSet.create(
+          doc,
+          findMentionSpacingDecorations(doc, 0, doc.content.size),
+        );
+      },
+
+      apply(tr, oldDecorationSet) {
+        if (!tr.docChanged) return oldDecorationSet;
+
+        let decorationSet = oldDecorationSet.map(tr.mapping, tr.doc);
+
+        tr.steps.forEach((step) => {
+          step.getMap().forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+            const from = Math.max(0, newStart);
+            const to = Math.min(tr.doc.content.size, newEnd);
+
+            // A mention's spacing depends on its siblings, so editing text
+            // *next to* a mention changes the mention even though the mention
+            // sits outside the raw step range. Expand to the containing
+            // textblock — spacing never crosses block boundaries — so the
+            // adjacent mention is re-evaluated.
+            const $from = tr.doc.resolve(from);
+            const $to = tr.doc.resolve(to);
+            const expFrom = $from.parent.isTextblock ? $from.start() : from;
+            const expTo = $to.parent.isTextblock ? $to.end() : to;
+
+            const stale = decorationSet.find(expFrom, expTo);
+            if (stale.length > 0) {
+              decorationSet = decorationSet.remove(stale);
+            }
+
+            const fresh = findMentionSpacingDecorations(tr.doc, expFrom, expTo);
+            if (fresh.length > 0) {
+              decorationSet = decorationSet.add(tr.doc, fresh);
+            }
+          });
+        });
+
+        return decorationSet;
+      },
+    },
+
+    props: {
+      decorations(state) {
+        return pluginKey.getState(state);
+      },
+    },
+  });

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSSRMapping.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSSRMapping.ts
@@ -1,0 +1,30 @@
+import { domOutputSpecToHTMLString } from '@tiptap/static-renderer/pm/html-string';
+import type { Node as PMNode } from '@tiptap/pm/model';
+import { mentionDOMOutputSpec } from './Mention.ssr';
+import { mentionSpacingClass } from './mentionSpacing';
+
+/**
+ * `nodeMapping.mention` override for `renderToHTMLString`. The static renderer
+ * hands each node its resolved PM `parent`, so — unlike the node's own
+ * `renderHTML`, which sees no siblings — this can compute conditional spacing
+ * classes and merge them onto the mention container.
+ */
+export const renderMentionToHTMLString = ({
+  node,
+  parent,
+}: {
+  node: PMNode;
+  parent?: PMNode;
+}): string => {
+  let index = -1;
+  // Locate the mention within its parent by identity; the renderer passes the
+  // same child node instances it iterated, so `===` is reliable.
+  parent?.forEach((child, _offset, i) => {
+    if (child === node) index = i;
+  });
+
+  const cls =
+    parent && index >= 0 ? mentionSpacingClass(node, parent, index) : '';
+  const spec = mentionDOMOutputSpec(node, cls ? { class: cls } : {});
+  return domOutputSpecToHTMLString(spec)([]);
+};

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSpacing.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSpacing.spec.ts
@@ -1,0 +1,120 @@
+import { getSchema, Node } from '@tiptap/core';
+import type { Node as PMNode } from '@tiptap/pm/model';
+import { MentionSSR, MentionItem } from './Mention.ssr';
+import {
+  mentionSpacingClass,
+  MENTION_SPACE_AFTER_CLASS,
+  MENTION_SPACE_BEFORE_CLASS,
+} from './mentionSpacing';
+
+const Document = Node.create({
+  name: 'doc',
+  topNode: true,
+  content: 'block+',
+});
+
+const Paragraph = Node.create({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+});
+
+const Text = Node.create({ name: 'text', group: 'inline' });
+
+const HardBreak = Node.create({
+  name: 'hardBreak',
+  group: 'inline',
+  inline: true,
+  selectable: false,
+});
+
+const schema = getSchema([Document, Paragraph, Text, HardBreak, MentionSSR]);
+
+const item = (overrides: Partial<MentionItem> = {}): MentionItem => ({
+  uuid: 'u',
+  entity: 'e',
+  linkType: 'work',
+  displayText: 'Ref',
+  ...overrides,
+});
+
+const mention = (overrides: Partial<MentionItem> = {}) =>
+  schema.node('mention', { items: [item(overrides)] });
+
+const emptyMention = () =>
+  schema.node('mention', {
+    items: [{ uuid: 'u', entity: 'e', linkType: 'work' }],
+  });
+
+/** Class for the mention at `index` inside a paragraph of `children`. */
+const classFor = (children: PMNode[], index: number): string => {
+  const paragraph = schema.node('paragraph', null, children);
+  return mentionSpacingClass(paragraph.child(index), paragraph, index);
+};
+
+describe('mentionSpacingClass', () => {
+  it('adds both gaps when flanked by letters', () => {
+    expect(
+      classFor([schema.text('foo'), mention(), schema.text('bar')], 1),
+    ).toBe(`${MENTION_SPACE_BEFORE_CLASS} ${MENTION_SPACE_AFTER_CLASS}`);
+  });
+
+  it('adds no gap next to whitespace', () => {
+    expect(
+      classFor([schema.text('foo '), mention(), schema.text(' bar')], 1),
+    ).toBe('');
+  });
+
+  it('adds no gap next to ASCII punctuation', () => {
+    expect(
+      classFor([schema.text('foo.'), mention(), schema.text(',bar')], 1),
+    ).toBe('');
+  });
+
+  it('adds no gap next to a quote or bracket', () => {
+    expect(
+      classFor([schema.text('(foo“'), mention(), schema.text('”bar)')], 1),
+    ).toBe('');
+  });
+
+  it('treats the Tibetan tsheg and shad as punctuation', () => {
+    // tsheg U+0F0B before, shad U+0F0D after
+    expect(
+      classFor([schema.text('foo་'), mention(), schema.text('།bar')], 1),
+    ).toBe('');
+  });
+
+  it('adds no gap at the start or end of a block', () => {
+    expect(classFor([mention()], 0)).toBe('');
+    expect(classFor([schema.text('foo'), mention()], 1)).toBe(
+      MENTION_SPACE_BEFORE_CLASS,
+    );
+    expect(classFor([mention(), schema.text('bar')], 0)).toBe(
+      MENTION_SPACE_AFTER_CLASS,
+    );
+  });
+
+  it('renders a single gap between two adjacent mentions', () => {
+    const children = [mention(), mention()];
+    expect(classFor(children, 0)).toBe(MENTION_SPACE_AFTER_CLASS);
+    expect(classFor(children, 1)).toBe('');
+  });
+
+  it('adds no gap next to a hard break', () => {
+    expect(classFor([mention(), schema.node('hardBreak')], 0)).toBe('');
+    expect(classFor([schema.node('hardBreak'), mention()], 1)).toBe('');
+  });
+
+  it('adds no gap for a mention with no resolvable label', () => {
+    expect(
+      classFor([schema.text('foo'), emptyMention(), schema.text('bar')], 1),
+    ).toBe('');
+  });
+
+  it('reads astral-plane letters without splitting surrogate pairs', () => {
+    // U+1D400 MATHEMATICAL BOLD CAPITAL A (a letter) is two UTF-16 units.
+    expect(classFor([schema.text('a\u{1D400}'), mention()], 1)).toBe(
+      MENTION_SPACE_BEFORE_CLASS,
+    );
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSpacing.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSpacing.spec.ts
@@ -65,23 +65,24 @@ describe('mentionSpacingClass', () => {
     ).toBe('');
   });
 
-  it('adds no gap next to ASCII punctuation', () => {
+  it('adds a leading gap after punctuation but no trailing gap before it', () => {
+    // Leading side gets a gap even after punctuation; trailing side does not.
     expect(
       classFor([schema.text('foo.'), mention(), schema.text(',bar')], 1),
-    ).toBe('');
+    ).toBe(MENTION_SPACE_BEFORE_CLASS);
   });
 
-  it('adds no gap next to a quote or bracket', () => {
+  it('adds a leading gap after a quote or bracket', () => {
     expect(
       classFor([schema.text('(foo“'), mention(), schema.text('”bar)')], 1),
-    ).toBe('');
+    ).toBe(MENTION_SPACE_BEFORE_CLASS);
   });
 
-  it('treats the Tibetan tsheg and shad as punctuation', () => {
-    // tsheg U+0F0B before, shad U+0F0D after
+  it('adds a leading gap after a Tibetan tsheg but none before a shad', () => {
+    // tsheg U+0F0B before (leading gap), shad U+0F0D after (no trailing gap)
     expect(
       classFor([schema.text('foo་'), mention(), schema.text('།bar')], 1),
-    ).toBe('');
+    ).toBe(MENTION_SPACE_BEFORE_CLASS);
   });
 
   it('adds no gap at the start or end of a block', () => {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSpacing.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSpacing.ts
@@ -5,18 +5,24 @@ import type { Node as PMNode } from '@tiptap/pm/model';
  * when it sits flush against a letter it reads as cramped. These helpers decide
  * whether to render the visual equivalent of a single space on either side.
  *
- * Rule: add a gap on a side only when the adjacent character exists and is
- * neither whitespace nor punctuation. Two directly adjacent mentions get
- * exactly one gap between them. The gap is purely presentational (a CSS
- * pseudo-element renders a real space) — the document content is untouched.
+ * Rules (asymmetric by design):
+ *  - Leading side: add a gap when preceded by any visible character —
+ *    punctuation included. Only whitespace (or the block start) suppresses it.
+ *  - Trailing side: add a gap only when followed by a non-whitespace,
+ *    non-punctuation character.
+ * Two directly adjacent mentions get exactly one gap between them. The gap is
+ * purely presentational (a CSS pseudo-element renders a real space) — the
+ * document content is untouched.
  */
 
 export const MENTION_SPACE_BEFORE_CLASS = 'mention-space-before';
 export const MENTION_SPACE_AFTER_CLASS = 'mention-space-after';
 
 // `\p{P}` covers Latin punctuation, CJK marks, quotes/brackets, and the Tibetan
-// tsheg (U+0F0B) and shad (U+0F0D) — all of which should suppress the gap.
+// tsheg (U+0F0B) and shad (U+0F0D). Punctuation suppresses only the trailing
+// gap; the leading gap keys off whitespace alone.
 const BOUNDARY_CHAR = /[\s\p{P}]/u;
+const WHITESPACE_CHAR = /\s/u;
 
 /** A mention with no resolvable label renders empty; it needs no spacing. */
 const hasVisibleText = (node: PMNode): boolean =>
@@ -38,15 +44,16 @@ const lastCodePoint = (text: string): string => {
   return points[points.length - 1] ?? '';
 };
 
-const isGapChar = (char: string): boolean => !!char && !BOUNDARY_CHAR.test(char);
-
 /** Should the mention render a gap toward the node preceding it? */
 const gapBefore = (prev: PMNode | null | undefined): boolean => {
   if (!prev) return false;
   // The preceding mention owns the single gap between the two (via its
   // `after` side), so this mention adds nothing on its `before` side.
   if (prev.type.name === 'mention') return false;
-  return isGapChar(lastCodePoint(siblingText(prev)));
+  // Leading gap keys off whitespace only — punctuation before a mention still
+  // gets a space.
+  const char = lastCodePoint(siblingText(prev));
+  return !!char && !WHITESPACE_CHAR.test(char);
 };
 
 /** Should the mention render a gap toward the node following it? */
@@ -54,7 +61,9 @@ const gapAfter = (next: PMNode | null | undefined): boolean => {
   if (!next) return false;
   // Emit the single gap between two adjacent mentions from the earlier one.
   if (next.type.name === 'mention') return true;
-  return isGapChar(firstCodePoint(siblingText(next)));
+  // Trailing gap suppressed next to both whitespace and punctuation.
+  const char = firstCodePoint(siblingText(next));
+  return !!char && !BOUNDARY_CHAR.test(char);
 };
 
 /**

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSpacing.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/mentionSpacing.ts
@@ -1,0 +1,78 @@
+import type { Node as PMNode } from '@tiptap/pm/model';
+
+/**
+ * Conditional visual spacing around mention nodes. A mention is an inline atom;
+ * when it sits flush against a letter it reads as cramped. These helpers decide
+ * whether to render the visual equivalent of a single space on either side.
+ *
+ * Rule: add a gap on a side only when the adjacent character exists and is
+ * neither whitespace nor punctuation. Two directly adjacent mentions get
+ * exactly one gap between them. The gap is purely presentational (a CSS
+ * pseudo-element renders a real space) — the document content is untouched.
+ */
+
+export const MENTION_SPACE_BEFORE_CLASS = 'mention-space-before';
+export const MENTION_SPACE_AFTER_CLASS = 'mention-space-after';
+
+// `\p{P}` covers Latin punctuation, CJK marks, quotes/brackets, and the Tibetan
+// tsheg (U+0F0B) and shad (U+0F0D) — all of which should suppress the gap.
+const BOUNDARY_CHAR = /[\s\p{P}]/u;
+
+/** A mention with no resolvable label renders empty; it needs no spacing. */
+const hasVisibleText = (node: PMNode): boolean =>
+  (Array.isArray(node.attrs.items) ? node.attrs.items : []).some(
+    (item: { text?: string; displayText?: string } | null) =>
+      !!(item && (item.text || item.displayText)),
+  );
+
+/** Text content of a sibling — empty for atoms/breaks (treated as no char). */
+const siblingText = (node: PMNode): string =>
+  node.isText ? node.text ?? '' : node.textContent;
+
+const firstCodePoint = (text: string): string =>
+  text ? String.fromCodePoint(text.codePointAt(0) as number) : '';
+
+const lastCodePoint = (text: string): string => {
+  if (!text) return '';
+  const points = Array.from(text);
+  return points[points.length - 1] ?? '';
+};
+
+const isGapChar = (char: string): boolean => !!char && !BOUNDARY_CHAR.test(char);
+
+/** Should the mention render a gap toward the node preceding it? */
+const gapBefore = (prev: PMNode | null | undefined): boolean => {
+  if (!prev) return false;
+  // The preceding mention owns the single gap between the two (via its
+  // `after` side), so this mention adds nothing on its `before` side.
+  if (prev.type.name === 'mention') return false;
+  return isGapChar(lastCodePoint(siblingText(prev)));
+};
+
+/** Should the mention render a gap toward the node following it? */
+const gapAfter = (next: PMNode | null | undefined): boolean => {
+  if (!next) return false;
+  // Emit the single gap between two adjacent mentions from the earlier one.
+  if (next.type.name === 'mention') return true;
+  return isGapChar(firstCodePoint(siblingText(next)));
+};
+
+/**
+ * The spacing class string for a mention at `index` within `parent`.
+ * Returns '' (no spacing), one class, or both, space-separated.
+ */
+export const mentionSpacingClass = (
+  node: PMNode,
+  parent: PMNode,
+  index: number,
+): string => {
+  if (!hasVisibleText(node)) return '';
+  const classes: string[] = [];
+  if (gapBefore(parent.maybeChild(index - 1))) {
+    classes.push(MENTION_SPACE_BEFORE_CLASS);
+  }
+  if (gapAfter(parent.maybeChild(index + 1))) {
+    classes.push(MENTION_SPACE_AFTER_CLASS);
+  }
+  return classes.join(' ');
+};

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -498,6 +498,92 @@ describe('TranslationSSRContent', () => {
     expect(html).not.toContain('en-gone');
   });
 
+  it('adds conditional spacing classes to a mention flanked by letters', () => {
+    // The static renderer has no siblings in a node's own renderHTML, so the
+    // nodeMapping.mention override computes adjacency from the resolved parent.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'see' },
+                {
+                  type: 'mention',
+                  attrs: {
+                    items: [
+                      {
+                        text: 'Sutra',
+                        entity: 'me-1',
+                        linkType: 'work',
+                        uuid: 'mi-1',
+                      },
+                    ],
+                  },
+                },
+                { type: 'text', text: 'here' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const el = TranslationSSRContent({
+      content: doc,
+    }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    expect(html).toMatch(
+      /<span class="mention-space-before mention-space-after mention-container"[^>]*data-type="mention"/,
+    );
+  });
+
+  it('adds no spacing class to a mention adjacent to punctuation', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: '(' },
+                {
+                  type: 'mention',
+                  attrs: {
+                    items: [
+                      {
+                        text: 'Sutra',
+                        entity: 'me-1',
+                        linkType: 'work',
+                        uuid: 'mi-1',
+                      },
+                    ],
+                  },
+                },
+                { type: 'text', text: ').' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const el = TranslationSSRContent({
+      content: doc,
+    }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    expect(html).toContain('<span class="mention-container" data-type="mention"');
+    expect(html).not.toContain('mention-space-before');
+    expect(html).not.toContain('mention-space-after');
+  });
+
   it('exposes the default SSR extension set including passage and bold', () => {
     const names = translationSSRExtensions.map((e) => e.name);
     expect(names).toEqual(expect.arrayContaining(['passage', 'bold']));

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -542,7 +542,7 @@ describe('TranslationSSRContent', () => {
     );
   });
 
-  it('adds no spacing class to a mention adjacent to punctuation', () => {
+  it('adds a leading gap after punctuation but no trailing gap before it', () => {
     const doc: JSONContent = {
       type: 'doc',
       content: [
@@ -553,7 +553,7 @@ describe('TranslationSSRContent', () => {
             {
               type: 'paragraph',
               content: [
-                { type: 'text', text: '(' },
+                { type: 'text', text: 'foo:' },
                 {
                   type: 'mention',
                   attrs: {
@@ -579,9 +579,99 @@ describe('TranslationSSRContent', () => {
       content: doc,
     }) as ReactElement<DangerousProps>;
     const html = renderedHtml(el);
+    // Leading `:` gets a gap; trailing `)` does not.
+    expect(html).toContain(
+      '<span class="mention-space-before mention-container" data-type="mention"',
+    );
+    expect(html).not.toContain('mention-space-after');
+  });
+
+  it('adds no spacing class to a mention flanked by whitespace', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'see ' },
+                {
+                  type: 'mention',
+                  attrs: {
+                    items: [
+                      {
+                        text: 'Sutra',
+                        entity: 'me-1',
+                        linkType: 'work',
+                        uuid: 'mi-1',
+                      },
+                    ],
+                  },
+                },
+                { type: 'text', text: ' here' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const el = TranslationSSRContent({
+      content: doc,
+    }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
     expect(html).toContain('<span class="mention-container" data-type="mention"');
     expect(html).not.toContain('mention-space-before');
     expect(html).not.toContain('mention-space-after');
+  });
+
+  it('sets data-toh on the mention container so toh-hiding removes its spacing', () => {
+    // The container's data-toh drives the runtime toh-visibility rule; hiding
+    // the container also removes its ::before/::after spacing.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                { type: 'text', text: 'see' },
+                {
+                  type: 'mention',
+                  attrs: {
+                    items: [
+                      {
+                        text: 'Sutra',
+                        entity: 'me-1',
+                        linkType: 'work',
+                        uuid: 'mi-1',
+                        toh: 'toh1',
+                      },
+                    ],
+                  },
+                },
+                { type: 'text', text: 'here' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const el = TranslationSSRContent({
+      content: doc,
+    }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    // Spacing classes and the toh union both land on the container span.
+    expect(html).toMatch(
+      /<span class="mention-space-before mention-space-after mention-container" data-toh="toh1" data-type="mention"/,
+    );
   });
 
   it('exposes the default SSR extension set including passage and bold', () => {

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
@@ -3,6 +3,7 @@ import { getSchema } from '@tiptap/core';
 import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { translationSSRExtensions } from '../editor/extensions/translationSSRExtensions';
+import { renderMentionToHTMLString } from '../editor/extensions/Mention/mentionSSRMapping';
 import { extractPlainText } from './ssr-text-fallback';
 
 type EndNoteItem = {
@@ -147,7 +148,10 @@ export const TranslationSSRContent = ({
     const html = renderToHTMLString({
       content: doc,
       extensions: exts,
-      options: { markMapping: { endNoteLink: renderEndNoteLinkMark } },
+      options: {
+        markMapping: { endNoteLink: renderEndNoteLinkMark },
+        nodeMapping: { mention: renderMentionToHTMLString },
+      },
     });
     return (
       <div className={className} dangerouslySetInnerHTML={{ __html: html }} />

--- a/libs/lib-editing/src/lib/components/stack/PassageStackController.ts
+++ b/libs/lib-editing/src/lib/components/stack/PassageStackController.ts
@@ -21,6 +21,7 @@ import {
 import type { TranslationEditorContentItem } from '@eightyfourthousand/data-access';
 
 import { incrementLabel } from '../editor/extensions/Passage/label';
+import { renderMentionToHTMLString } from '../editor/extensions/Mention/mentionSSRMapping';
 import {
   buildStackEditorExtensions,
   buildStackSchemaExtensions,
@@ -161,6 +162,7 @@ export class PassageStackController {
       html = renderToHTMLString({
         content: this.getDocJSON(uuid),
         extensions: buildStackSchemaExtensions(),
+        options: { nodeMapping: { mention: renderMentionToHTMLString } },
       });
     } catch (error) {
       console.error('failed to statically render passage', error);


### PR DESCRIPTION
### Summary

Mentions are zero-length annotations, often with dynamically generated text. They often need space on one or more sides, but the editor will strip extra spaces in some situations. To accommodate this, mentions need to be aware of their context. Now, mentions will ensure there is space around them when the next character on either side (if there is one) is not punctuation.

In the editor, mentions will also present with a light background to show what space is artificial and what is editable.
