### PR TITLE
Quote Highlighting

### DIFF
--- a/libs/data-access/src/lib/types/annotation/annotation-type.ts
+++ b/libs/data-access/src/lib/types/annotation/annotation-type.ts
@@ -168,6 +168,8 @@ export type AnnotationDTOContentKey =
   | 'paragraph'
   | 'quote_xmlId'
   | 'src'
+  | 'start'
+  | 'end'
   | 'style'
   | 'text-style'
   | 'text'

--- a/libs/data-access/src/lib/types/annotation/annotation.ts
+++ b/libs/data-access/src/lib/types/annotation/annotation.ts
@@ -167,6 +167,12 @@ export type MentionAnnotation = AnnotationBase & {
   linkToh?: string;
   lang?: ExtendedTranslationLanguage;
   style?: MentionStyle;
+  // Character range to highlight in the linked target (e.g. the root-text
+  // passage a commentary quote points to). Parsed from the `start`/`end`
+  // key/value pairs in the annotation's `content` — distinct from the
+  // annotation's own `start`/`end` span within its host passage.
+  highlightStart?: number;
+  highlightEnd?: number;
 };
 
 export type ParagraphAnnotation = AnnotationBase & {

--- a/libs/data-access/src/lib/types/annotation/mention.spec.ts
+++ b/libs/data-access/src/lib/types/annotation/mention.spec.ts
@@ -1,0 +1,53 @@
+import { annotationFromDTO, annotationToDTO } from './transform';
+import type { AnnotationDTO } from './annotation-type';
+import type { MentionAnnotation } from './annotation';
+
+describe('mention highlight range', () => {
+  const baseDto: AnnotationDTO = {
+    uuid: 'mention-1',
+    start: 4,
+    end: 4,
+    type: 'mention',
+    passage_uuid: 'passage-1',
+    content: [
+      { uuid: 'entity-1' },
+      { type: 'passage' },
+      { same_work: true },
+      { start: 0 },
+      { end: 248 },
+    ],
+  };
+
+  it('parses `start`/`end` content pairs into highlightStart/highlightEnd', () => {
+    const mention = annotationFromDTO(baseDto, 100) as MentionAnnotation;
+    expect(mention.highlightStart).toBe(0);
+    expect(mention.highlightEnd).toBe(248);
+    // The annotation's own span is untouched by the content highlight range.
+    expect(mention.start).toBe(4);
+    expect(mention.end).toBe(4);
+  });
+
+  it('round-trips the highlight range back into content', () => {
+    const mention = annotationFromDTO(baseDto, 100);
+    const dto = annotationToDTO(mention);
+    expect(dto?.content).toEqual(
+      expect.arrayContaining([{ start: 0 }, { end: 248 }]),
+    );
+  });
+
+  it('omits the highlight range when no `start`/`end` content is present', () => {
+    const mention = annotationFromDTO(
+      { ...baseDto, content: [{ uuid: 'entity-1' }, { type: 'passage' }] },
+      100,
+    ) as MentionAnnotation;
+    expect(mention.highlightStart).toBeUndefined();
+    expect(mention.highlightEnd).toBeUndefined();
+
+    const dto = annotationToDTO(mention);
+    expect(dto?.content).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ start: expect.anything() }),
+      ]),
+    );
+  });
+});

--- a/libs/data-access/src/lib/types/annotation/mention.ts
+++ b/libs/data-access/src/lib/types/annotation/mention.ts
@@ -34,14 +34,30 @@ export const transformer: AnnotationTransformer = (dto): MentionAnnotation => {
     if (content.style) {
       mention.style = content.style as MentionAnnotation['style'];
     }
+    if (content.start !== undefined) {
+      mention.highlightStart = Number(content.start);
+    }
+    if (content.end !== undefined) {
+      mention.highlightEnd = Number(content.end);
+    }
   });
 
   return mention;
 };
 
 export const exporter: AnnotationExporter = (annotation): AnnotationDTO => {
-  const { entity, linkType, text, isSameWork, subtype, linkToh, lang, style } =
-    annotation as MentionAnnotation;
+  const {
+    entity,
+    linkType,
+    text,
+    isSameWork,
+    subtype,
+    linkToh,
+    lang,
+    style,
+    highlightStart,
+    highlightEnd,
+  } = annotation as MentionAnnotation;
   const dto = baseAnnotationToDto(annotation);
 
   if (entity) {
@@ -68,6 +84,12 @@ export const exporter: AnnotationExporter = (annotation): AnnotationDTO => {
   }
   if (style) {
     dto.content.push({ style });
+  }
+  if (highlightStart !== undefined) {
+    dto.content.push({ start: highlightStart });
+  }
+  if (highlightEnd !== undefined) {
+    dto.content.push({ end: highlightEnd });
   }
 
   return dto;

--- a/libs/design-system/src/lib/theme/global.css
+++ b/libs/design-system/src/lib/theme/global.css
@@ -65,6 +65,8 @@
     --warning-foreground: var(--foreground);
     --error: var(--destructive);
     --error-foreground: var(--destructive-foreground);
+
+    --highlight: color-mix(in oklab, var(--ochre) 45%, transparent);
   }
 
   /* TODO: dark mode is temporarily disabled */
@@ -220,4 +222,5 @@
   --color-success-foreground: var(--success-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
+  --color-highlight: var(--highlight);
 }

--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -21,6 +21,7 @@ import {
 import type { PanelFilter } from '@eightyfourthousand/data-access';
 import { PassageSkeleton } from '../shared/PassageSkeleton';
 import {
+  clearTextRangeHighlight,
   highlightTextRange,
   isUuid,
   scrollToElement,
@@ -125,9 +126,18 @@ export const PaginationProvider = ({
   const handledEndLoadRequestRef = useRef(0);
   const dataClient = useMemo(() => createGraphQLClient(), []);
 
-  const { panels, updatePanel, setShowOuterContent, highlight, clearHighlight } =
+  const { panels, updatePanel, setShowOuterContent, highlight } =
     useNavigation();
   const isMobile = useIsMobile();
+
+  // The passage + range currently painted by the deep-link highlight. Held
+  // locally (not in nav state / the URL) so it survives the DOM churn from
+  // post-navigation editor transactions and is re-applied by the effect below.
+  const [activeHighlight, setActiveHighlight] = useState<{
+    target: string;
+    start: number;
+    end: number;
+  } | null>(null);
 
   // Extract hash as a primitive value so we only react to actual hash changes,
   // not to every panels object reference change.
@@ -271,19 +281,32 @@ export const PaginationProvider = ({
 
         await scrollToElement({ element });
 
-        // Paint the requested character range within the target passage's
-        // content column (excludes the label and the compare-source column,
-        // so offsets align with the passage's own text). Cleared once applied.
+        // Claim this passage as the highlight target when a range is pending,
+        // else clear any prior highlight now that we've navigated elsewhere.
+        // Painting happens in the effect below (which re-applies after editor
+        // DOM churn); a one-shot paint here would be lost to that race.
+        setActiveHighlight(
+          highlight
+            ? { target: navCursor, start: highlight.start, end: highlight.end }
+            : null,
+        );
+
+        // Now that the range is captured locally, strip it from the URL so it
+        // can't re-apply to a different passage on refresh or a later
+        // navigation. Done here (the consumption point) rather than in the
+        // URL-writing effect, which runs on mount before the range is claimed.
         if (highlight) {
-          const content =
-            element.querySelector<HTMLElement>('.passage.is-editable') ??
-            element;
-          highlightTextRange({
-            container: content,
-            start: highlight.start,
-            end: highlight.end,
-          });
-          clearHighlight();
+          const stripped = new URLSearchParams(window.location.search);
+          stripped.delete('start');
+          stripped.delete('end');
+          const strippedQuery = stripped.toString();
+          window.history.replaceState(
+            null,
+            '',
+            `${window.location.pathname}${
+              strippedQuery ? `?${strippedQuery}` : ''
+            }${window.location.hash}`,
+          );
         }
 
         updatePanel({
@@ -315,8 +338,37 @@ export const PaginationProvider = ({
     tab,
     fragment,
     highlight,
-    clearHighlight,
   ]);
+
+  // Paints the deep-link highlight and re-applies it on every editor
+  // transaction. The CSS Custom Highlight API paints a live Range; ProseMirror
+  // transactions that fire after navigation (chrome sync, pagination,
+  // decorations) rebuild the passage's text nodes and detach the Range, so a
+  // one-shot paint is racy. Re-applying on each `update` keeps it painted; the
+  // cleanup clears it when the target changes or the provider unmounts.
+  useEffect(() => {
+    const div = childrenDivRef.current;
+    if (!activeHighlight || !editor || !div) {
+      return;
+    }
+
+    const { target, start, end } = activeHighlight;
+    const apply = () => {
+      const passage = div.querySelector<HTMLElement>(`#${CSS.escape(target)}`);
+      const content =
+        passage?.querySelector<HTMLElement>('.passage.is-editable') ?? passage;
+      if (content) {
+        highlightTextRange({ container: content, start, end });
+      }
+    };
+
+    apply();
+    editor.on('update', apply);
+    return () => {
+      editor.off('update', apply);
+      clearTextRangeHighlight();
+    };
+  }, [activeHighlight, editor]);
 
   useEffect(() => {
     return () => {

--- a/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/PaginationProvider.tsx
@@ -21,6 +21,7 @@ import {
 import type { PanelFilter } from '@eightyfourthousand/data-access';
 import { PassageSkeleton } from '../shared/PassageSkeleton';
 import {
+  highlightTextRange,
   isUuid,
   scrollToElement,
   useIsMobile,
@@ -124,7 +125,8 @@ export const PaginationProvider = ({
   const handledEndLoadRequestRef = useRef(0);
   const dataClient = useMemo(() => createGraphQLClient(), []);
 
-  const { panels, updatePanel, setShowOuterContent } = useNavigation();
+  const { panels, updatePanel, setShowOuterContent, highlight, clearHighlight } =
+    useNavigation();
   const isMobile = useIsMobile();
 
   // Extract hash as a primitive value so we only react to actual hash changes,
@@ -269,6 +271,21 @@ export const PaginationProvider = ({
 
         await scrollToElement({ element });
 
+        // Paint the requested character range within the target passage's
+        // content column (excludes the label and the compare-source column,
+        // so offsets align with the passage's own text). Cleared once applied.
+        if (highlight) {
+          const content =
+            element.querySelector<HTMLElement>('.passage.is-editable') ??
+            element;
+          highlightTextRange({
+            container: content,
+            start: highlight.start,
+            end: highlight.end,
+          });
+          clearHighlight();
+        }
+
         updatePanel({
           name: panel,
           state: { ...panels[panel], hash: undefined },
@@ -297,6 +314,8 @@ export const PaginationProvider = ({
     setNavigating,
     tab,
     fragment,
+    highlight,
+    clearHighlight,
   ]);
 
   useEffect(() => {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ssr.ts
@@ -18,10 +18,31 @@ export interface MentionItem {
   toh?: string;
   lang?: string;
   style?: 'quote';
+  // Character range to highlight in the linked target passage, surfaced as the
+  // `start`/`end` navigation query parameters when the link is followed.
+  highlightStart?: number;
+  highlightEnd?: number;
 }
 
 const isMentionItem = (value: unknown): value is MentionItem => {
   return !!value && typeof value === 'object';
+};
+
+/**
+ * Adds the `start`/`end` highlight query parameters to `params` when the item
+ * carries a highlight range, so following the link highlights that character
+ * range in the target passage (see the deep-link highlight in NavigationProvider).
+ */
+export const applyMentionHighlightParams = (
+  params: URLSearchParams,
+  item: MentionItem,
+) => {
+  if (item.highlightStart !== undefined) {
+    params.set('start', String(item.highlightStart));
+  }
+  if (item.highlightEnd !== undefined) {
+    params.set('end', String(item.highlightEnd));
+  }
 };
 
 /**
@@ -80,7 +101,12 @@ export const mentionDOMOutputSpec = (
       return ['span', { class: 'mention-link', ...extraAttrs }, label] as unknown;
     }
 
-    const href = safeHref(`/entity/${item.linkType}/${item.entity}`);
+    const hrefParams = new URLSearchParams();
+    applyMentionHighlightParams(hrefParams, item);
+    const hrefQuery = hrefParams.toString();
+    const href = safeHref(
+      `/entity/${item.linkType}/${item.entity}${hrefQuery ? `?${hrefQuery}` : ''}`,
+    );
     const attrs: Record<string, string> = {
       class: 'mention-link',
       ...extraAttrs,

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/Mention.ts
@@ -2,7 +2,12 @@ import { v4 as uuidv4 } from 'uuid';
 import Suggestion from '@tiptap/suggestion';
 import { registerEditorElement } from '../../util';
 import { PANEL_FOR_SECTION, TAB_FOR_SECTION } from '../../../shared/types';
-import { MentionSSR, MentionItem, mentionContainerToh } from './Mention.ssr';
+import {
+  MentionSSR,
+  MentionItem,
+  mentionContainerToh,
+  applyMentionHighlightParams,
+} from './Mention.ssr';
 import { mentionDropSelectionPlugin } from './MentionDropSelection';
 import { mentionSpacingPlugin } from './MentionSpacingPlugin';
 import { mentionSuggestion } from './MentionSuggestion';
@@ -113,11 +118,17 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
           );
         }
 
-        // Compute href from linkType + entity
-        let href = `/entity/${item.linkType}/${item.entity}`;
+        // Compute href from linkType + entity, carrying the edit flag and any
+        // highlight range through as query parameters.
+        const hrefParams = new URLSearchParams();
         if (isEditable) {
-          href = `${href}?edit=true`;
+          hrefParams.set('edit', 'true');
         }
+        applyMentionHighlightParams(hrefParams, item);
+        const hrefQuery = hrefParams.toString();
+        const href = `/entity/${item.linkType}/${item.entity}${
+          hrefQuery ? `?${hrefQuery}` : ''
+        }`;
 
         if (isEditable || !item.isSameWork) {
           anchor.setAttribute('href', href);
@@ -143,6 +154,11 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
               query.set('toh', item.linkToh);
             }
 
+            // Drop any highlight range from a previous navigation; only a
+            // passage link with its own range re-adds it below.
+            query.delete('start');
+            query.delete('end');
+
             switch (item.linkType) {
               case 'bibliography':
                 query.set('right', `open:bibliography:${item.entity}`);
@@ -155,6 +171,7 @@ export const Mention = MentionSSR.extend<unknown, MentionStorage>({
                 const tab =
                   TAB_FOR_SECTION[item.subtype || ''] || 'translation';
                 query.set(panel, `open:${tab}:${item.entity}`);
+                applyMentionHighlightParams(query, item);
                 break;
               }
               case 'folio': {

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionHoverContent.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionHoverContent.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@eightyfourthousand/design-system';
+import { Button, Input } from '@eightyfourthousand/design-system';
 import { ExtendedTranslationLanguage } from '@eightyfourthousand/data-access';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { Editor } from '@tiptap/core';
@@ -6,17 +6,19 @@ import {
   CheckIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  HighlighterIcon,
   LanguagesIcon,
   QuoteIcon,
   Trash2Icon,
   TypeIcon,
   XIcon,
 } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { HoverInputField } from '../HoverInputField';
+import { useNavigation } from '../../../shared';
 import type { MentionItem } from './Mention.ssr';
 
-type Mode = 'view' | 'rename' | 'lang';
+type Mode = 'view' | 'rename' | 'lang' | 'range';
 
 /**
  * Language options offered when tagging a `work` mention. The `lang` attribute
@@ -112,6 +114,7 @@ export const MentionHoverContent = ({
   setHoverCardEditing: (isEditing: boolean) => void;
 }) => {
   const [mode, setModeLocal] = useState<Mode>('view');
+  const { fetchPassage } = useNavigation();
 
   // Snapshot the item once when the card opens — the custom override (`text`)
   // pre-fills the rename field, and text/displayText drive the label shown.
@@ -200,6 +203,52 @@ export const MentionHoverContent = ({
     }));
   }, [mutateItem]);
 
+  // Highlight-range editing (only offered for `quote`-styled passage mentions).
+  // The range highlights text in the *linked* passage, so its text is fetched
+  // to preview the selection.
+  const [rangeStart, setRangeStart] = useState(
+    item?.highlightStart != null ? String(item.highlightStart) : '',
+  );
+  const [rangeEnd, setRangeEnd] = useState(
+    item?.highlightEnd != null ? String(item.highlightEnd) : '',
+  );
+  const [passageText, setPassageText] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (mode !== 'range' || !entity) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const passage = await fetchPassage(entity);
+      if (!cancelled) {
+        setPassageText(passage?.content ?? '');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, entity, fetchPassage]);
+
+  const start = Number(rangeStart);
+  const end = Number(rangeEnd);
+  const hasValidRange =
+    rangeStart !== '' &&
+    rangeEnd !== '' &&
+    Number.isFinite(start) &&
+    Number.isFinite(end) &&
+    start >= 0 &&
+    end > start;
+
+  // Persist the range, or clear it when the inputs don't describe a valid one.
+  const saveRange = useCallback(() => {
+    mutateItem((item) => ({
+      ...item,
+      highlightStart: hasValidRange ? start : undefined,
+      highlightEnd: hasValidRange ? end : undefined,
+    }));
+  }, [mutateItem, hasValidRange, start, end]);
+
   if (mode === 'rename') {
     return (
       <div className="flex justify-between gap-2 p-2 w-fit max-w-80">
@@ -259,6 +308,93 @@ export const MentionHoverContent = ({
     );
   }
 
+  if (mode === 'range') {
+    // Clamp for the preview so an over-long end still shows a sensible slice.
+    const previewEnd =
+      passageText != null ? Math.min(end, passageText.length) : end;
+
+    return (
+      <div className="flex flex-col gap-2 p-2 w-80">
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6 [&_svg]:size-4"
+            title="Back"
+            onClick={() => setMode('view')}
+          >
+            <ChevronLeftIcon className="text-primary" />
+          </Button>
+          <span className="text-primary text-sm my-auto">Highlight range</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="flex flex-col gap-0.5 flex-1">
+            <span className="text-xs text-muted-foreground">Start</span>
+            <Input
+              type="number"
+              min={0}
+              value={rangeStart}
+              onChange={(e) => setRangeStart(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-0.5 flex-1">
+            <span className="text-xs text-muted-foreground">End</span>
+            <Input
+              type="number"
+              min={0}
+              value={rangeEnd}
+              onChange={(e) => setRangeEnd(e.target.value)}
+            />
+          </label>
+        </div>
+
+        <div className="max-h-32 overflow-auto rounded-md border border-border p-2 text-sm leading-relaxed">
+          {passageText == null ? (
+            <span className="text-muted-foreground">Loading…</span>
+          ) : !hasValidRange ? (
+            <span className="text-muted-foreground">
+              Enter a start and end offset (end after start) to preview the
+              highlighted text.
+            </span>
+          ) : (
+            <span className="text-foreground/70">
+              {passageText.slice(0, start)}
+              <mark className="bg-highlight text-foreground rounded-sm">
+                {passageText.slice(start, previewEnd)}
+              </mark>
+              {passageText.slice(previewEnd)}
+            </span>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6 [&_svg]:size-4"
+            title="Clear range"
+            onClick={() => {
+              setRangeStart('');
+              setRangeEnd('');
+            }}
+          >
+            <Trash2Icon className="text-destructive" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6 [&_svg]:size-4"
+            title="Save range"
+            onClick={saveRange}
+          >
+            <CheckIcon className="text-primary" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex justify-between gap-2 p-2 w-fit max-w-80">
       <span className="text-primary text-sm my-auto">{entityType}</span>
@@ -290,6 +426,24 @@ export const MentionHoverContent = ({
             className={cn(
               'my-auto',
               item?.style === 'quote' ? 'text-primary' : 'text-foreground/50',
+            )}
+          />
+        </Button>
+      )}
+      {isPassage && item?.style === 'quote' && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 [&_svg]:size-4"
+          title="Set highlight range"
+          onClick={() => setMode('range')}
+        >
+          <HighlighterIcon
+            className={cn(
+              'my-auto',
+              item?.highlightStart != null
+                ? 'text-primary'
+                : 'text-foreground/50',
             )}
           />
         </Button>

--- a/libs/lib-editing/src/lib/components/shared/NavigationContext.ts
+++ b/libs/lib-editing/src/lib/components/shared/NavigationContext.ts
@@ -9,7 +9,7 @@ import type {
   Work,
 } from '@eightyfourthousand/data-access';
 import { createContext, useContext } from 'react';
-import { PanelName, PanelsState, PanelState } from './types';
+import { HighlightRange, PanelName, PanelsState, PanelState } from './types';
 
 export interface NavigationState {
   uuid: string;
@@ -19,6 +19,12 @@ export interface NavigationState {
   showOuterContent: boolean;
   hasTranslationContent: boolean;
   focusMode: boolean;
+  /**
+   * Character range within the navigation-target passage to highlight, parsed
+   * from the `start`/`end` query parameters. Cleared once applied.
+   */
+  highlight?: HighlightRange;
+  clearHighlight: () => void;
   setToh: (toh: TohokuCatalogEntry) => void;
   setShowOuterContent: (withTitles: boolean) => void;
   setHasTranslationContent: (hasTranslationContent: boolean) => void;
@@ -47,6 +53,7 @@ export const NavigationContext = createContext<NavigationState>({
   showOuterContent: true,
   hasTranslationContent: true,
   focusMode: false,
+  clearHighlight: () => { throw new Error('Not implemented'); },
   updatePanel: () => { throw new Error('Not implemented'); },
   setToh: () => { throw new Error('Not implemented'); },
   setShowOuterContent: () => { throw new Error('Not implemented'); },

--- a/libs/lib-editing/src/lib/components/shared/NavigationContext.ts
+++ b/libs/lib-editing/src/lib/components/shared/NavigationContext.ts
@@ -21,10 +21,9 @@ export interface NavigationState {
   focusMode: boolean;
   /**
    * Character range within the navigation-target passage to highlight, parsed
-   * from the `start`/`end` query parameters. Cleared once applied.
+   * from the `start`/`end` query parameters.
    */
   highlight?: HighlightRange;
-  clearHighlight: () => void;
   setToh: (toh: TohokuCatalogEntry) => void;
   setShowOuterContent: (withTitles: boolean) => void;
   setHasTranslationContent: (hasTranslationContent: boolean) => void;
@@ -53,7 +52,6 @@ export const NavigationContext = createContext<NavigationState>({
   showOuterContent: true,
   hasTranslationContent: true,
   focusMode: false,
-  clearHighlight: () => { throw new Error('Not implemented'); },
   updatePanel: () => { throw new Error('Not implemented'); },
   setToh: () => { throw new Error('Not implemented'); },
   setShowOuterContent: () => { throw new Error('Not implemented'); },

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -27,6 +27,7 @@ import {
 } from 'react';
 import { ReadonlyURLSearchParams, useSearchParams } from 'next/navigation';
 import {
+  HighlightRange,
   PANEL_NAMES,
   PANEL_FOR_SECTION,
   PanelName,
@@ -76,6 +77,27 @@ const parsePanelParams = (
   return { toh, panels };
 };
 
+/**
+ * Parses the `start`/`end` query parameters into a highlight range. Both must
+ * be present and numeric with `end > start`; otherwise no highlight is applied.
+ */
+const parseHighlight = (
+  params: ReadonlyURLSearchParams,
+): HighlightRange | undefined => {
+  const start = Number(params.get('start'));
+  const end = Number(params.get('end'));
+  if (
+    !params.has('start') ||
+    !params.has('end') ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    end <= start
+  ) {
+    return undefined;
+  }
+  return { start, end };
+};
+
 export const NavigationProvider = ({
   uuid,
   initialToh,
@@ -99,6 +121,9 @@ export const NavigationProvider = ({
   );
   const [showOuterContent, setShowOuterContent] = useState(true);
   const [focusMode, setFocusMode] = useState(false);
+  const [highlight, setHighlight] = useState<HighlightRange | undefined>(() =>
+    parseHighlight(query),
+  );
   const [hasTranslationContent, setHasTranslationContent] = useState(
     initialHasTranslationContent,
   );
@@ -255,6 +280,22 @@ export const NavigationProvider = ({
     [isMobile, hasTranslationContent],
   );
 
+  const clearHighlight = useCallback(() => {
+    setHighlight(undefined);
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has('start') && !params.has('end')) {
+      return;
+    }
+    params.delete('start');
+    params.delete('end');
+    const query = params.toString();
+    window.history.replaceState(
+      null,
+      '',
+      `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`,
+    );
+  }, []);
+
   useEffect(() => {
     if (!toh && !panels) {
       return;
@@ -393,6 +434,8 @@ export const NavigationProvider = ({
       showOuterContent,
       hasTranslationContent,
       focusMode,
+      highlight,
+      clearHighlight,
       setToh,
       setShowOuterContent,
       setHasTranslationContent,
@@ -412,6 +455,8 @@ export const NavigationProvider = ({
       showOuterContent,
       hasTranslationContent,
       focusMode,
+      highlight,
+      clearHighlight,
       setToh,
       setShowOuterContent,
       setHasTranslationContent,

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -280,22 +280,6 @@ export const NavigationProvider = ({
     [isMobile, hasTranslationContent],
   );
 
-  const clearHighlight = useCallback(() => {
-    setHighlight(undefined);
-    const params = new URLSearchParams(window.location.search);
-    if (!params.has('start') && !params.has('end')) {
-      return;
-    }
-    params.delete('start');
-    params.delete('end');
-    const query = params.toString();
-    window.history.replaceState(
-      null,
-      '',
-      `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`,
-    );
-  }, []);
-
   useEffect(() => {
     if (!toh && !panels) {
       return;
@@ -407,6 +391,11 @@ export const NavigationProvider = ({
     if (newToh) {
       setToh(newToh);
     }
+
+    // Re-read the highlight range so an in-session navigation (e.g. a
+    // same-work mention link that pushes `start`/`end`) triggers a highlight,
+    // and navigating away (no range) clears it.
+    setHighlight(parseHighlight(query));
   }, [query, parsePanelParams]);
 
   const hasHoverCards = useFeatureFlagEnabled('translation-hover-cards');
@@ -435,7 +424,6 @@ export const NavigationProvider = ({
       hasTranslationContent,
       focusMode,
       highlight,
-      clearHighlight,
       setToh,
       setShowOuterContent,
       setHasTranslationContent,
@@ -456,7 +444,6 @@ export const NavigationProvider = ({
       hasTranslationContent,
       focusMode,
       highlight,
-      clearHighlight,
       setToh,
       setShowOuterContent,
       setHasTranslationContent,

--- a/libs/lib-editing/src/lib/components/shared/types.ts
+++ b/libs/lib-editing/src/lib/components/shared/types.ts
@@ -89,6 +89,12 @@ export type PanelState = {
   hash?: string;
 };
 
+/** Character offsets `[start, end)` into a passage's text content to highlight. */
+export type HighlightRange = {
+  start: number;
+  end: number;
+};
+
 export type PanelsState = {
   [key in PanelName]: PanelState;
 };

--- a/libs/lib-editing/src/lib/exporters/mention.ts
+++ b/libs/lib-editing/src/lib/exporters/mention.ts
@@ -24,6 +24,8 @@ export const mention: Exporter<MentionAnnotation[]> = ({
       linkToh?: string;
       lang?: MentionAnnotation['lang'];
       style?: MentionAnnotation['style'];
+      highlightStart?: number;
+      highlightEnd?: number;
     }): MentionAnnotation => ({
       uuid: item.uuid,
       type: 'mention',
@@ -37,6 +39,12 @@ export const mention: Exporter<MentionAnnotation[]> = ({
       ...(item.linkToh && { linkToh: item.linkToh }),
       ...(item.lang && { lang: item.lang }),
       ...(item.style && { style: item.style }),
+      ...(item.highlightStart !== undefined && {
+        highlightStart: item.highlightStart,
+      }),
+      ...(item.highlightEnd !== undefined && {
+        highlightEnd: item.highlightEnd,
+      }),
       // Zero-length annotation: start === end
       start,
       end: start,

--- a/libs/lib-editing/src/lib/transformers/mention.ts
+++ b/libs/lib-editing/src/lib/transformers/mention.ts
@@ -22,6 +22,8 @@ export const mention: Transformer = (ctx) => {
     toh,
     lang,
     style,
+    highlightStart,
+    highlightEnd,
   } = annotation as MentionAnnotation;
 
   const item = {
@@ -36,6 +38,8 @@ export const mention: Transformer = (ctx) => {
     toh: serializeTohList(toh),
     lang,
     style,
+    highlightStart,
+    highlightEnd,
   };
   const matched = recurse({
     ...ctx,

--- a/libs/lib-utils/src/index.ts
+++ b/libs/lib-utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/compare';
 export * from './lib/style';
 export * from './lib/highlight';
+export * from './lib/highlight-range';
 export * from './lib/hooks';
 export * from './lib/string';
 export * from './lib/url';

--- a/libs/lib-utils/src/lib/highlight-range.ts
+++ b/libs/lib-utils/src/lib/highlight-range.ts
@@ -1,0 +1,138 @@
+'use client';
+
+/**
+ * Highlights a character range within a DOM subtree using the CSS Custom
+ * Highlight API. Unlike wrapping text in `<mark>`, this paints the range
+ * without mutating the DOM — essential for content rendered by ProseMirror /
+ * TipTap, where DOM mutations trigger a reparse loop.
+ *
+ * The `::highlight(deep-link)` rule that styles the range is injected at
+ * runtime (below) rather than authored in a stylesheet — build-time CSS
+ * tooling (Tailwind v4 / lightningcss) rejects the `::highlight()`
+ * pseudo-element, but the browser CSSOM parses it fine.
+ */
+
+const HIGHLIGHT_NAME = 'deep-link';
+const STYLE_ELEMENT_ID = 'deep-link-highlight-style';
+
+// Uses the shared `--color-highlight` token (the same color `bg-highlight`
+// resolves to), defined in the design-system theme.
+const HIGHLIGHT_STYLE = `::highlight(${HIGHLIGHT_NAME}) {
+  background-color: var(--color-highlight);
+}`;
+
+/** Injects the `::highlight()` rule once, on first use. */
+const ensureHighlightStyle = () => {
+  if (typeof document === 'undefined' || document.getElementById(STYLE_ELEMENT_ID)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = STYLE_ELEMENT_ID;
+  style.textContent = HIGHLIGHT_STYLE;
+  document.head.appendChild(style);
+};
+
+// `HighlightRegistry` is only partially typed in lib.dom (forEach), so narrow
+// to the map methods we use.
+type HighlightMap = {
+  set: (name: string, highlight: Highlight) => void;
+  delete: (name: string) => void;
+};
+
+const highlightRegistry = (): HighlightMap | null => {
+  if (
+    typeof CSS === 'undefined' ||
+    !('highlights' in CSS) ||
+    typeof Highlight === 'undefined'
+  ) {
+    return null;
+  }
+  return CSS.highlights as unknown as HighlightMap;
+};
+
+/**
+ * Builds a DOM Range spanning character offsets `[start, end)` across the text
+ * nodes inside `container`, treating the container's text content as one
+ * continuous string. This matches the offset system passage annotations use
+ * (offsets into the passage's concatenated text content).
+ */
+const rangeForOffsets = (
+  container: HTMLElement,
+  start: number,
+  end: number,
+): Range | null => {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let consumed = 0;
+  let startNode: Text | null = null;
+  let startOffset = 0;
+  let endNode: Text | null = null;
+  let endOffset = 0;
+
+  let node = walker.nextNode() as Text | null;
+  while (node) {
+    const length = node.data.length;
+    if (!startNode && consumed + length > start) {
+      startNode = node;
+      startOffset = start - consumed;
+    }
+    if (startNode && consumed + length >= end) {
+      endNode = node;
+      endOffset = end - consumed;
+      break;
+    }
+    consumed += length;
+    node = walker.nextNode() as Text | null;
+  }
+
+  if (!startNode || !endNode) {
+    return null;
+  }
+
+  const range = document.createRange();
+  try {
+    range.setStart(startNode, Math.max(0, startOffset));
+    range.setEnd(endNode, Math.min(endNode.data.length, endOffset));
+  } catch {
+    return null;
+  }
+  return range;
+};
+
+/**
+ * Paints the character range `[start, end)` inside `container`. Replaces any
+ * previously registered deep-link highlight. Returns true when the highlight
+ * was applied.
+ */
+export const highlightTextRange = ({
+  container,
+  start,
+  end,
+}: {
+  container: HTMLElement;
+  start: number;
+  end: number;
+}): boolean => {
+  const registry = highlightRegistry();
+  if (
+    !registry ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    end <= start
+  ) {
+    return false;
+  }
+
+  const range = rangeForOffsets(container, start, end);
+  if (!range) {
+    return false;
+  }
+
+  ensureHighlightStyle();
+  registry.set(HIGHLIGHT_NAME, new Highlight(range));
+  return true;
+};
+
+/** Removes the deep-link highlight, if any. */
+export const clearTextRangeHighlight = () => {
+  highlightRegistry()?.delete(HIGHLIGHT_NAME);
+};


### PR DESCRIPTION
### Summary

- Adds support for `start` and `end` query parameters that will highlight passage text when a passage uuid is also provided.
- Adds support for mentions with `start` and `end` values in the `content` column
- Adds a UI for editing quote range

### Linear

- [ED-1337](https://linear.app/84000/issue/ED-1337)
