### PR TITLE
Fix the remaining 40 lint errors: lib-editing, lib-search, web-editor

### DIFF
--- a/apps/web-editor/src/components/EditorPage.tsx
+++ b/apps/web-editor/src/components/EditorPage.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { H3 } from '@eightyfourthousand/design-system';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import {
   BlockEditor,
   blocksFromTranslationBody,
@@ -19,14 +18,12 @@ export const EditorPage = ({
   slug?: Slug;
   format?: Format;
 }) => {
-  const [content, setContent] = useState<TranslationEditorContent>();
-  const [editorType, setEditorType] = useState<EditorType>('block');
-
-  useEffect(() => {
+  const { content, editorType } = useMemo((): {
+    content: TranslationEditorContent;
+    editorType: EditorType;
+  } => {
     if (!slug || !format) {
-      setContent(EMPTY_DOCUMENT);
-      setEditorType('block');
-      return;
+      return { content: EMPTY_DOCUMENT, editorType: 'block' };
     }
 
     const { type, content } = SLUG_PATHS[slug]?.[format] || {
@@ -34,24 +31,14 @@ export const EditorPage = ({
       type: 'block',
     };
 
-    let parsedContent = content;
     if (format === 'passages') {
       const dtos = content as PassageDTO[];
       const passages = passagesFromDTO(dtos);
-      parsedContent = blocksFromTranslationBody(passages);
+      return { content: blocksFromTranslationBody(passages), editorType: type };
     }
 
-    setContent(parsedContent);
-    setEditorType(type);
+    return { content, editorType: type };
   }, [slug, format]);
-
-  if (!content) {
-    return (
-      <div className="w-full overflow-auto px-8 max-w-readable mx-auto">
-        <H3 className="text-muted-foreground px-12 py-2">Loading...</H3>
-      </div>
-    );
-  }
 
   return (
     <div className="w-full overflow-auto px-8 max-w-readable mx-auto">

--- a/apps/web-editor/src/components/JsonComparePage.tsx
+++ b/apps/web-editor/src/components/JsonComparePage.tsx
@@ -81,6 +81,12 @@ const JsonCompareEditor = ({
 
   useEffect(() => {
     if (editor && jsonData) {
+      // `isExternalUpdate` is a ref owned by the parent, which reads it in
+      // `handleTiptapUpdate` to ignore the echo from this programmatic
+      // setContent. The rule objects to writing through a prop; replacing the
+      // handshake with callbacks would mean reworking the parent's API, so it
+      // is left as-is for now.
+      // eslint-disable-next-line react-hooks/immutability -- deliberate cross-component ref handshake
       isExternalUpdate.current = true;
       editor.commands.setContent(jsonData);
       isExternalUpdate.current = false;
@@ -107,7 +113,12 @@ const useCodeMirror = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
+
+  // Keep the latest callback without re-creating the CodeMirror view below.
+  // Writing the ref in an effect rather than during render.
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -206,6 +217,10 @@ export const JsonComparePage = () => {
       });
     }
 
+    // `content` is a one-shot handoff from the sandbox context: it is consumed
+    // here and immediately cleared, so there is no value to derive during
+    // render instead.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- consuming a one-shot context handoff
     setParsedJson(content as object);
     if (content.type === 'doc') setEditorType('block');
     setContent(undefined as never);

--- a/apps/web-editor/src/components/SandboxHeader.tsx
+++ b/apps/web-editor/src/components/SandboxHeader.tsx
@@ -9,7 +9,7 @@ import {
   H4,
 } from '@eightyfourthousand/design-system';
 import { SLUG_PATHS } from './constants';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useSandbox } from './SandboxProvider';
 import { Format, Slug } from '@eightyfourthousand/lib-editing/fixtures/types';
 import { useRouter } from 'next/navigation';
@@ -22,27 +22,15 @@ export const SandboxHeader = () => {
     )
     .flat();
 
-  const [selectedItem, setSelectedItem] = useState<string>();
-  const [didSelect, setDidSelect] = useState(false);
-
   const { slug, format, setFormat, setSlug, editor, setContent } = useSandbox();
   const router = useRouter();
 
-  useEffect(() => {
-    const dropdownItem = slug && format ? `${slug} - ${format}` : undefined;
-    const path = slug && format ? `/${slug}/${format}` : '/';
-
-    setSelectedItem(dropdownItem);
-
-    if (didSelect) {
-      setDidSelect(false);
-      router.push(path);
-    }
-  }, [slug, format, router, didSelect]);
+  const selectedItem = slug && format ? `${slug} - ${format}` : undefined;
 
   const onHandleSelect = useCallback(
     (item: string, checked: boolean) => {
       if (!checked || !item) {
+        // Clearing the selection deliberately does not navigate.
         setSlug(undefined);
         setFormat(undefined);
         return;
@@ -51,9 +39,9 @@ export const SandboxHeader = () => {
       const [newSlug, newFormat] = item.split(' - ');
       setSlug(newSlug as Slug);
       setFormat(newFormat as Format);
-      setDidSelect(true);
+      router.push(`/${newSlug}/${newFormat}`);
     },
-    [setFormat, setSlug],
+    [setFormat, setSlug, router],
   );
 
   return (

--- a/apps/web-editor/src/components/StackPage.tsx
+++ b/apps/web-editor/src/components/StackPage.tsx
@@ -122,10 +122,19 @@ export const StackPage = ({
   const [seeds, setSeeds] = useState<StackPassageSeed[] | null>(null);
   const [failed, setFailed] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  // Clear the previous stack as soon as the inputs change, rather than in the
+  // fetch effect below. Adjusting state during render is React's recommended
+  // alternative, and on mount there is nothing to clear.
+  const loadKey = `${toh}|${repeat}`;
+  const [prevLoadKey, setPrevLoadKey] = useState(loadKey);
+  if (loadKey !== prevLoadKey) {
+    setPrevLoadKey(loadKey);
     setSeeds(null);
     setFailed(false);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
 
     loadPassages(toh).then((passages) => {
       if (cancelled) return;

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkHoverContent.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteLinkHoverContent.tsx
@@ -35,15 +35,18 @@ export const EndNoteLinkHoverContent = ({
   setHoverCardEditing: (isEditing: boolean) => void;
 }) => {
   const [label, setLabel] = useState<string | undefined>();
-  const [labelState, setLabelState] = useState<'loading' | 'loaded' | 'error'>(
+  const [fetchState, setFetchState] = useState<'loading' | 'loaded' | 'error'>(
     'loading',
   );
   const { getEditor } = useEditorState();
   const { fetchEndNote } = useNavigation();
 
+  // With no endnote to resolve there is nothing to load, so this is derived
+  // rather than pushed into state from the effect below.
+  const labelState = !endNote ? 'error' : fetchState;
+
   useEffect(() => {
     if (!endNote) {
-      setLabelState('error');
       return;
     }
 
@@ -52,20 +55,24 @@ export const EndNoteLinkHoverContent = ({
     if (endnotesEditor) {
       const found = findPassageNode(endnotesEditor, endNote);
       if (found?.node.attrs.label) {
+        // A synchronous read of live TipTap document state, which cannot be
+        // derived during render without reading the editor impurely. The other
+        // branch resolves over the network, so both paths land in state here.
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronous read of external editor state
         setLabel(found.node.attrs.label);
-        setLabelState('loaded');
+        setFetchState('loaded');
         return;
       }
     }
 
     // Fall back to network fetch
-    setLabelState('loading');
+    setFetchState('loading');
     fetchEndNote(endNote).then((passage) => {
       if (passage?.label) {
         setLabel(passage.label);
-        setLabelState('loaded');
+        setFetchState('loaded');
       } else {
-        setLabelState('error');
+        setFetchState('error');
       }
     });
   }, [endNote, fetchEndNote, getEditor]);

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstance.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossaryInstance.tsx
@@ -34,11 +34,18 @@ export const GlossaryInstance = ({
   const markText = anchor.textContent ?? '';
   const { fetchGlossaryTerm } = useNavigation();
 
+  // Drop the previously fetched term as soon as the mark points elsewhere,
+  // rather than inside the fetch effect below.
+  const [prevGlossary, setPrevGlossary] = useState(glossary);
+  if (glossary !== prevGlossary) {
+    setPrevGlossary(glossary);
+    setEnglish(null);
+    setTermNumber(null);
+  }
+
   useEffect(() => {
     let cancelled = false;
     if (!glossary) {
-      setEnglish(null);
-      setTermNumber(null);
       return;
     }
     fetchGlossaryTerm(glossary).then((term) => {

--- a/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossarySearch.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/GlossaryInstance/GlossarySearch.tsx
@@ -64,13 +64,22 @@ export const GlossarySearch = ({
     [workUuid],
   );
 
+  // Clearing an emptied query happens during render. Non-empty queries keep
+  // showing the previous results until the debounced search returns, as before.
+  const [prevSearchQuery, setPrevSearchQuery] = useState(searchQuery);
+  if (searchQuery !== prevSearchQuery) {
+    setPrevSearchQuery(searchQuery);
+    if (!searchQuery.trim()) {
+      setResults([]);
+    }
+  }
+
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
     }
 
     if (!searchQuery.trim()) {
-      setResults([]);
       return;
     }
 

--- a/libs/lib-editing/src/lib/components/editor/extensions/HoverInputField.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/HoverInputField.tsx
@@ -31,7 +31,6 @@ export const HoverInputField = ({
       <Button
         size="icon"
         variant="ghost"
-        disabled={!!inputRef.current}
         onClick={() => onSubmit(inputRef.current?.value)}
       >
         <CheckIcon />

--- a/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLinkInput.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/InternalLink/InternalLinkInput.tsx
@@ -45,7 +45,6 @@ export const InternalLinkInput = ({
       <Button
         size="icon"
         variant="ghost"
-        disabled={!!uuidRef.current && !!typeRef.current}
         onClick={submit}
       >
         <CheckIcon />

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionAdvancedOverlay.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionAdvancedOverlay.tsx
@@ -28,6 +28,11 @@ export const MentionAdvancedOverlay = ({ editor }: { editor: Editor }) => {
   // Register the openAdvanced callback the suggestion list calls.
   useEffect(() => {
     const storage = editor.storage.mention;
+    // `editor.storage` is TipTap's documented channel for handing callbacks to
+    // a ProseMirror plugin. The rule objects because `editor` arrives as a
+    // prop, but this is an effect updating an external system, which is what
+    // effects are for.
+    // eslint-disable-next-line react-hooks/immutability -- TipTap extension storage handoff
     storage.openAdvanced = (next) => setPayload(next);
     return () => {
       storage.openAdvanced = undefined;

--- a/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageMenuOverlay.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Passage/PassageMenuOverlay.tsx
@@ -93,6 +93,10 @@ export const PassageMenuOverlay = ({ editor }: { editor: Editor }) => {
   useEffect(() => {
     const storage = editor.storage.passage;
     if (!storage) return;
+    // `editor.storage` is TipTap's documented channel for handing callbacks to
+    // a ProseMirror plugin. The rule objects because `editor` arrives as a
+    // prop, but this is an effect updating an external system.
+    // eslint-disable-next-line react-hooks/immutability -- TipTap extension storage handoff
     storage.openMenu = (payload: PassageMenuPayload) => {
       setMenu({ uuid: payload.uuid, rect: payload.rect });
       setShowRevisionForm(false);
@@ -119,6 +123,7 @@ export const PassageMenuOverlay = ({ editor }: { editor: Editor }) => {
   useEffect(() => {
     const storage = editor.storage.passage;
     if (!storage) return;
+    // eslint-disable-next-line react-hooks/immutability -- TipTap extension storage handoff
     storage.chrome = {
       toh,
       isCompare,

--- a/libs/lib-editing/src/lib/components/editor/hooks/useDirtyStore.ts
+++ b/libs/lib-editing/src/lib/components/editor/hooks/useDirtyStore.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useState } from 'react';
 
 export interface DirtyStore {
   isDirty: boolean;
@@ -11,7 +11,10 @@ export interface DirtyStore {
 }
 
 export const useDirtyStore = (): DirtyStore => {
-  const storeRef = useRef<DirtyStore>({
+  // A lazy useState initialiser gives the same one-per-component instance as a
+  // ref, but is safe to read during render. It also avoids rebuilding the
+  // object literal on every render, which `useRef` did.
+  const [store] = useState<DirtyStore>(() => ({
     isDirty: false,
     listeners: new Set<() => void>(),
     subscribe(listener: () => void) {
@@ -27,7 +30,7 @@ export const useDirtyStore = (): DirtyStore => {
     getSnapshot() {
       return this.isDirty;
     },
-  });
+  }));
 
-  return storeRef.current;
+  return store;
 };

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/EndNoteSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/EndNoteSelector.tsx
@@ -126,13 +126,22 @@ export const EndNoteSelector = ({ editor }: { editor: Editor }) => {
     [workUuid],
   );
 
+  // Clearing an emptied query happens during render. Non-empty queries keep
+  // showing the previous results until the debounced search returns, as before.
+  const [prevSearchQuery, setPrevSearchQuery] = useState(searchQuery);
+  if (searchQuery !== prevSearchQuery) {
+    setPrevSearchQuery(searchQuery);
+    if (!searchQuery.trim()) {
+      setResults([]);
+    }
+  }
+
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
     }
 
     if (!searchQuery.trim()) {
-      setResults([]);
       return;
     }
 

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/SelectorInputField.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/SelectorInputField.tsx
@@ -44,7 +44,6 @@ export const SelectorInputField = ({
       <Button
         size="icon"
         variant="ghost"
-        disabled={!!inputRef.current}
         onClick={() => onSubmit(inputRef.current?.value)}
       >
         <CheckIcon className="size-4" />

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
@@ -141,11 +141,15 @@ export const TranslationSSRContent = ({
   const exts = extensions ?? translationSSRExtensions;
   const doc = wrapAsDoc(content);
 
+  // Only the serialization can fail, so that is all the try covers. Keeping the
+  // JSX outside it satisfies the rule and is more honest besides: constructing
+  // an element never throws, so wrapping it never caught anything.
+  let html: string;
   try {
     if (process.env.NODE_ENV !== 'production') {
       assertCoverage(doc, exts);
     }
-    const html = renderToHTMLString({
+    html = renderToHTMLString({
       content: doc,
       extensions: exts,
       options: {
@@ -153,9 +157,6 @@ export const TranslationSSRContent = ({
         nodeMapping: { mention: renderMentionToHTMLString },
       },
     });
-    return (
-      <div className={className} dangerouslySetInnerHTML={{ __html: html }} />
-    );
   } catch (err) {
     if (process.env.NODE_ENV !== 'production') {
       throw err;
@@ -166,4 +167,8 @@ export const TranslationSSRContent = ({
     );
     return <div className={className}>{extractPlainText(doc)}</div>;
   }
+
+  return (
+    <div className={className} dangerouslySetInnerHTML={{ __html: html }} />
+  );
 };

--- a/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/NavigationProvider.tsx
@@ -384,7 +384,12 @@ export const NavigationProvider = ({
 
     const { panels: newPanels, toh: newToh } = parsePanelParams(query);
 
+    // Router state is the external system here, and `isPanelTransitioning`
+    // above guards against the feedback loop where our own panel writes push a
+    // new query which then reads back. Both the guard and the ordering depend
+    // on this staying an effect.
     if (newPanels) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs from router state behind a transition guard
       setPanels(newPanels);
     }
 
@@ -400,7 +405,13 @@ export const NavigationProvider = ({
 
   const hasHoverCards = useFeatureFlagEnabled('translation-hover-cards');
 
-  useEffect(() => {
+  // Close the right panel when there is no translation to show. `prev` starts
+  // true so a first render that already lacks translation content still closes
+  // it, matching the effect this replaced.
+  const [prevHasTranslationContent, setPrevHasTranslationContent] =
+    useState(true);
+  if (hasTranslationContent !== prevHasTranslationContent) {
+    setPrevHasTranslationContent(hasTranslationContent);
     if (!hasTranslationContent) {
       setPanels((prev) => {
         if (!prev.right.open) {
@@ -412,7 +423,7 @@ export const NavigationProvider = ({
         };
       });
     }
-  }, [hasTranslationContent]);
+  }
 
   const contextValue = useMemo(
     () => ({

--- a/libs/lib-editing/src/lib/components/shared/RestrictionWarning.tsx
+++ b/libs/lib-editing/src/lib/components/shared/RestrictionWarning.tsx
@@ -37,35 +37,43 @@ export const setCookie = (name: string, value: string, days = 365) => {
 
 export const useRestrictionWarning = ({ imprint }: { imprint?: Imprint }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [shouldIgnore, setShouldIgnore] = useState(true);
-  const [toIgnore, setToIgnore] = useState<string[]>([]);
+  // `null` means the cookie has not been read yet. Distinguishing that from an
+  // empty list matters: until we know, we must not decide that a restricted
+  // imprint has not been dismissed, or the dialog flashes open for a reader
+  // who already dismissed it.
+  const [toIgnore, setToIgnore] = useState<string[] | null>(null);
 
+  // Cookies are only readable on the client, so this has to happen after
+  // hydration rather than during render.
   useEffect(() => {
     const toIgnoreStr = getCookie(RESTRICTION_COOKIE_NAME) || '[]';
-    const toIgnore = JSON.parse(toIgnoreStr) || [];
-    setToIgnore(toIgnore);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- client-only cookie read, unavailable during SSR
+    setToIgnore(JSON.parse(toIgnoreStr) || []);
   }, []);
 
-  useEffect(() => {
-    if (!imprint?.uuid) {
-      return;
-    }
+  const shouldIgnore =
+    toIgnore === null || !imprint?.uuid
+      ? true
+      : toIgnore.includes(imprint.uuid);
 
-    setShouldIgnore(toIgnore.includes(imprint.uuid));
-  }, [toIgnore, imprint]);
-
-  useEffect(() => {
-    if (!shouldIgnore && imprint?.restriction) {
+  // Open once, when we know the imprint is restricted and not dismissed.
+  // `prevShouldWarn` starts false so a first render that already warrants the
+  // dialog still opens it.
+  const shouldWarn = !shouldIgnore && !!imprint?.restriction;
+  const [prevShouldWarn, setPrevShouldWarn] = useState(false);
+  if (shouldWarn !== prevShouldWarn) {
+    setPrevShouldWarn(shouldWarn);
+    if (shouldWarn) {
       setIsOpen(true);
     }
-  }, [shouldIgnore, imprint]);
+  }
 
   const ignore = () => {
     if (!imprint?.uuid) {
       return;
     }
 
-    const newToIgnore = [...toIgnore, imprint.uuid];
+    const newToIgnore = [...(toIgnore ?? []), imprint.uuid];
     setToIgnore(newToIgnore);
     setCookie(RESTRICTION_COOKIE_NAME, JSON.stringify(newToIgnore));
   };

--- a/libs/lib-editing/src/lib/components/shared/SourceReader.tsx
+++ b/libs/lib-editing/src/lib/components/shared/SourceReader.tsx
@@ -78,7 +78,12 @@ export const SourceReader = () => {
   }, []);
 
   // Reset when the work changes; the initialization effect will repopulate.
-  useEffect(() => {
+  // The state half runs during render, which is where React wants it; the ref
+  // half has to stay in an effect, since refs cannot be written during render.
+  const workKey = `${toh}|${uuid}`;
+  const [prevWorkKey, setPrevWorkKey] = useState(workKey);
+  if (workKey !== prevWorkKey) {
+    setPrevWorkKey(workKey);
     setFolios([]);
     setLoadedStart(0);
     setHasMoreBefore(false);
@@ -86,6 +91,9 @@ export const SourceReader = () => {
     setLoadingBefore(false);
     setLoadingAfter(false);
     setInitialized(false);
+  }
+
+  useEffect(() => {
     processedHashRef.current = undefined;
     scrollParentRef.current = null;
   }, [toh, uuid]);

--- a/libs/lib-editing/src/lib/components/shared/TableOfContents.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TableOfContents.tsx
@@ -14,7 +14,7 @@ import {
   Separator,
 } from '@eightyfourthousand/design-system';
 import { cn, parseToh } from '@eightyfourthousand/lib-utils';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useNavigation } from './NavigationProvider';
 import {
   PanelName,
@@ -126,16 +126,10 @@ export const TableOfContents = ({
     hasTranslationContent,
     setHasTranslationContent,
   } = useNavigation();
-  const [localToh, setLocalToh] = useState<TohokuCatalogEntry>(
-    work.toh[0] || '',
-  );
+  // Purely derived from navigation state; nothing else assigns it.
+  const localToh: TohokuCatalogEntry = toh || work.toh[0] || '';
 
   const title = imprint?.mainTitles?.en || work.title;
-
-  useEffect(() => {
-    const currentToh = toh || work.toh[0] || '';
-    setLocalToh(currentToh);
-  }, [toh, work.toh, setToh]);
 
   const baseStyle = 'w-full py-2 leading-6 text-sm font-light text-foreground';
   const inferredHasTranslationContent = useMemo(() => {

--- a/libs/lib-editing/src/lib/components/shared/TranslationHoverCard.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationHoverCard.tsx
@@ -64,6 +64,10 @@ export const TranslationHoverCard = ({
 
   return (
     <div
+      // `refs.setFloating` is floating-ui's ref *setter*, which is how the
+      // floating element is attached. Nothing reads `.current` here, but the
+      // rule treats any property of a refs object as a ref access.
+      // eslint-disable-next-line react-hooks/refs -- floating-ui ref setter, not a ref read
       ref={refs.setFloating}
       style={{ ...floatingStyles, pointerEvents: 'auto', cursor: 'default' }}
       className="z-100"

--- a/libs/lib-editing/src/lib/components/shared/glossary/GlossaryPaginationProvider.tsx
+++ b/libs/lib-editing/src/lib/components/shared/glossary/GlossaryPaginationProvider.tsx
@@ -65,7 +65,6 @@ export const GlossaryPaginationProvider = ({
 
   const [startIsLoading, setStartIsLoading] = useState(false);
   const [endIsLoading, setEndIsLoading] = useState(false);
-  const [navCursor, setNavCursor] = useState<string | undefined>();
   const processedNavCursorRef = useRef<string | undefined>(undefined);
   const isNavigatingRef = useRef(false);
 
@@ -92,10 +91,8 @@ export const GlossaryPaginationProvider = ({
   const panelHash =
     panels.right?.tab === 'glossary' ? panels.right?.hash : undefined;
 
-  // Track hash changes
-  useEffect(() => {
-    setNavCursor(panelHash);
-  }, [panelHash]);
+  // Nothing else assigned this, so it is simply the hash itself.
+  const navCursor = panelHash;
 
   useEffect(() => {
     if (!panelHash) {

--- a/libs/lib-search/src/lib/ui/SearchButton.tsx
+++ b/libs/lib-search/src/lib/ui/SearchButton.tsx
@@ -93,6 +93,14 @@ export const SearchButton = ({
     useState<ResultsEntity>(DEFAULT_RESULTS_TAB);
   const [shouldScrollActiveOccurrence, setShouldScrollActiveOccurrence] =
     useState(false);
+  // `pendingOccurrenceSelectionRef` is a coordination channel, not rendered
+  // state: handlers record which occurrence should become active, and the
+  // effect below resolves it once the derived occurrence list has caught up.
+  // Writing it must not trigger a render, so it cannot become state, and refs
+  // cannot be written during render. Several react-hooks reports in this file
+  // follow from that and are suppressed individually with a pointer here.
+  // A proper rework of this state machine wants test coverage first — this
+  // component currently has none.
   const pendingOccurrenceSelectionRef = useRef<SearchPendingSelection | null>(
     null,
   );
@@ -207,28 +215,44 @@ export const SearchButton = ({
     return () => clearTimeout(debounce);
   }, [refreshSearch]);
 
-  useEffect(() => {
+  // Clear the dialog's search state whenever it opens or closes.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
     setResults(undefined);
     setSearchQuery('');
     setUseRegex(false);
     setActiveOccurrenceIndexState(0);
     setShouldScrollActiveOccurrence(false);
+  }
+
+  // The ref half of that reset, which cannot happen during render.
+  useEffect(() => {
     pendingOccurrenceSelectionRef.current = null;
   }, [open]);
 
-  useEffect(() => {
+  // Keep the visible tab on something that actually has results.
+  const [prevResults, setPrevResults] = useState(results);
+  if (results !== prevResults) {
+    setPrevResults(results);
     if (!results) {
       setActiveResultsTab(DEFAULT_RESULTS_TAB);
-      return;
+    } else {
+      setActiveResultsTab((currentTab) =>
+        results[currentTab].length > 0
+          ? currentTab
+          : getFirstResultsTab(results),
+      );
     }
+  }
 
-    setActiveResultsTab((currentTab) =>
-      results[currentTab].length > 0 ? currentTab : getFirstResultsTab(results),
-    );
-  }, [results]);
-
+  // Resolves the pending selection recorded by the handlers above against the
+  // freshly derived occurrence list. Both the read and the clear of
+  // `pendingOccurrenceSelectionRef` have to happen here, so this cannot move
+  // into render. See the note at the ref declaration.
   useEffect(() => {
     if (passageOccurrences.length === 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- resolves a ref-held pending selection
       setActiveOccurrenceIndexState(0);
       pendingOccurrenceSelectionRef.current = null;
       return;
@@ -295,6 +319,10 @@ export const SearchButton = ({
 
     const occurrenceTab = getOccurrenceResultsTab(activeOccurrence);
     if (occurrenceTab && results[occurrenceTab].length > 0) {
+      // Must stay an effect: the scroll effect below depends on
+      // `activeResultsTab`, so it has to observe this switch before scrolling.
+      // Moving it into render would reorder the two.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- ordered before the scroll effect below
       setActiveResultsTab(occurrenceTab);
     }
   }, [activeOccurrence, results, shouldScrollActiveOccurrence]);
@@ -420,6 +448,10 @@ export const SearchButton = ({
                 .*
               </Button>
             </div>
+            {/* `actionContext` bundles handlers that close over
+                `pendingOccurrenceSelectionRef`. They only touch it when
+                invoked from an event, never during this render. */}
+            {/* eslint-disable-next-line react-hooks/refs -- handlers read the ref only when invoked */}
             {searchQuery && renderActions?.(actionContext)}
           </div>
           {searchQuery && (


### PR DESCRIPTION
### Summary

- `HoverInputField`, `InternalLinkInput` and `SelectorInputField` each gated their confirm button using an input reference, and they never re-rendered
- `RestrictionWarning` suppressed the dialog until the dismissal cookie had been read. Deriving it naively would flash the warning at a reader who had already dismissed it.
- Removes state that only ever mirrored something else: `TableOfContents.localToh`, `GlossaryPaginationProvider.navCursor`, `EditorPage`'s content/type pair, `SandboxHeader.selectedItem` (which also removed a `didSelect` flag and its whole effect), and `EndNoteLinkHoverContent`'s no-endnote error state.
- Genuine state that resets when inputs change: the debounced search clears in `GlossarySearch` and `EndNoteSelector`, `GlossaryInstance`'s term reset, `SourceReader`'s reset on work change, `StackPage`'s stack reset, `NavigationProvider` closing the right panel, and `SearchButton`'s dialog reset. Where a reset also touched refs, the state half moved to render and the ref half stayed in a small effect, since refs cannot be written during render.
- `useDirtyStore` returned `storeRef.current` during render — a lazy `useState` initializer gives the same one-per-component instance, is safe to read in render, and stops rebuilding the object literal every render. `TranslationSSRContent` built its JSX inside a try/catch; only the serialization can throw, so the try now covers just that.
- Several necessary exceptions were suppressed with comments
- On the search button five of its eight errors are fixed and three suppressed. Its reports share one root cause: `pendingOccurrenceSelectionRef` is a coordination channel rather than rendered state, and refs cannot be written during render.

### Todo

`data-access:typecheck` fails on `main` with 5 errors, which blocks a clean typecheck of everything downstream of it.