### PR TITLE
Add lint and typecheck CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,53 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# Superseded runs on the same PR are not worth finishing.
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Run Lint
+    runs-on: ubuntu-latest
+
+    env:
+      NX_BASE: origin/${{ github.base_ref }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # `nx affected` diffs against the base branch, so it needs real history.
+          fetch-depth: 0
+
+      # `fetch-depth: 0` already brings the base branch down, but naming it here
+      # keeps the diff working if that ever gets trimmed to speed the job up.
+      - name: Fetch base branch
+        run: git fetch --no-tags origin ${{ github.base_ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # No `paths:` filter, for the same reason as test.yml: those are
+      # workflow-level and cannot scope to a project. Nx works it out from the
+      # project graph instead.
+      - name: List affected projects
+        run: npx nx show projects --affected --base=$NX_BASE --with-target lint
+
+      # `--max-warnings=0` is deliberately not set. Every project is at zero
+      # errors, but ~79 pre-existing warnings remain across the workspace
+      # (mostly no-explicit-any, no-unused-vars, exhaustive-deps). Failing on
+      # warnings today would block every PR.
+      - name: Lint affected projects
+        run: npx nx affected -t lint --base=$NX_BASE

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,52 @@
+name: Typecheck
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# Superseded runs on the same PR are not worth finishing.
+concurrency:
+  group: typecheck-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Run Typecheck
+    runs-on: ubuntu-latest
+
+    env:
+      NX_BASE: origin/${{ github.base_ref }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # `nx affected` diffs against the base branch, so it needs real history.
+          fetch-depth: 0
+
+      # `fetch-depth: 0` already brings the base branch down, but naming it here
+      # keeps the diff working if that ever gets trimmed to speed the job up.
+      - name: Fetch base branch
+        run: git fetch --no-tags origin ${{ github.base_ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # No `paths:` filter, for the same reason as test.yml: those are
+      # workflow-level and cannot scope to a project. Nx works it out from the
+      # project graph instead.
+      - name: List affected projects
+        run: npx nx show projects --affected --base=$NX_BASE --with-target typecheck
+
+      # The typecheck target declares `dependsOn: ["tsc:build", "^typecheck"]`,
+      # so Nx builds each project's dependencies first. Nothing extra to set up
+      # here — it needs no credentials.
+      - name: Typecheck affected projects
+        run: npx nx affected -t typecheck --base=$NX_BASE


### PR DESCRIPTION
### Summary

Adds `Lint` and `Typecheck` workflows, scoped with `nx affected` like `test.yml`, so a project is checked when its own code or a dependency changes. Neither target was gated by any workflow before — which is how the `data-access:typecheck` failure fixed in #449 sat on `main` masking six other projects.

### Notes

`--max-warnings=0` is deliberately not set on lint: every project is at zero errors, but ~79 pre-existing warnings remain workspace-wide, so failing on warnings today would block every PR.
