### PR TITLE
add search to mcp read tools

### DIFF
--- a/libs/lib-agent/src/lib/tools/read/index.ts
+++ b/libs/lib-agent/src/lib/tools/read/index.ts
@@ -5,6 +5,7 @@ import { createGetTranslationTool } from './get-translation';
 import { createGetPassageTool } from './get-passage';
 import { createGetTranslationPassagesTool } from './get-translation-passages';
 import { createSearchTranslationTool } from './search-translation';
+import { createSearchEntitiesTool } from './search-entities';
 import { createGetGlossaryTermTool } from './get-glossary-term';
 import { createListGlossaryTermsTool } from './list-glossary-terms';
 import { createSearchGlossaryTermsTool } from './search-glossary-terms';
@@ -22,6 +23,7 @@ export function createReadTools(client: DataClient): McpToolDefinition[] {
     createGetPassageTool(client),
     createGetTranslationPassagesTool(client),
     createSearchTranslationTool(client),
+    createSearchEntitiesTool(client),
     createGetGlossaryTermTool(client),
     createListGlossaryTermsTool(client),
     createSearchGlossaryTermsTool(client),
@@ -39,6 +41,7 @@ export { createGetTranslationTool } from './get-translation';
 export { createGetPassageTool } from './get-passage';
 export { createGetTranslationPassagesTool } from './get-translation-passages';
 export { createSearchTranslationTool } from './search-translation';
+export { createSearchEntitiesTool } from './search-entities';
 export { createGetGlossaryTermTool } from './get-glossary-term';
 export { createListGlossaryTermsTool } from './list-glossary-terms';
 export { createSearchGlossaryTermsTool } from './search-glossary-terms';

--- a/libs/lib-agent/src/lib/tools/read/search-entities.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-entities.spec.ts
@@ -1,0 +1,59 @@
+import { createSearchEntitiesTool } from './search-entities';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  searchEntities: jest.fn(),
+}));
+
+import { searchEntities } from '@eightyfourthousand/data-access';
+const mockedSearch = jest.mocked(searchEntities);
+
+describe('search-entities tool', () => {
+  const client = {} as DataClient;
+  const tool = createSearchEntitiesTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('search-entities');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('returns search results as JSON', async () => {
+    const results = [
+      { uuid: 'w1', type: 'work', label: 'Toh 1', text: 'The Play in Full' },
+    ];
+    mockedSearch.mockResolvedValue(results as any);
+
+    const result = await tool.handler(
+      { query: 'play', workUuid: 'work-1', types: ['work'] },
+      extra,
+    );
+
+    expect(mockedSearch).toHaveBeenCalledWith({
+      client,
+      query: 'play',
+      workUuid: 'work-1',
+      toh: undefined,
+      types: ['work'],
+      limit: undefined,
+    });
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(results, null, 2),
+    });
+  });
+
+  it('returns empty results as JSON', async () => {
+    mockedSearch.mockResolvedValue([]);
+
+    const result = await tool.handler({ query: 'nothing' }, extra);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify([], null, 2),
+    });
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/search-entities.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-entities.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import {
+  searchEntities,
+  type DataClient,
+  type EntitySearchResultType,
+} from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult } from './util';
+
+const ENTITY_TYPES = [
+  'work',
+  'passage',
+  'folio',
+  'bibliography',
+  'glossary',
+] as const satisfies readonly EntitySearchResultType[];
+
+const inputSchema = {
+  query: z.string().describe('Search query text'),
+  workUuid: z
+    .string()
+    .optional()
+    .describe(
+      'Optional work UUID to scope passages, folios, bibliographies, and glossary terms',
+    ),
+  toh: z
+    .string()
+    .optional()
+    .describe('Optional Tohoku catalog number to scope folios'),
+  types: z
+    .array(z.enum(ENTITY_TYPES))
+    .optional()
+    .describe('Optional list of entity types to restrict the search to'),
+  limit: z
+    .number()
+    .optional()
+    .describe('Maximum number of results (1-50, defaults to 20)'),
+};
+
+export function createSearchEntitiesTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'search-entities',
+    description:
+      'Search across works, passages, folios, bibliographies, and glossary terms. Works are searched globally by title/toh; other types can be scoped to a work via workUuid (or folios via toh).',
+    inputSchema,
+    annotations: {
+      title: 'Search Entities',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({ query, workUuid, toh, types, limit }) => {
+      const results = await searchEntities({
+        client,
+        query,
+        workUuid,
+        toh,
+        types,
+        limit,
+      });
+      return jsonResult(results);
+    },
+  };
+}


### PR DESCRIPTION
### Summary

The `search_entities` function on Supabase has been optimized for a more general search, no work uuid or toh required. This exposes it over MCP as well.
