### PR TITLE
Fix typecheck and the remaining build failures

### DIFF
--- a/apps/node-scripts/project.json
+++ b/apps/node-scripts/project.json
@@ -4,62 +4,14 @@
   "sourceRoot": "apps/node-scripts/src",
   "projectType": "application",
   "tags": [],
-  "// typecheck": "node-scripts is a collection of standalone one-off migration scripts (its build entry main.ts is already absent). It is excluded from typecheck rather than maintained against strict app-level type rules.",
+  "// targets": "node-scripts is a collection of standalone one-off scripts, run directly with ts-node. It has no single entry point, so it has no build or serve target — those previously pointed at an absent main.ts and could never succeed. typecheck is a real tsc --noEmit and is the type-safety net for these files.",
   "targets": {
     "typecheck": {
-      "executor": "nx:run-commands",
+      "command": "tsc --noEmit -p tsconfig.app.json",
       "options": {
-        "command": "echo 'node-scripts: typecheck skipped (standalone scripts project)'"
-      }
-    },
-    "build": {
-      "executor": "@nx/esbuild:esbuild",
-      "outputs": ["{options.outputPath}"],
-      "defaultConfiguration": "production",
-      "options": {
-        "platform": "node",
-        "outputPath": "dist/apps/node-scripts",
-        "format": ["cjs"],
-        "bundle": false,
-        "main": "apps/node-scripts/src/main.ts",
-        "tsConfig": "apps/node-scripts/tsconfig.app.json",
-        "assets": ["apps/node-scripts/src/assets"],
-        "generatePackageJson": true,
-        "esbuildOptions": {
-          "sourcemap": true,
-          "outExtension": {
-            ".js": ".js"
-          }
-        }
+        "cwd": "apps/node-scripts"
       },
-      "configurations": {
-        "development": {},
-        "production": {
-          "esbuildOptions": {
-            "sourcemap": false,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        }
-      }
-    },
-    "serve": {
-      "executor": "@nx/js:node",
-      "defaultConfiguration": "development",
-      "dependsOn": ["build"],
-      "options": {
-        "buildTarget": "node-scripts:build",
-        "runBuildTargetDependencies": false
-      },
-      "configurations": {
-        "development": {
-          "buildTarget": "node-scripts:build:development"
-        },
-        "production": {
-          "buildTarget": "node-scripts:build:production"
-        }
-      }
+      "cache": true
     }
   }
 }

--- a/apps/node-scripts/src/config.ts
+++ b/apps/node-scripts/src/config.ts
@@ -21,6 +21,19 @@ export const loadConfig = () => {
   const SUPABASE_URL = process.env['SUPABASE_URL'];
   const SUPABASE_SERVICE_KEY = process.env['SUPABASE_SERVICE_KEY'];
 
+  // Fail with something readable rather than handing undefined to createClient,
+  // which otherwise surfaces much later as an opaque request error.
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+    const missing = [
+      !SUPABASE_URL && 'SUPABASE_URL',
+      !SUPABASE_SERVICE_KEY && 'SUPABASE_SERVICE_KEY',
+    ].filter(Boolean);
+    throw new Error(
+      `Missing required environment variable(s): ${missing.join(', ')}. ` +
+        'Set them in apps/node-scripts/.env or the environment.',
+    );
+  }
+
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
   return {
     supabase,

--- a/apps/node-scripts/src/migrate-endnotes.ts
+++ b/apps/node-scripts/src/migrate-endnotes.ts
@@ -120,7 +120,8 @@ const main = async () => {
         start,
         end,
         toh,
-        passage_xmlId,
+        // Optional upstream, but the column is nullable rather than optional.
+        passage_xmlId: passage_xmlId ?? null,
         content: [
           {
             endnote_xmlId: xmlId,

--- a/apps/node-scripts/src/migrate-glossary-instances.ts
+++ b/apps/node-scripts/src/migrate-glossary-instances.ts
@@ -121,7 +121,8 @@ const main = async () => {
         start,
         end,
         toh,
-        passage_xmlId,
+        // Optional upstream, but the column is nullable rather than optional.
+        passage_xmlId: passage_xmlId ?? null,
         content: [
           {
             type: 'glossary',

--- a/apps/node-scripts/tsconfig.app.json
+++ b/apps/node-scripts/tsconfig.app.json
@@ -5,6 +5,9 @@
     "declaration": true,
     "module": "ESNext",
     "esModuleInterop": true,
+    // These scripts import lib-utils, whose barrel pulls in .tsx modules.
+    // Without a jsx setting tsc refuses to resolve them.
+    "jsx": "react-jsx",
     "types": ["node"]
   },
   "ts-node": {

--- a/apps/web-docs/index.d.ts
+++ b/apps/web-docs/index.d.ts
@@ -4,3 +4,8 @@ declare module '*.svg' {
   export const ReactComponent: any;
   export default content;
 }
+
+// Side-effect stylesheet imports, e.g. `import 'nextra-theme-docs/style.css'`.
+// Next handles these at build time, but with `moduleResolution: bundler` tsc
+// still wants a declaration for the package subpath.
+declare module '*.css';

--- a/apps/web-editor/src/components/JsonComparePage.tsx
+++ b/apps/web-editor/src/components/JsonComparePage.tsx
@@ -306,7 +306,7 @@ export const JsonComparePage = () => {
           />
         </div>
       </div>
-      <ResizablePanelGroup direction="horizontal" className="flex-1">
+      <ResizablePanelGroup orientation="horizontal" className="flex-1">
         <ResizablePanel defaultSize={50} minSize={20}>
           <div className="flex flex-col h-full bg-white">
             <div ref={containerRef} className="flex-1 overflow-hidden" />

--- a/libs/data-access/src/lib/glossary/instance.spec.ts
+++ b/libs/data-access/src/lib/glossary/instance.spec.ts
@@ -4,6 +4,18 @@ import { DataClient } from '../types';
 type QueryResult = { data: unknown; error: unknown };
 
 /**
+ * The chainable methods return the builder itself, so the type has to be
+ * declared rather than inferred — TypeScript cannot infer a type that refers to
+ * itself in its own initializer.
+ */
+type MockQueryBuilder = {
+  select: () => MockQueryBuilder;
+  eq: (column: string, value: unknown) => MockQueryBuilder;
+  limit: () => MockQueryBuilder;
+  maybeSingle: () => Promise<QueryResult>;
+};
+
+/**
  * Builds a chainable Supabase-like query builder where `.from('table')`
  * resolves (via `maybeSingle()`) to the result registered for that table.
  * `eq` calls are recorded so tests can assert which column/value was queried.
@@ -15,7 +27,7 @@ const createMockClient = (resultsByTable: Record<string, QueryResult>) => {
   const client = {
     from: jest.fn((table: string) => {
       fromCalls.push(table);
-      const builder = {
+      const builder: MockQueryBuilder = {
         select: jest.fn(() => builder),
         eq: jest.fn((column: string, value: unknown) => {
           eqCalls.push({ table, column, value });
@@ -90,7 +102,7 @@ describe('getGlossaryInstance', () => {
 
     const client = {
       from: jest.fn((table: string) => {
-        const builder = {
+        const builder: MockQueryBuilder = {
           select: jest.fn(() => builder),
           eq: jest.fn(() => builder),
           limit: jest.fn(() => builder),

--- a/libs/data-access/src/lib/types/annotation/transform.spec.ts
+++ b/libs/data-access/src/lib/types/annotation/transform.spec.ts
@@ -1,5 +1,5 @@
 import { annotationsFromDTO } from './transform';
-import type { AnnotationDTO } from './dto';
+import type { AnnotationDTO } from './annotation-type';
 
 const spanDTO = (start: number, end: number): AnnotationDTO => ({
   uuid: 'span-1',

--- a/libs/lib-agent/src/lib/tools/write/apply-docx-import.spec.ts
+++ b/libs/lib-agent/src/lib/tools/write/apply-docx-import.spec.ts
@@ -58,6 +58,7 @@ describe('apply-docx-import tool', () => {
       counts: {
         workUpdates: 1,
         titles: 1,
+        titlesUpdated: 0,
         folioUpdates: 0,
         passages: 1,
         annotations: 0,

--- a/libs/lib-editing/src/lib/block.ts
+++ b/libs/lib-editing/src/lib/block.ts
@@ -173,10 +173,14 @@ const PRIORITY_FOR_ANNOTAION_TYPE: { [key in AnnotationType]: BlockPriority } =
     unknown: BlockPriority.Unknown,
   };
 
+// Returns the array member of `TranslationEditorContent` rather than the union.
+// It always builds an array, and declaring the union meant `push` and `map`
+// resolved through `JSONContent`'s index signature as `any`, which hid the
+// element type from callers. An array is still assignable to the union.
 export const blocksFromTranslationBody = (
   passages: Passage[],
-): TranslationEditorContent => {
-  const blocks: TranslationEditorContent = [];
+): TranslationEditorContentItem[] => {
+  const blocks: TranslationEditorContentItem[] = [];
   passages.forEach((passage) => {
     // Only drop passages with malformed (missing) content; an empty string is
     // a legitimate empty passage and must still render so it can be edited or

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteCursor.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/EndNoteCursor.spec.ts
@@ -72,13 +72,17 @@ const press = (
   cursorPlugin: Plugin,
   key: 'ArrowLeft' | 'ArrowRight' | 'Backspace' | 'Delete',
 ) =>
-  cursorPlugin.props.handleKeyDown?.(
+  // ProseMirror invokes prop handlers with the plugin as `this`, so call them
+  // the same way rather than as plain methods on `props`.
+  cursorPlugin.props.handleKeyDown?.call(
+    cursorPlugin,
     view,
     new KeyboardEvent('keydown', { key }),
   ) || false;
 
 const typeText = (view: EditorView, cursorPlugin: Plugin, text: string) =>
-  cursorPlugin.props.handleTextInput?.(
+  cursorPlugin.props.handleTextInput?.call(
+    cursorPlugin,
     view,
     view.state.selection.from,
     view.state.selection.to,

--- a/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EnsureUniqueUuids/EnsureUniqueUuids.spec.ts
@@ -41,7 +41,12 @@ const schema = new Schema({
 });
 
 const getPlugin = (): Plugin => {
-  const plugins = EnsureUniqueUuids.config.addProseMirrorPlugins?.call({});
+  // `addProseMirrorPlugins` does not touch `this`, so an empty stub is enough;
+  // it just has to be typed as the context TipTap would otherwise bind.
+  const context = {} as ThisParameterType<
+    NonNullable<typeof EnsureUniqueUuids.config.addProseMirrorPlugins>
+  >;
+  const plugins = EnsureUniqueUuids.config.addProseMirrorPlugins?.call(context);
   if (!plugins?.length) {
     throw new Error('EnsureUniqueUuids did not register a plugin');
   }

--- a/libs/lib-editing/src/lib/components/shared/HoverCardProvider.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/HoverCardProvider.spec.tsx
@@ -27,6 +27,8 @@ jest.mock('../editor/extensions/Mention/MentionHoverContent', () => ({
   MentionHoverContent: () => <div>Mention hover card</div>,
 }));
 
+const MENTION_UUID_ATTR = { uuid: 'mention-id' } as Record<string, string>;
+
 describe('HoverCardProvider', () => {
   afterEach(() => {
     jest.useRealTimers();
@@ -37,7 +39,11 @@ describe('HoverCardProvider', () => {
     const { container } = render(
       <HoverCardProvider openDelay={0} closeDelay={0}>
         <span className="mention-container" draggable>
-          <a href="/mention" type="mention" uuid="mention-id">
+          {/* The editor renders mention anchors with a bare `uuid` attribute,
+              which HoverCardProvider reads back with getAttribute. React
+              forwards unknown lowercase attributes to the DOM; only the JSX
+              types object, hence the spread. */}
+          <a href="/mention" type="mention" {...MENTION_UUID_ATTR}>
             Mention
           </a>
         </span>

--- a/libs/lib-instr/jest.config.ts
+++ b/libs/lib-instr/jest.config.ts
@@ -6,5 +6,7 @@ export default {
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../coverage/libs/lib-utils',
+  coverageDirectory: '../../coverage/libs/lib-instr',
+  // This project has no specs yet; an empty run should not fail the target.
+  passWithNoTests: true,
 };


### PR DESCRIPTION
### Summary

`data-access:typecheck` was failing and blocking type checking on five other projects, which had errors of their own. This fixes remaining type check errors, test failures, and build failures.