### PR TITLE
Fix 40 lint errors across lib-agent, data-access, lib-user, design-system, lib-utils and lib-instr

### DIFF
--- a/libs/data-access/src/lib/import-preview.spec.ts
+++ b/libs/data-access/src/lib/import-preview.spec.ts
@@ -1,7 +1,3 @@
-jest.mock('./passage', () => ({
-  savePassagesWithDeletions: jest.fn(),
-}));
-
 import {
   applyImportPreview,
   normalizeImportOperations,
@@ -9,6 +5,10 @@ import {
 } from './import-preview';
 import { savePassagesWithDeletions } from './passage';
 import type { DataClient, ImportOperationInput } from './types';
+
+jest.mock('./passage', () => ({
+  savePassagesWithDeletions: jest.fn(),
+}));
 
 const mockedSavePassages = jest.mocked(savePassagesWithDeletions);
 

--- a/libs/design-system/src/lib/DatePicker/DatePicker.tsx
+++ b/libs/design-system/src/lib/DatePicker/DatePicker.tsx
@@ -6,7 +6,7 @@ import { Button } from '../Button/Button';
 import { Calendar } from '../Calendar/Calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '../Popover/Popover';
 import { cn } from '@eightyfourthousand/lib-utils';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 const YEAR_RANGE = 10;
 
@@ -26,12 +26,17 @@ export function DatePicker({
 
   const [open, setOpen] = useState(false);
   const [nextDate, setDate] = useState<Date | undefined>(date);
+  const [prevDate, setPrevDate] = useState(date);
 
-  useEffect(() => {
+  // Track the controlled `date` prop while keeping the in-popover selection as
+  // local state. Adjusting state during render is React's recommended
+  // alternative to a sync effect.
+  if (date !== prevDate) {
+    setPrevDate(date);
     if (date) {
       setDate(date);
     }
-  }, [date]);
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/libs/design-system/src/lib/Sidebar/Sidebar.tsx
+++ b/libs/design-system/src/lib/Sidebar/Sidebar.tsx
@@ -608,10 +608,17 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<'div'> & {
   showIcon?: boolean;
 }) {
-  // Random width between 50 to 90%.
+  // Varied width between 50 and 90%, derived from the instance id rather than
+  // Math.random() so it is stable across render and matches between server and
+  // client.
+  const id = React.useId();
   const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+    let hash = 0;
+    for (let i = 0; i < id.length; i++) {
+      hash = (hash * 31 + id.charCodeAt(i)) | 0;
+    }
+    return `${(Math.abs(hash) % 40) + 50}%`;
+  }, [id]);
 
   return (
     <div

--- a/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
+++ b/libs/design-system/src/lib/Table/DataTable/DataTable.tsx
@@ -11,7 +11,7 @@ import {
   VisibilityState,
   flexRender,
 } from '@tanstack/react-table';
-import { ReactElement, useEffect, useState } from 'react';
+import { ReactElement, useMemo } from 'react';
 import { cn } from '@eightyfourthousand/lib-utils';
 import {
   DataTableColumn,
@@ -63,14 +63,7 @@ export const DataTable = <T extends DataTableRow>({
   infiniteScroll?: boolean;
   resizableColumns?: boolean;
 }) => {
-  const [columnClasses, setColumnClasses] = useState<{ [key: string]: string }>(
-    {},
-  );
-  const [columnActions, setColumnActions] = useState<{
-    [key: string]: (row: Cell<T, unknown>) => void;
-  }>({});
-
-  useEffect(() => {
+  const { columnClasses, columnActions } = useMemo(() => {
     const classes: { [key: string]: string } = {};
     const actions: { [key: string]: (row: Cell<T, unknown>) => void } = {};
     columns.forEach((column) => {
@@ -83,8 +76,7 @@ export const DataTable = <T extends DataTableRow>({
         }
       }
     });
-    setColumnClasses(classes);
-    setColumnActions(actions);
+    return { columnClasses: classes, columnActions: actions };
   }, [columns]);
   const { table } = useDataTable({
     data,

--- a/libs/lib-agent/src/lib/agents/index.ts
+++ b/libs/lib-agent/src/lib/agents/index.ts
@@ -1,3 +1,6 @@
+import { registerAgent } from './registry';
+import { libraryAssistant } from './library-assistant/definition';
+
 export type { AgentDefinition } from './types';
 export { AgentDefinitionSchema } from './types';
 export {
@@ -13,8 +16,5 @@ export {
 export { createAgentTools } from './create-agent-tools';
 export { createAgentPrompts } from './create-agent-prompts';
 export { buildAgentInstructions } from './invocation';
-
-import { registerAgent } from './registry';
-import { libraryAssistant } from './library-assistant/definition';
 
 registerAgent(libraryAssistant);

--- a/libs/lib-agent/src/lib/auth.spec.ts
+++ b/libs/lib-agent/src/lib/auth.spec.ts
@@ -3,15 +3,6 @@
  */
 import type { DataClient } from '@eightyfourthousand/data-access';
 
-jest.mock('jwt-decode', () => ({
-  jwtDecode: jest.fn(),
-}));
-
-jest.mock('@eightyfourthousand/data-access', () => ({
-  createTokenClient: jest.fn(),
-  hasPermission: jest.fn(),
-}));
-
 import { jwtDecode } from 'jwt-decode';
 import {
   createTokenClient,
@@ -23,6 +14,15 @@ import {
   decodeRole,
   ROLE_HIERARCHY,
 } from './auth';
+
+jest.mock('jwt-decode', () => ({
+  jwtDecode: jest.fn(),
+}));
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  createTokenClient: jest.fn(),
+  hasPermission: jest.fn(),
+}));
 
 const mockedJwtDecode = jest.mocked(jwtDecode);
 const mockedCreateTokenClient = jest.mocked(createTokenClient);

--- a/libs/lib-agent/src/lib/tools/read/get-bibliography-entry.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-bibliography-entry.spec.ts
@@ -1,11 +1,11 @@
 import { createGetBibliographyEntryTool } from './get-bibliography-entry';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getBibliographyEntry } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getBibliographyEntry: jest.fn(),
 }));
-
-import { getBibliographyEntry } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(getBibliographyEntry);
 
 describe('get-bibliography-entry tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/get-glossary-instances.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-glossary-instances.spec.ts
@@ -1,11 +1,11 @@
 import { createGetGlossaryInstancesTool } from './get-glossary-instances';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getGlossaryInstances } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getGlossaryInstances: jest.fn(),
 }));
-
-import { getGlossaryInstances } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(getGlossaryInstances);
 
 describe('get-glossary-instances tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/get-glossary-term.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-glossary-term.spec.ts
@@ -1,11 +1,11 @@
 import { createGetGlossaryTermTool } from './get-glossary-term';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getGlossaryInstance } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getGlossaryInstance: jest.fn(),
 }));
-
-import { getGlossaryInstance } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(getGlossaryInstance);
 
 describe('get-glossary-term tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/get-imprint.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-imprint.spec.ts
@@ -1,11 +1,11 @@
 import { createGetImprintTool } from './get-imprint';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getTranslationImprint } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getTranslationImprint: jest.fn(),
 }));
-
-import { getTranslationImprint } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(getTranslationImprint);
 
 describe('get-imprint tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/get-passage.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-passage.spec.ts
@@ -1,11 +1,11 @@
 import { createGetPassageTool } from './get-passage';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getPassage } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getPassage: jest.fn(),
 }));
-
-import { getPassage } from '@eightyfourthousand/data-access';
 const mockedGetPassage = jest.mocked(getPassage);
 
 describe('get-passage tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/get-toc.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-toc.spec.ts
@@ -1,11 +1,11 @@
 import { createGetTocTool } from './get-toc';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getTranslationToc } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getTranslationToc: jest.fn(),
 }));
-
-import { getTranslationToc } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(getTranslationToc);
 
 describe('get-toc tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/get-translation-passages.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation-passages.spec.ts
@@ -1,15 +1,15 @@
 import { createGetTranslationPassagesTool } from './get-translation-passages';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
-jest.mock('@eightyfourthousand/data-access', () => ({
-  getTranslationPassages: jest.fn(),
-  getTranslationPassagesAround: jest.fn(),
-}));
-
 import {
   getTranslationPassages,
   getTranslationPassagesAround,
 } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getTranslationPassages: jest.fn(),
+  getTranslationPassagesAround: jest.fn(),
+}));
 
 const mockedSequential = jest.mocked(getTranslationPassages);
 const mockedAround = jest.mocked(getTranslationPassagesAround);

--- a/libs/lib-agent/src/lib/tools/read/get-translation.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation.spec.ts
@@ -1,15 +1,15 @@
 import { createGetTranslationTool } from './get-translation';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
-jest.mock('@eightyfourthousand/data-access', () => ({
-  getTranslationMetadataByUuid: jest.fn(),
-  getTranslationMetadataByToh: jest.fn(),
-}));
-
 import {
   getTranslationMetadataByUuid,
   getTranslationMetadataByToh,
 } from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getTranslationMetadataByUuid: jest.fn(),
+  getTranslationMetadataByToh: jest.fn(),
+}));
 
 const mockedByUuid = jest.mocked(getTranslationMetadataByUuid);
 const mockedByToh = jest.mocked(getTranslationMetadataByToh);

--- a/libs/lib-agent/src/lib/tools/read/get-work-titles.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-work-titles.spec.ts
@@ -1,11 +1,11 @@
 import { createGetWorkTitlesTool } from './get-work-titles';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getWorkTitles } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getWorkTitles: jest.fn(),
 }));
-
-import { getWorkTitles } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(getWorkTitles);
 
 describe('get-work-titles tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/list-glossary-terms.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/list-glossary-terms.spec.ts
@@ -1,11 +1,11 @@
 import { createListGlossaryTermsTool } from './list-glossary-terms';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getWorkGlossaryTermsPage } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getWorkGlossaryTermsPage: jest.fn(),
 }));
-
-import { getWorkGlossaryTermsPage } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(getWorkGlossaryTermsPage);
 
 describe('list-glossary-terms tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/list-work-bibliographies.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/list-work-bibliographies.spec.ts
@@ -1,11 +1,11 @@
 import { createListWorkBibliographiesTool } from './list-work-bibliographies';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { getBibliographyEntries } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   getBibliographyEntries: jest.fn(),
 }));
-
-import { getBibliographyEntries } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(getBibliographyEntries);
 
 describe('list-work-bibliographies tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/lookup-entity.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/lookup-entity.spec.ts
@@ -1,11 +1,11 @@
 import { createLookupEntityTool } from './lookup-entity';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { lookupEntityWithClient } from '@eightyfourthousand/data-access/ssr';
+
 jest.mock('@eightyfourthousand/data-access/ssr', () => ({
   lookupEntityWithClient: jest.fn(),
 }));
-
-import { lookupEntityWithClient } from '@eightyfourthousand/data-access/ssr';
 const mocked = jest.mocked(lookupEntityWithClient);
 
 describe('lookup-entity tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/search-entities.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-entities.spec.ts
@@ -1,11 +1,11 @@
 import { createSearchEntitiesTool } from './search-entities';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { searchEntities } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   searchEntities: jest.fn(),
 }));
-
-import { searchEntities } from '@eightyfourthousand/data-access';
 const mockedSearch = jest.mocked(searchEntities);
 
 describe('search-entities tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/search-glossary-terms.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-glossary-terms.spec.ts
@@ -1,11 +1,11 @@
 import { createSearchGlossaryTermsTool } from './search-glossary-terms';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { searchWorkGlossaryTerms } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   searchWorkGlossaryTerms: jest.fn(),
 }));
-
-import { searchWorkGlossaryTerms } from '@eightyfourthousand/data-access';
 const mocked = jest.mocked(searchWorkGlossaryTerms);
 
 describe('search-glossary-terms tool', () => {

--- a/libs/lib-agent/src/lib/tools/read/search-translation.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/search-translation.spec.ts
@@ -1,11 +1,11 @@
 import { createSearchTranslationTool } from './search-translation';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { searchWithClient } from '@eightyfourthousand/lib-search';
+
 jest.mock('@eightyfourthousand/lib-search', () => ({
   searchWithClient: jest.fn(),
 }));
-
-import { searchWithClient } from '@eightyfourthousand/lib-search';
 const mockedSearch = jest.mocked(searchWithClient);
 
 describe('search-translation tool', () => {

--- a/libs/lib-agent/src/lib/tools/write/apply-docx-import.spec.ts
+++ b/libs/lib-agent/src/lib/tools/write/apply-docx-import.spec.ts
@@ -1,12 +1,12 @@
 import { createApplyDocxImportTool } from './apply-docx-import';
 import type { DataClient } from '@eightyfourthousand/data-access';
 
+import { applyImportPreview, hasPermission } from '@eightyfourthousand/data-access';
+
 jest.mock('@eightyfourthousand/data-access', () => ({
   applyImportPreview: jest.fn(),
   hasPermission: jest.fn(),
 }));
-
-import { applyImportPreview, hasPermission } from '@eightyfourthousand/data-access';
 
 const mockedApply = jest.mocked(applyImportPreview);
 const mockedHasPermission = jest.mocked(hasPermission);

--- a/libs/lib-instr/src/lib/feature-flags.tsx
+++ b/libs/lib-instr/src/lib/feature-flags.tsx
@@ -7,7 +7,7 @@ import {
   PostHogFeatureProps,
 } from '@posthog/react';
 import { JsonType } from 'posthog-js';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useSyncExternalStore } from 'react';
 
 export type FeatureFlag =
   | 'authority-pages'
@@ -66,13 +66,20 @@ export type GatedFeatureProps = Omit<PostHogFeatureProps, 'flag' | 'children'> &
   children: ReactNode;
 };
 
-export const GatedFeature = ({ children, flag }: GatedFeatureProps) => {
-  const [isClient, setIsClient] = useState(false);
-  const enabled = useFeatureFlagEnabled(flag);
+// Never changes, so the store never notifies. `getSnapshot` reports true on the
+// client and `getServerSnapshot` false during SSR and the hydration render,
+// which is the flag this component needs to avoid a hydration mismatch.
+const subscribeToNothing = () => () => undefined;
+const useIsHydrated = () =>
+  useSyncExternalStore(
+    subscribeToNothing,
+    () => true,
+    () => false,
+  );
 
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
+export const GatedFeature = ({ children, flag }: GatedFeatureProps) => {
+  const isClient = useIsHydrated();
+  const enabled = useFeatureFlagEnabled(flag);
 
   if (!isClient) {
     return null;

--- a/libs/lib-user/src/lib/LibraryBibliographiesPage.tsx
+++ b/libs/lib-user/src/lib/LibraryBibliographiesPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   DataTable,
   DataTableColumn,
@@ -62,16 +62,14 @@ const COLUMNS: DataTableColumn<RowType>[] = [
 
 export const LibraryBibliographiesPage = () => {
   const { cache, refreshCache, setPageTitle } = useProfile();
-  const [data, setData] = useState<RowType[]>([]);
+  const data = useMemo(
+    () => (cache.bibliographies as RowType[]) ?? [],
+    [cache.bibliographies],
+  );
 
   useEffect(() => {
     refreshCache('bibliographies');
   }, [refreshCache]);
-
-  useEffect(() => {
-    const data = cache.bibliographies as RowType[];
-    setData(data || []);
-  }, [cache.bibliographies]);
 
   useEffect(() => {
     setPageTitle('My Saved Bibliographies');

--- a/libs/lib-user/src/lib/LibraryGlossariesPage.tsx
+++ b/libs/lib-user/src/lib/LibraryGlossariesPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   DataTable,
   DataTableColumn,
@@ -82,16 +82,14 @@ const COLUMNS: DataTableColumn<RowType>[] = [
 
 export const LibraryGlossariesPage = () => {
   const { cache, refreshCache, setPageTitle } = useProfile();
-  const [data, setData] = useState<RowType[]>([]);
+  const data = useMemo(
+    () => (cache.glossaries as RowType[]) ?? [],
+    [cache.glossaries],
+  );
 
   useEffect(() => {
     refreshCache('glossaries');
   }, [refreshCache]);
-
-  useEffect(() => {
-    const data = cache.glossaries as RowType[];
-    setData(data || []);
-  }, [cache.glossaries]);
 
   useEffect(() => {
     setPageTitle('My Saved Glossaries');

--- a/libs/lib-user/src/lib/LibraryPassagesPage.tsx
+++ b/libs/lib-user/src/lib/LibraryPassagesPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   DataTable,
   DataTableColumn,
@@ -73,16 +73,14 @@ const COLUMNS: DataTableColumn<RowType>[] = [
 
 export const LibraryPassagesPage = () => {
   const { cache, refreshCache, setPageTitle } = useProfile();
-  const [data, setData] = useState<RowType[]>([]);
+  const data = useMemo(
+    () => (cache.passages as RowType[]) ?? [],
+    [cache.passages],
+  );
 
   useEffect(() => {
     refreshCache('passages');
   }, [refreshCache]);
-
-  useEffect(() => {
-    const data = cache.passages as RowType[];
-    setData(data || []);
-  }, [cache.passages]);
 
   useEffect(() => {
     setPageTitle('My Saved Passages');

--- a/libs/lib-user/src/lib/LibraryPublicationsPage.tsx
+++ b/libs/lib-user/src/lib/LibraryPublicationsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   DataTable,
   DataTableColumn,
@@ -80,16 +80,14 @@ const COLUMNS: DataTableColumn<RowType>[] = [
 
 export const LibraryPublicationsPage = () => {
   const { cache, refreshCache, setPageTitle } = useProfile();
-  const [data, setData] = useState<RowType[]>([]);
+  const data = useMemo(
+    () => (cache.publications as RowType[]) ?? [],
+    [cache.publications],
+  );
 
   useEffect(() => {
     refreshCache('publications');
   }, [refreshCache]);
-
-  useEffect(() => {
-    const publications = cache.publications as RowType[];
-    setData(publications || []);
-  }, [cache.publications]);
 
   useEffect(() => {
     setPageTitle('My Saved Publications');

--- a/libs/lib-user/src/lib/LibrarySearchesPage.tsx
+++ b/libs/lib-user/src/lib/LibrarySearchesPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   DataTable,
   DataTableColumn,
@@ -60,16 +60,14 @@ const COLUMNS: DataTableColumn<RowType>[] = [
 
 export const LibrarySearchesPage = () => {
   const { cache, refreshCache, setPageTitle } = useProfile();
-  const [data, setData] = useState<RowType[]>([]);
+  const data = useMemo(
+    () => (cache.searches as RowType[]) ?? [],
+    [cache.searches],
+  );
 
   useEffect(() => {
     refreshCache('searches');
   }, [refreshCache]);
-
-  useEffect(() => {
-    const data = cache.searches as RowType[];
-    setData(data || []);
-  }, [cache.searches]);
 
   useEffect(() => {
     setPageTitle('My Saved Searches');

--- a/libs/lib-user/src/lib/Login.tsx
+++ b/libs/lib-user/src/lib/Login.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { SocialLogin } from './SocialLogin';
 import { Button, H4, MainLogo, Separator } from '@eightyfourthousand/design-system';
 import { EmailLogin } from './EmailLogin';
@@ -32,19 +32,10 @@ const LINK_TEXT = {
 
 export const Login = () => {
   const [variation, setVariation] = useState<LoginVariation>('login');
-  const [header, setHeader] = useState<string>(HEADER.login);
-  const [welcomeLines, setWelcomeLines] = useState<string[]>(
-    WELCOME_LINES.login,
-  );
-  const [footerText, setFooterText] = useState<string>(FOOTER_TEXT.login);
-  const [linkText, setLinkText] = useState<string>(LINK_TEXT.login);
-
-  useEffect(() => {
-    setHeader(HEADER[variation]);
-    setWelcomeLines(WELCOME_LINES[variation]);
-    setFooterText(FOOTER_TEXT[variation]);
-    setLinkText(LINK_TEXT[variation]);
-  }, [variation]);
+  const header = HEADER[variation];
+  const welcomeLines = WELCOME_LINES[variation];
+  const footerText = FOOTER_TEXT[variation];
+  const linkText = LINK_TEXT[variation];
 
   const toggleVariation = useCallback(() => {
     setVariation((prev) => (prev === 'login' ? 'create' : 'login'));

--- a/libs/lib-user/src/lib/ProfileProvider.tsx
+++ b/libs/lib-user/src/lib/ProfileProvider.tsx
@@ -96,6 +96,18 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
   const [activeMenu, setActiveMenu] = useState<MenuItem>(
     (pathname.split('/').pop() as MenuItem) || 'profile',
   );
+  const [prevPathname, setPrevPathname] = useState(pathname);
+
+  // Follow the route, but keep the last real menu when the path does not end
+  // in one. Adjusting state during render is React's recommended alternative
+  // to a sync effect.
+  if (pathname !== prevPathname) {
+    setPrevPathname(pathname);
+    const currentMenu = pathname.split('/').pop() as MenuItem;
+    if (MENU_ITEMS.includes(currentMenu)) {
+      setActiveMenu(currentMenu);
+    }
+  }
   const [pageTitle, setPageTitle] = useState('My Profile');
   const [user, setUser] = useState<ScholarUser>();
   const [library, setLibrary] = useState<UserLibraryItem[]>([]);
@@ -264,20 +276,18 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
     [dataClient, user, refreshProfile],
   );
 
+  // These two fetch on mount and set state only after awaiting the network.
+  // The rule cannot distinguish that from a synchronous setState, so it
+  // reports a cascading render that does not happen here.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch; setState runs after await
     refreshProfile();
   }, [refreshProfile]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch; setState runs after await
     refreshCache();
   }, [refreshCache]);
-
-  useEffect(() => {
-    const currentMenu = pathname.split('/').pop() as MenuItem;
-    if (MENU_ITEMS.includes(currentMenu)) {
-      setActiveMenu(currentMenu);
-    }
-  }, [pathname]);
 
   return (
     <ProfileContext.Provider

--- a/libs/lib-user/src/lib/UserCard.tsx
+++ b/libs/lib-user/src/lib/UserCard.tsx
@@ -17,7 +17,7 @@ import {
 } from '@eightyfourthousand/design-system';
 import { cn } from '@eightyfourthousand/lib-utils';
 import { UploadIcon, UserIcon } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { v4 } from 'uuid';
 import { useProfile } from './ProfileProvider';
 import { updateUserProfile, uploadToStorage } from '@eightyfourthousand/data-access';
@@ -26,7 +26,15 @@ export const UserCard = () => {
   const { user, dataClient, refreshProfile } = useProfile();
   const [avatar, setAvatar] = useState<string | undefined>(user?.avatar);
   const [localFile, setLocalFile] = useState<File>();
+  const [prevUserAvatar, setPrevUserAvatar] = useState(user?.avatar);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Drop any local preview once the saved avatar changes. Adjusting state
+  // during render is React's recommended alternative to a sync effect.
+  if (user?.avatar !== prevUserAvatar) {
+    setPrevUserAvatar(user?.avatar);
+    setAvatar(user?.avatar);
+  }
 
   const clearFile = useCallback(() => {
     setLocalFile(undefined);
@@ -66,10 +74,6 @@ export const UserCard = () => {
     await refreshProfile();
     setLocalFile(undefined);
   }, [localFile, user, dataClient, clearFile, refreshProfile]);
-
-  useEffect(() => {
-    setAvatar(user?.avatar);
-  }, [user?.avatar]);
 
   return (
     <Card>

--- a/libs/lib-user/src/lib/UserSubscriptionsCard.tsx
+++ b/libs/lib-user/src/lib/UserSubscriptionsCard.tsx
@@ -9,7 +9,7 @@ import {
   Switch,
 } from '@eightyfourthousand/design-system';
 import { SUBSCRIPTION_TYPES, SubscriptionType } from './types';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useProfile } from './ProfileProvider';
 
 const NOTIFICATION_LABELS: Record<SubscriptionType, string> = {
@@ -19,10 +19,16 @@ const NOTIFICATION_LABELS: Record<SubscriptionType, string> = {
 export const UserSubscriptionsCard = () => {
   const { user, saveProfile } = useProfile();
   const [subscriptions, setSubscriptions] = useState(user?.subscriptions || []);
+  const [prevUserSubscriptions, setPrevUserSubscriptions] = useState(
+    user?.subscriptions,
+  );
 
-  useEffect(() => {
+  // Reset the local toggles whenever the saved profile changes. Adjusting
+  // state during render is React's recommended alternative to a sync effect.
+  if (user?.subscriptions !== prevUserSubscriptions) {
+    setPrevUserSubscriptions(user?.subscriptions);
     setSubscriptions(user?.subscriptions || []);
-  }, [user?.subscriptions]);
+  }
 
   const toggleSubscription = useCallback(
     (type: SubscriptionType, isOn: boolean) => {

--- a/libs/lib-utils/src/lib/hooks/use-mobile.tsx
+++ b/libs/lib-utils/src/lib/hooks/use-mobile.tsx
@@ -1,21 +1,21 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
 const MOBILE_BREAKPOINT = 768;
 
+const subscribe = (onChange: () => void) => {
+  const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+  mql.addEventListener('change', onChange);
+  return () => mql.removeEventListener('change', onChange);
+};
+
+const getSnapshot = () => window.innerWidth < MOBILE_BREAKPOINT;
+
+// No viewport on the server. Matches the previous hook, which reported false
+// until its effect had run on the client.
+const getServerSnapshot = () => false;
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined);
-
-  useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    mql.addEventListener('change', onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener('change', onChange);
-  }, []);
-
-  return !!isMobile;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
### Summary

Fixes a large portion of the lint errors lurking in the codebase.

#### Result

| Project | Errors before | After |
| --- | --- | --- |
| lib-agent | 21 | **0** |
| lib-user | 11 | **0** |
| design-system | 3 | **0** |
| data-access | 3 | **0** |
| lib-instr | 1 | **0** |
| lib-utils | 1 | **0** |

13 of 16 projects now lint clean.

### Still to do

- Many errors remain in `lib-editing`, `lib-search`, and `web-editor` and will be addressed in a follow-up.
- `data-access:typecheck` fails on `main`: 5 errors in `glossary/instance.spec.ts` (TS7022/TS7024) and `types/annotation/transform.spec.ts` (TS2307, missing `./dto`). This blocks a clean typecheck of every dependent project.
- `lib-instr:test` fails on `main` — no test files, and jest is not run with `--passWithNoTests`.