### PR TITLE
Mention `quote` Style

### DIFF
--- a/libs/data-access/src/lib/types/annotation/annotation-type.ts
+++ b/libs/data-access/src/lib/types/annotation/annotation-type.ts
@@ -168,6 +168,7 @@ export type AnnotationDTOContentKey =
   | 'paragraph'
   | 'quote_xmlId'
   | 'src'
+  | 'style'
   | 'text-style'
   | 'text'
   | 'type'

--- a/libs/data-access/src/lib/types/annotation/annotation.ts
+++ b/libs/data-access/src/lib/types/annotation/annotation.ts
@@ -154,6 +154,8 @@ export type MantraAnnotation = AnnotationBase & {
   lang: ExtendedTranslationLanguage;
 };
 
+export type MentionStyle = 'quote';
+
 export type MentionAnnotation = AnnotationBase & {
   type: 'mention';
   entity: string;
@@ -164,6 +166,7 @@ export type MentionAnnotation = AnnotationBase & {
   subtype?: string;
   linkToh?: string;
   lang?: ExtendedTranslationLanguage;
+  style?: MentionStyle;
 };
 
 export type ParagraphAnnotation = AnnotationBase & {

--- a/libs/data-access/src/lib/types/annotation/mention.ts
+++ b/libs/data-access/src/lib/types/annotation/mention.ts
@@ -31,13 +31,16 @@ export const transformer: AnnotationTransformer = (dto): MentionAnnotation => {
     if (content.lang) {
       mention.lang = content.lang as MentionAnnotation['lang'];
     }
+    if (content.style) {
+      mention.style = content.style as MentionAnnotation['style'];
+    }
   });
 
   return mention;
 };
 
 export const exporter: AnnotationExporter = (annotation): AnnotationDTO => {
-  const { entity, linkType, text, isSameWork, subtype, linkToh, lang } =
+  const { entity, linkType, text, isSameWork, subtype, linkToh, lang, style } =
     annotation as MentionAnnotation;
   const dto = baseAnnotationToDto(annotation);
 
@@ -62,6 +65,9 @@ export const exporter: AnnotationExporter = (annotation): AnnotationDTO => {
   }
   if (lang) {
     dto.content.push({ lang });
+  }
+  if (style) {
+    dto.content.push({ style });
   }
 
   return dto;

--- a/libs/design-system/src/lib/theme/components.css
+++ b/libs/design-system/src/lib/theme/components.css
@@ -85,6 +85,12 @@
     @apply italic;
   }
 
+  /* Quote-style mentions render as a superscript with a little extra padding
+     at the end, separating them from the following text. */
+  .mention-link[data-style='quote'] {
+    @apply align-super pe-0.5 text-[0.75em];
+  }
+
   .glossary-instance-definition {
     p {
       @apply mb-1 mt-2 @c/sidebar:pt-1;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -17,6 +17,7 @@ export interface MentionItem {
   linkToh?: string;
   toh?: string;
   lang?: string;
+  style?: 'quote';
 }
 
 const isMentionItem = (value: unknown): value is MentionItem => {
@@ -70,6 +71,9 @@ export const mentionDOMOutputSpec = (
     const extraAttrs: Record<string, string> = {
       ...(item.toh ? { 'data-toh': item.toh } : {}),
       ...(item.lang ? { lang: item.lang } : {}),
+      // `data-style` drives presentational rules (e.g. quote mentions render
+      // as a superscript with trailing padding).
+      ...(item.style ? { 'data-style': item.style } : {}),
     };
 
     if (!label || !item.entity || !item.linkType) {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -94,6 +94,11 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
         if (item.lang) {
           anchor.setAttribute('lang', item.lang);
         }
+        // `data-style` drives presentational rules (e.g. quote mentions render
+        // as a superscript with trailing padding).
+        if (item.style) {
+          anchor.setAttribute('data-style', item.style);
+        }
 
         // Display priority: text (custom override) > displayText (dynamic) > entity UUID (fallback)
         const displayText = item.text || item.displayText;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionHoverContent.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionHoverContent.tsx
@@ -1,11 +1,13 @@
 import { Button } from '@eightyfourthousand/design-system';
 import { ExtendedTranslationLanguage } from '@eightyfourthousand/data-access';
+import { cn } from '@eightyfourthousand/lib-utils';
 import { Editor } from '@tiptap/core';
 import {
   CheckIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   LanguagesIcon,
+  QuoteIcon,
   Trash2Icon,
   TypeIcon,
   XIcon,
@@ -123,6 +125,8 @@ export const MentionHoverContent = ({
   const displayLabel = item?.text || item?.displayText || entity;
   // Language tagging is only meaningful for work titles.
   const isWork = entityType === 'work';
+  // Quote styling (superscript label) is only offered for passage mentions.
+  const isPassage = entityType === 'passage';
 
   const setMode = useCallback(
     (next: Mode) => {
@@ -187,6 +191,14 @@ export const MentionHoverContent = ({
     },
     [mutateItem],
   );
+
+  // Toggle the `quote` style on/off, clearing it back to the default label.
+  const toggleQuoteStyle = useCallback(() => {
+    mutateItem((item) => ({
+      ...item,
+      style: item.style === 'quote' ? undefined : 'quote',
+    }));
+  }, [mutateItem]);
 
   if (mode === 'rename') {
     return (
@@ -264,6 +276,22 @@ export const MentionHoverContent = ({
           onClick={() => setMode('lang')}
         >
           <LanguagesIcon className="text-primary my-auto" />
+        </Button>
+      )}
+      {isPassage && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 [&_svg]:size-4"
+          title="Toggle quote style"
+          onClick={toggleQuoteStyle}
+        >
+          <QuoteIcon
+            className={cn(
+              'my-auto',
+              item?.style === 'quote' ? 'text-primary' : 'text-foreground/50',
+            )}
+          />
         </Button>
       )}
       <Button

--- a/libs/lib-editing/src/lib/exporters/mention.ts
+++ b/libs/lib-editing/src/lib/exporters/mention.ts
@@ -23,6 +23,7 @@ export const mention: Exporter<MentionAnnotation[]> = ({
       subtype?: string;
       linkToh?: string;
       lang?: MentionAnnotation['lang'];
+      style?: MentionAnnotation['style'];
     }): MentionAnnotation => ({
       uuid: item.uuid,
       type: 'mention',
@@ -35,6 +36,7 @@ export const mention: Exporter<MentionAnnotation[]> = ({
       ...(item.subtype && { subtype: item.subtype }),
       ...(item.linkToh && { linkToh: item.linkToh }),
       ...(item.lang && { lang: item.lang }),
+      ...(item.style && { style: item.style }),
       // Zero-length annotation: start === end
       start,
       end: start,

--- a/libs/lib-editing/src/lib/transformers/mention.ts
+++ b/libs/lib-editing/src/lib/transformers/mention.ts
@@ -21,6 +21,7 @@ export const mention: Transformer = (ctx) => {
     linkToh,
     toh,
     lang,
+    style,
   } = annotation as MentionAnnotation;
 
   const item = {
@@ -34,6 +35,7 @@ export const mention: Transformer = (ctx) => {
     linkToh,
     toh: serializeTohList(toh),
     lang,
+    style,
   };
   const matched = recurse({
     ...ctx,


### PR DESCRIPTION
### Summary

Adds support for an optional `style` property for mentions. Currently, the only possible value is `quote`, which renders the mention as a superscript and adds padding. This is intended for mentions within blockquotes that point to the original passage.

### Linear

- [ED-1337](https://linear.app/84000/issue/ED-1337)

### Notes

Mentions can also have `start` and `end` properties to highlight a portion of the linked passage. Support for highlighting when opening a link will be a follow-up change.
