### PR TITLE
Fix endnote insertion in paginated notes panels

### DIFF
--- a/apps/api-graphql/src/graphql/schema/passage/passage.graphql
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.graphql
@@ -239,9 +239,24 @@ type SavePassagesResult {
   passages: [Passage!]!
 
   """
+  Passages whose label the server changed while renumbering a series, excluding
+  those returned in `passages`. Mostly passages the editor never loaded — it
+  uses these to refresh the labels cached in endnote links without a reload.
+  """
+  renumberedPassages: [RenumberedPassage!]!
+
+  """
   Error message if the save failed
   """
   error: String
+}
+
+"""
+A passage renumbered by the server during a save
+"""
+type RenumberedPassage {
+  uuid: ID!
+  label: String!
 }
 
 """

--- a/apps/api-graphql/src/graphql/schema/passage/passage.mutation.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.mutation.ts
@@ -10,6 +10,7 @@ import {
   persistReplaceChanges,
   replacePassageText,
   savePassagesWithDeletions,
+  type RenumberedPassageRow,
   type SavedPassageRow,
 } from '@eightyfourthousand/data-access';
 import {
@@ -42,6 +43,7 @@ interface SavePassagesResult {
   savedCount: number;
   deletedCount?: number;
   passages: SavedPassageRow[];
+  renumberedPassages: RenumberedPassageRow[];
   error?: string;
 }
 
@@ -82,6 +84,7 @@ export const savePassagesMutation = async (
       success: false,
       savedCount: 0,
       passages: [],
+      renumberedPassages: [],
       error: permission.error,
     };
   }
@@ -112,6 +115,7 @@ export const savePassagesMutation = async (
       success: false,
       savedCount: 0,
       passages: [],
+      renumberedPassages: [],
       error: error instanceof Error ? error.message : 'Unknown error',
     };
   }

--- a/libs/client-graphql/src/index.ts
+++ b/libs/client-graphql/src/index.ts
@@ -51,6 +51,7 @@ export {
   type PublishFinding,
   type PublishReadiness,
   type PublishStatusKind,
+  type RenumberedPassage,
   type WorkPublishStatus,
   type FindingLocation,
 } from './lib/functions';

--- a/libs/client-graphql/src/lib/functions/index.ts
+++ b/libs/client-graphql/src/lib/functions/index.ts
@@ -39,7 +39,7 @@ export { getWorkFolios } from './get-work-folios';
 export { getWorkFoliosAround } from './get-work-folios-around';
 export { hasPermission, type Permission } from './has-permission';
 export { replace, type ReplaceType, type ReplacedPassage } from './replace';
-export { savePassages } from './save-passages';
+export { savePassages, type RenumberedPassage } from './save-passages';
 export {
   getPublishReadiness,
   isReadinessUndetermined,

--- a/libs/client-graphql/src/lib/functions/save-passages.ts
+++ b/libs/client-graphql/src/lib/functions/save-passages.ts
@@ -14,9 +14,23 @@ const SAVE_PASSAGES_MUTATION = gql`
         uuid
         json
       }
+      renumberedPassages {
+        uuid
+        label
+      }
     }
   }
 `;
+
+/**
+ * A passage the server relabelled while renumbering a series. Not part of the
+ * submitted payload — the editor uses these to refresh labels it is showing
+ * for passages outside its loaded window.
+ */
+export interface RenumberedPassage {
+  uuid: string;
+  label: string;
+}
 
 interface SavePassagesResponse {
   savePassages: {
@@ -24,6 +38,7 @@ interface SavePassagesResponse {
     savedCount: number;
     deletedCount?: number;
     passages: ReplacedPassage[];
+    renumberedPassages: RenumberedPassage[];
     error?: string;
   };
 }
@@ -72,6 +87,7 @@ export const savePassages = async ({
   savedCount: number;
   deletedCount?: number;
   passages: ReplacedPassage[];
+  renumberedPassages: RenumberedPassage[];
   error?: string;
 }> => {
   const passageInputs = passages.map(passageToInput);

--- a/libs/data-access/src/lib/passage/save.spec.ts
+++ b/libs/data-access/src/lib/passage/save.spec.ts
@@ -620,4 +620,144 @@ describe('savePassagesWithDeletions failure propagation', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('stale annotations');
   });
+
+  // DEV-720. The editor holds a window of a series, not all of it, so it can
+  // only renumber the notes it has loaded. Those arrive already carrying their
+  // expected label; treating that as "the rest of the series is contiguous"
+  // stopped the walk at the edge of the window and left every note beyond it
+  // sharing a number with its neighbour.
+  describe('renumbering past the editor window', () => {
+    /** n.843 inserted after n.842; the editor had n.843–n.844 loaded. */
+    const insertedNote: Passage = {
+      uuid: 'note-new',
+      workUuid: 'work-1',
+      content: '',
+      label: 'n.843',
+      sort: 843,
+      type: 'endnotes',
+      annotations: [],
+    };
+
+    /** The old n.843, renumbered by the client and sent in the payload. */
+    const clientRenumbered: Passage = {
+      ...insertedNote,
+      uuid: 'note-843',
+      content: 'Was n.843',
+      label: 'n.844',
+      sort: 844,
+    };
+
+    const endnoteRow = (
+      uuid: string,
+      label: string,
+      sort: number,
+    ): PassageRowDTO => ({
+      uuid,
+      work_uuid: 'work-1',
+      content: label,
+      label,
+      sort,
+      type: 'endnotes',
+    });
+
+    it('renumbers notes past the window and reports their new labels', async () => {
+      const state = createState({
+        passages: [
+          // Already upserted with the label the client computed.
+          endnoteRow('note-843', 'n.844', 844),
+          // Never loaded by the editor, so still holding pre-insert labels.
+          endnoteRow('note-844', 'n.844', 845),
+          endnoteRow('note-845', 'n.845', 846),
+        ],
+      });
+
+      const result = await savePassagesWithDeletions({
+        client: createFakeClient(state),
+        passages: [insertedNote, clientRenumbered],
+      });
+
+      expect(result.success).toBe(true);
+      expect(state.labelUpserts.flat()).toEqual([
+        { uuid: 'note-844', label: 'n.845' },
+        { uuid: 'note-845', label: 'n.846' },
+      ]);
+      expect(result.renumberedPassages).toEqual([
+        { uuid: 'note-844', label: 'n.845' },
+        { uuid: 'note-845', label: 'n.846' },
+      ]);
+    });
+
+    it('still stops at a note that was already contiguous on its own', async () => {
+      const state = createState({
+        passages: [
+          // Not in the payload: its label is authoritative evidence that the
+          // tail of the series needs no renumbering.
+          endnoteRow('note-untouched', 'n.844', 844),
+          endnoteRow('note-845', 'n.845', 845),
+        ],
+      });
+
+      const result = await savePassagesWithDeletions({
+        client: createFakeClient(state),
+        passages: [insertedNote],
+      });
+
+      expect(result.success).toBe(true);
+      expect(state.labelUpserts).toEqual([]);
+      expect(result.renumberedPassages).toEqual([]);
+    });
+
+    // A work spanning several Tohoku texts holds per-text variants of one note:
+    // same label, distinguished by a non-null `toh`. Advancing the number once
+    // per row fans a single slot out across several numbers and cascades
+    // through the rest of the sequence.
+    it('moves every per-text variant of a slot to the same new number', async () => {
+      const state = createState({
+        passages: [
+          { ...endnoteRow('n4-916', 'n.4', 844), toh: 'toh916' },
+          { ...endnoteRow('n4-526', 'n.4', 845), toh: 'toh526' },
+          { ...endnoteRow('n4-141', 'n.4', 846), toh: 'toh141' },
+          endnoteRow('n5', 'n.5', 847),
+        ],
+      });
+
+      const result = await savePassagesWithDeletions({
+        client: createFakeClient(state),
+        passages: [{ ...insertedNote, label: 'n.4' }],
+      });
+
+      expect(result.success).toBe(true);
+      expect(state.labelUpserts.flat()).toEqual([
+        { uuid: 'n4-916', label: 'n.5' },
+        { uuid: 'n4-526', label: 'n.5' },
+        { uuid: 'n4-141', label: 'n.5' },
+        { uuid: 'n5', label: 'n.6' },
+      ]);
+    });
+
+    it('omits passages returned in `passages` from `renumberedPassages`', async () => {
+      const state = createState({
+        passages: [
+          endnoteRow('note-843', 'n.844', 844),
+          endnoteRow('note-844', 'n.844', 845),
+        ],
+      });
+
+      const result = await savePassagesWithDeletions({
+        client: createFakeClient(state),
+        // note-844 is both in the payload and renumbered by the walk; it comes
+        // back in `passages` with its final label, so reporting it twice would
+        // be redundant.
+        passages: [
+          insertedNote,
+          clientRenumbered,
+          { ...clientRenumbered, uuid: 'note-844', label: 'n.845', sort: 845 },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.renumberedPassages).toEqual([]);
+      expect(result.passages.map((row) => row.uuid)).toContain('note-844');
+    });
+  });
 });

--- a/libs/data-access/src/lib/passage/save.ts
+++ b/libs/data-access/src/lib/passage/save.ts
@@ -18,24 +18,47 @@ async function normalizePassageLabelsAfter({
   fromSort,
   fromLabel,
   delta,
+  clientRenumberedUuids,
 }: {
   client: DataClient;
   workUuid: string;
   fromSort: number;
   fromLabel: string;
   delta: number;
-}): Promise<{ error?: string }> {
+  /**
+   * Passages in this save's payload. The editor renumbers the passages it has
+   * loaded before saving, so those rows already carry their expected label —
+   * which must not be read as "the rest of the series is already correct".
+   * See the `expectedLabel` check below.
+   */
+  clientRenumberedUuids?: Set<string>;
+}): Promise<{ error?: string; renumbered: RenumberedPassageRow[] }> {
   const parts = fromLabel.split('.');
   const depth = parts.length;
   const prefix = depth > 1 ? `${parts.slice(0, -1).join('.')}.` : '';
   let nextInt = Number.parseInt(parts[depth - 1], 10) + Math.max(delta, 0);
   let lastSort = fromSort;
   let done = false;
+  const renumbered: RenumberedPassageRow[] = [];
+
+  // A label is a slot, not a row. A work covering several Tohoku texts can hold
+  // per-text variants of one note — same label, distinguished by a non-null
+  // `toh` — so those rows must all land on the same new number. Advancing per
+  // row instead of per slot fans one slot out across several numbers and
+  // cascades through the rest of the sequence.
+  //
+  // `toh` is what makes variants identifiable, and it is load-bearing here:
+  // matching on the label alone would also group the row the client just
+  // renumbered with the stale row behind it, which transiently share a label
+  // mid-save. A `toh`-less row always stands alone in its slot.
+  let previousLabel: string | undefined;
+  let previousToh: unknown = null;
+  let previousAssignedLabel: string | undefined;
 
   while (!done) {
     const { data, error } = await client
       .from('passages')
-      .select('uuid, label, sort')
+      .select('uuid, label, sort, toh')
       .eq('work_uuid', workUuid)
       .gt('sort', lastSort)
       .order('sort', { ascending: true })
@@ -43,7 +66,7 @@ async function normalizePassageLabelsAfter({
 
     if (error) {
       console.error('Error fetching passages for label normalization:', error);
-      return { error: error.message };
+      return { error: error.message, renumbered };
     }
     if (!data || data.length === 0) break;
 
@@ -60,18 +83,51 @@ async function normalizePassageLabelsAfter({
 
       if (rowParts.length > depth) continue;
 
-      const expectedLabel = prefix + nextInt;
-      if (row.label === expectedLabel) {
+      // Another per-text variant of the slot the previous row belonged to.
+      const rowToh = (row as { toh?: unknown }).toh ?? null;
+      const isSameSlot =
+        previousLabel !== undefined &&
+        row.label === previousLabel &&
+        rowToh !== null &&
+        previousToh !== null;
+      const expectedLabel = isSameSlot
+        ? (previousAssignedLabel as string)
+        : prefix + nextInt;
+
+      if (!isSameSlot && row.label === expectedLabel) {
+        // Normally a row already holding its expected label means the tail of
+        // the sequence is contiguous and there is nothing left to do. That does
+        // not hold for a row the client renumbered in this same save: the
+        // editor only holds a window of the sequence, so rows past that window
+        // are still stale. Step over it and keep walking.
+        if (clientRenumberedUuids?.has(row.uuid)) {
+          previousLabel = row.label;
+          previousToh = rowToh;
+          previousAssignedLabel = expectedLabel;
+          nextInt++;
+          continue;
+        }
         done = true;
         break;
       }
 
-      labelUpdates.push({ uuid: row.uuid, label: expectedLabel });
-      prefixRenames.push({
-        oldPrefix: `${row.label}.`,
-        newPrefix: `${expectedLabel}.`,
-      });
-      nextInt++;
+      if (row.label !== expectedLabel) {
+        labelUpdates.push({ uuid: row.uuid, label: expectedLabel });
+        // One rename per slot — the variants share both prefixes.
+        if (!isSameSlot) {
+          prefixRenames.push({
+            oldPrefix: `${row.label}.`,
+            newPrefix: `${expectedLabel}.`,
+          });
+        }
+      }
+
+      previousLabel = row.label;
+      previousToh = rowToh;
+      previousAssignedLabel = expectedLabel;
+      if (!isSameSlot) {
+        nextInt++;
+      }
     }
 
     if (labelUpdates.length > 0) {
@@ -80,8 +136,10 @@ async function normalizePassageLabelsAfter({
         .upsert(labelUpdates, { onConflict: 'uuid' });
       if (upsertError) {
         console.error('Error normalizing passage labels:', upsertError);
-        return { error: upsertError.message };
+        return { error: upsertError.message, renumbered };
       }
+
+      renumbered.push(...labelUpdates);
 
       for (const { oldPrefix, newPrefix } of prefixRenames) {
         const { error: prefixError } = await client.rpc(
@@ -94,7 +152,7 @@ async function normalizePassageLabelsAfter({
         );
         if (prefixError) {
           console.error('Error renaming passage label prefix:', prefixError);
-          return { error: prefixError.message };
+          return { error: prefixError.message, renumbered };
         }
       }
     }
@@ -103,8 +161,19 @@ async function normalizePassageLabelsAfter({
     lastSort = data[data.length - 1].sort;
   }
 
-  return {};
+  return { renumbered };
 }
+
+/**
+ * A passage whose label the server changed while renumbering a series, rather
+ * than because the client sent new content for it. The editor holds only a
+ * window of a series, so these are mostly passages it never loaded; it needs
+ * them to refresh the labels cached in `endNoteLink` marks without a reload.
+ */
+export type RenumberedPassageRow = {
+  uuid: string;
+  label: string;
+};
 
 export type SavedPassageRow = {
   uuid: string;
@@ -122,6 +191,7 @@ export type SavePassagesWithDeletionsResult = {
   savedCount: number;
   deletedCount?: number;
   passages: SavedPassageRow[];
+  renumberedPassages: RenumberedPassageRow[];
   error?: string;
 };
 
@@ -200,6 +270,7 @@ const failure = (
   success: false,
   savedCount,
   passages: [],
+  renumberedPassages: [],
   error,
 });
 
@@ -333,14 +404,18 @@ export const savePassagesWithDeletions = async ({
   }
 
   // Renumber neighbors of inserted passages now that the content is safe.
+  const renumberedByUuid = new Map<string, string>();
+  const clientRenumberedUuids = new Set(inputUuids);
   for (const passage of sortedNewPassages) {
-    const { error } = await normalizePassageLabelsAfter({
+    const { error, renumbered } = await normalizePassageLabelsAfter({
       client,
       workUuid: passage.workUuid,
       fromSort: passage.sort,
       fromLabel: passage.label,
       delta: 1,
+      clientRenumberedUuids,
     });
+    renumbered.forEach((row) => renumberedByUuid.set(row.uuid, row.label));
     if (error) {
       return failure(
         `Content saved but passage labels were not renumbered: ${error}`,
@@ -459,13 +534,15 @@ export const savePassagesWithDeletions = async ({
       // first would leave labels shifted while the passage still exists if
       // the delete failed. The deleted rows' sort/label were captured above.
       for (const deletedPassage of sortedDeleted) {
-        const { error } = await normalizePassageLabelsAfter({
+        const { error, renumbered } = await normalizePassageLabelsAfter({
           client,
           workUuid: deletedPassage.work_uuid,
           fromSort: deletedPassage.sort,
           fromLabel: deletedPassage.label,
           delta: -1,
+          clientRenumberedUuids,
         });
+        renumbered.forEach((row) => renumberedByUuid.set(row.uuid, row.label));
         if (error) {
           return failure(
             `Passages deleted but labels were not renumbered: ${error}`,
@@ -516,10 +593,20 @@ export const savePassagesWithDeletions = async ({
     toh: (row.toh as TohokuCatalogEntry) ?? null,
   }));
 
+  // Rows returned in `passages` already carry their final label, so reporting
+  // them again as renumbered would be redundant.
+  const savedUuidSet = new Set(savedPassages.map((row) => row.uuid));
+  const renumberedPassages: RenumberedPassageRow[] = Array.from(
+    renumberedByUuid.entries(),
+  )
+    .filter(([uuid]) => !savedUuidSet.has(uuid))
+    .map(([uuid, label]) => ({ uuid, label }));
+
   return {
     success: true,
     savedCount: passages.length,
     deletedCount,
     passages: savedPassages,
+    renumberedPassages,
   };
 };

--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -33,6 +33,7 @@ import {
   shouldRescanFragment,
   type FragmentBaseline,
 } from './observer-utils';
+import { applyRenumberedLabels } from './extensions/EndNoteLink/endnote-utils';
 
 interface EditorContextState {
   doc?: Doc;
@@ -576,6 +577,25 @@ export const EditorContextProvider = ({
         await applyReplacedPassages(replacements);
       }
 
+      // Inserting or deleting a passage renumbers the rest of its series
+      // server-side, including passages this client never loaded. Adopt those
+      // labels so endnote links stop showing stale numbers without a reload.
+      // `setNavigating` keeps the resulting transactions out of dirty tracking:
+      // the labels came from the server, so saving them back is pointless and
+      // would leave the editor permanently dirty.
+      const renumbered = result.renumberedPassages ?? [];
+      if (renumbered.length) {
+        setNavigating(true);
+        try {
+          applyRenumberedLabels(
+            Object.values(editorCache.current),
+            renumbered,
+          );
+        } finally {
+          setNavigating(false);
+        }
+      }
+
       // The dirty flag reflects what is left: mid-flight edits plus any
       // structural changes that have not been saved yet.
       const residualLive: PassageUuidRecord = {};
@@ -599,6 +619,7 @@ export const EditorContextProvider = ({
     getEditorUuids,
     applyReplacedPassages,
     dirtyStore,
+    setNavigating,
   ]);
 
   return (

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/endnote-utils.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/endnote-utils.spec.ts
@@ -1,0 +1,459 @@
+import { Editor } from '@tiptap/core';
+import { Node as ProseMirrorNode, Schema } from '@tiptap/pm/model';
+import { EditorState, Transaction } from '@tiptap/pm/state';
+import {
+  applyRenumberedLabels,
+  insertEndnotePassage,
+  waitFor,
+  waitForPassageNode,
+} from './endnote-utils';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'passage+' },
+    passage: {
+      content: 'paragraph+',
+      attrs: {
+        uuid: { default: null },
+        label: { default: null },
+        sort: { default: 0 },
+        type: { default: 'endnotes' },
+        toh: { default: null },
+      },
+      toDOM: () => ['div', 0],
+    },
+    paragraph: {
+      content: 'text*',
+      toDOM: () => ['p', 0],
+    },
+    text: { group: 'inline' },
+  },
+  marks: {
+    endNoteLink: {
+      attrs: { notes: { default: undefined } },
+      toDOM: () => ['span', 0],
+    },
+  },
+});
+
+type PassageSpec = {
+  uuid: string;
+  label: string;
+  sort: number;
+  type?: string;
+  text?: string;
+  /** Non-null on a per-text variant of a shared label slot. */
+  toh?: string;
+};
+
+const passageNode = ({ uuid, label, sort, type, text, toh }: PassageSpec) =>
+  schema.node(
+    'passage',
+    { uuid, label, sort, type: type ?? 'endnotes', toh: toh ?? null },
+    [schema.node('paragraph', null, text ? [schema.text(text)] : [])],
+  );
+
+/**
+ * A stand-in for a TipTap editor: `insertEndnotePassage` and friends only need
+ * `state`, `view.dispatch` and `isDestroyed`, and a real editor would drag in
+ * the whole extension stack plus a DOM.
+ */
+const createEditor = (passages: PassageSpec[]) => {
+  let state = EditorState.create({
+    schema,
+    doc: schema.node('doc', null, passages.map(passageNode)),
+  });
+  const dispatched: Transaction[] = [];
+
+  const editor = {
+    isDestroyed: false,
+    get state() {
+      return state;
+    },
+    view: {
+      dispatch: (tr: Transaction) => {
+        dispatched.push(tr);
+        state = state.apply(tr);
+      },
+    },
+  };
+
+  return {
+    editor: editor as unknown as Editor,
+    dispatched,
+    /** Every passage in doc order, as `[label, sort, uuid]` triples. */
+    passages: () => {
+      const rows: Array<[string, number, string]> = [];
+      state.doc.descendants((node: ProseMirrorNode) => {
+        if (node.type.name === 'passage') {
+          rows.push([node.attrs.label, node.attrs.sort, node.attrs.uuid]);
+        }
+        return true;
+      });
+      return rows;
+    },
+    setDestroyed: () => {
+      editor.isDestroyed = true;
+    },
+  };
+};
+
+describe('insertEndnotePassage', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('inserts after the anchor and renumbers the notes that follow it', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'a', label: 'n.1', sort: 1 },
+      { uuid: 'b', label: 'n.2', sort: 2 },
+      { uuid: 'c', label: 'n.3', sort: 3 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.3',
+        sort: 3,
+        uuid: 'new',
+        afterPassageUuid: 'b',
+      }),
+    ).toBe(true);
+
+    expect(passages()).toEqual([
+      ['n.1', 1, 'a'],
+      ['n.2', 2, 'b'],
+      ['n.3', 3, 'new'],
+      ['n.4', 4, 'c'],
+    ]);
+  });
+
+  it('inserts before the anchor, pushing the anchor down a number', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'a', label: 'n.1', sort: 1 },
+      { uuid: 'b', label: 'n.2', sort: 2 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.2',
+        sort: 2,
+        uuid: 'new',
+        beforePassageUuid: 'b',
+      }),
+    ).toBe(true);
+
+    expect(passages()).toEqual([
+      ['n.1', 1, 'a'],
+      ['n.2', 2, 'new'],
+      ['n.3', 3, 'b'],
+    ]);
+  });
+
+  it('appends to the end when no anchor is named', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'a', label: 'n.1', sort: 1 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, { label: 'n.2', sort: 2, uuid: 'new' }),
+    ).toBe(true);
+
+    expect(passages()).toEqual([
+      ['n.1', 1, 'a'],
+      ['n.2', 2, 'new'],
+    ]);
+  });
+
+  // DEV-720: the endnotes panel holds a paginated window. Anchoring on a note
+  // outside it used to append the new note to the end of the window, leaving
+  // its label a duplicate of the real note further down the series.
+  it('refuses to insert when the anchor is outside the loaded window', () => {
+    const { editor, passages, dispatched } = createEditor([
+      { uuid: 'n1', label: 'n.1', sort: 1 },
+      { uuid: 'n100', label: 'n.100', sort: 100 },
+    ]);
+    const before = passages();
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.843',
+        sort: 843,
+        uuid: 'new',
+        afterPassageUuid: 'n842-not-loaded',
+      }),
+    ).toBe(false);
+
+    expect(passages()).toEqual(before);
+    expect(dispatched).toHaveLength(0);
+  });
+
+  it('refuses a missing `beforePassageUuid` anchor too', () => {
+    const { editor, dispatched } = createEditor([
+      { uuid: 'n1', label: 'n.1', sort: 1 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.500',
+        sort: 500,
+        uuid: 'new',
+        beforePassageUuid: 'n500-not-loaded',
+      }),
+    ).toBe(false);
+    expect(dispatched).toHaveLength(0);
+  });
+
+  // A work spanning several Tohoku texts holds per-text variants of one note:
+  // same label, distinguished by a non-null `toh`. All variants of a slot must
+  // move to the same new number, or one slot fans out across several.
+  it('moves every per-text variant of a slot to the same new number', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'n3', label: 'n.3', sort: 3 },
+      { uuid: 'n4-916', label: 'n.4', sort: 4, toh: 'toh916' },
+      { uuid: 'n4-526', label: 'n.4', sort: 5, toh: 'toh526' },
+      { uuid: 'n4-141', label: 'n.4', sort: 6, toh: 'toh141' },
+      { uuid: 'n5', label: 'n.5', sort: 7 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.4',
+        sort: 4,
+        uuid: 'new',
+        afterPassageUuid: 'n3',
+      }),
+    ).toBe(true);
+
+    expect(passages()).toEqual([
+      ['n.3', 3, 'n3'],
+      ['n.4', 4, 'new'],
+      ['n.5', 5, 'n4-916'],
+      ['n.5', 6, 'n4-526'],
+      ['n.5', 7, 'n4-141'],
+      ['n.6', 8, 'n5'],
+    ]);
+  });
+
+  it('leaves endnotesHeader labels alone while still shifting their sort', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'a', label: 'n.1', sort: 1 },
+      { uuid: 'h', label: 'n.2', sort: 2, type: 'endnotesHeader' },
+      { uuid: 'b', label: 'n.3', sort: 3 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.2',
+        sort: 2,
+        uuid: 'new',
+        afterPassageUuid: 'a',
+      }),
+    ).toBe(true);
+
+    expect(passages()).toEqual([
+      ['n.1', 1, 'a'],
+      ['n.2', 2, 'new'],
+      ['n.2', 3, 'h'],
+      ['n.3', 4, 'b'],
+    ]);
+  });
+});
+
+describe('waitForPassageNode', () => {
+  it('resolves true as soon as the passage appears', async () => {
+    const { editor } = createEditor([{ uuid: 'a', label: 'n.1', sort: 1 }]);
+
+    await expect(
+      waitForPassageNode(editor, 'a', { timeoutMs: 100, intervalMs: 10 }),
+    ).resolves.toBe(true);
+  });
+
+  it('resolves true when the passage loads during the wait', async () => {
+    const { editor } = createEditor([{ uuid: 'a', label: 'n.1', sort: 1 }]);
+
+    setTimeout(() => {
+      const { state } = editor;
+      editor.view.dispatch(
+        state.tr.insert(
+          state.doc.content.size,
+          passageNode({ uuid: 'late', label: 'n.2', sort: 2 }),
+        ),
+      );
+    }, 30);
+
+    await expect(
+      waitForPassageNode(editor, 'late', { timeoutMs: 500, intervalMs: 10 }),
+    ).resolves.toBe(true);
+  });
+
+  it('resolves false when the passage never loads', async () => {
+    const { editor } = createEditor([{ uuid: 'a', label: 'n.1', sort: 1 }]);
+
+    await expect(
+      waitForPassageNode(editor, 'missing', { timeoutMs: 40, intervalMs: 10 }),
+    ).resolves.toBe(false);
+  });
+
+  it('resolves false for a destroyed editor', async () => {
+    const { editor, setDestroyed } = createEditor([
+      { uuid: 'a', label: 'n.1', sort: 1 },
+    ]);
+    setDestroyed();
+
+    await expect(
+      waitForPassageNode(editor, 'a', { timeoutMs: 40, intervalMs: 10 }),
+    ).resolves.toBe(false);
+  });
+});
+
+describe('waitFor', () => {
+  // The caller waits on "loaded AND no longer navigating", because dirty
+  // tracking is suppressed for the duration of a navigation — editing inside
+  // that window leaves the change unsaveable.
+  it('holds out until every part of a composite condition is true', async () => {
+    let loaded = false;
+    let navigating = true;
+    const calls: string[] = [];
+
+    setTimeout(() => {
+      loaded = true;
+      calls.push('loaded');
+    }, 20);
+    setTimeout(() => {
+      navigating = false;
+      calls.push('settled');
+    }, 60);
+
+    await expect(
+      waitFor(() => loaded && !navigating, { timeoutMs: 500, intervalMs: 10 }),
+    ).resolves.toBe(true);
+    expect(calls).toEqual(['loaded', 'settled']);
+  });
+
+  it('resolves false when the condition never holds', async () => {
+    await expect(
+      waitFor(() => false, { timeoutMs: 30, intervalMs: 10 }),
+    ).resolves.toBe(false);
+  });
+
+  it('resolves true without waiting when already satisfied', async () => {
+    let checks = 0;
+    await expect(
+      waitFor(
+        () => {
+          checks++;
+          return true;
+        },
+        { timeoutMs: 1000, intervalMs: 10 },
+      ),
+    ).resolves.toBe(true);
+    expect(checks).toBe(1);
+  });
+});
+
+describe('applyRenumberedLabels', () => {
+  const createLinkEditor = (endNoteUuid: string, label: string) => {
+    const mark = schema.marks['endNoteLink'].create({
+      notes: [{ uuid: 'link-1', endNote: endNoteUuid, label }],
+    });
+    let state = EditorState.create({
+      schema,
+      doc: schema.node('doc', null, [
+        schema.node(
+          'passage',
+          { uuid: 'body', label: '1.1', sort: 1, type: 'translation' },
+          [schema.node('paragraph', null, [schema.text('deva', [mark])])],
+        ),
+      ]),
+    });
+
+    const editor = {
+      isDestroyed: false,
+      get state() {
+        return state;
+      },
+      view: {
+        dispatch: (tr: Transaction) => {
+          state = state.apply(tr);
+        },
+      },
+    };
+
+    return {
+      editor: editor as unknown as Editor,
+      linkLabels: () => {
+        const labels: string[] = [];
+        state.doc.descendants((node: ProseMirrorNode) => {
+          node.marks
+            .filter((m) => m.type.name === 'endNoteLink')
+            .forEach((m) => {
+              (m.attrs.notes as { label?: string }[]).forEach((note) =>
+                labels.push(note.label ?? ''),
+              );
+            });
+          return true;
+        });
+        return labels;
+      },
+    };
+  };
+
+  it('adopts server labels for notes the client never loaded', () => {
+    // The link points at a note outside the endnotes window, so only the
+    // server knows it moved from n.843 to n.844.
+    const link = createLinkEditor('note-843', 'n.843');
+    const { editor: notes, passages } = createEditor([
+      { uuid: 'note-1', label: 'n.1', sort: 1 },
+    ]);
+
+    applyRenumberedLabels(
+      [link.editor, notes],
+      [{ uuid: 'note-843', label: 'n.844' }],
+    );
+
+    expect(link.linkLabels()).toEqual(['n.844']);
+    // Unrelated loaded passages are untouched.
+    expect(passages()).toEqual([['n.1', 1, 'note-1']]);
+  });
+
+  it('updates loaded passage nodes as well as link labels', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'note-1', label: 'n.1', sort: 1 },
+      { uuid: 'note-2', label: 'n.2', sort: 2 },
+    ]);
+
+    applyRenumberedLabels([editor], [{ uuid: 'note-2', label: 'n.3' }]);
+
+    expect(passages()).toEqual([
+      ['n.1', 1, 'note-1'],
+      ['n.3', 2, 'note-2'],
+    ]);
+  });
+
+  it('dispatches nothing when no label actually changes', () => {
+    const { editor, dispatched } = createEditor([
+      { uuid: 'note-1', label: 'n.1', sort: 1 },
+    ]);
+
+    applyRenumberedLabels([editor], [{ uuid: 'note-1', label: 'n.1' }]);
+    applyRenumberedLabels([editor], [{ uuid: 'absent', label: 'n.9' }]);
+    applyRenumberedLabels([editor], []);
+
+    expect(dispatched).toHaveLength(0);
+  });
+
+  it('skips destroyed editors', () => {
+    const { editor, dispatched, setDestroyed } = createEditor([
+      { uuid: 'note-1', label: 'n.1', sort: 1 },
+    ]);
+    setDestroyed();
+
+    applyRenumberedLabels([editor], [{ uuid: 'note-1', label: 'n.2' }]);
+
+    expect(dispatched).toHaveLength(0);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/endnote-utils.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/endnote-utils.ts
@@ -114,33 +114,6 @@ export function removeAllEndnoteLinksForPassage(
 export { findPassageNode } from '../../util';
 
 /**
- * Get the last passage node in the endnotes editor.
- * Returns { label, sort, uuid } or undefined if no passages exist.
- */
-export function getLastEndnoteInEditor(
-  editor: Editor,
-): { label: string; sort: number; uuid: string } | undefined {
-  const { doc } = editor.state;
-  let last: { label: string; sort: number; uuid: string; pos: number } | undefined;
-
-  doc.descendants((node, pos) => {
-    if (node.type.name === 'passage') {
-      last = {
-        label: node.attrs.label || '',
-        sort: node.attrs.sort ?? 0,
-        uuid: node.attrs.uuid,
-        pos,
-      };
-    }
-    return true;
-  });
-
-  return last
-    ? { label: last.label, sort: last.sort, uuid: last.uuid }
-    : undefined;
-}
-
-/**
  * Get the first endnotes-type passage node in the endnotes editor.
  * Skips endnotesHeader passages.
  * Returns { label, sort, uuid } or undefined if no passages exist.
@@ -169,8 +142,18 @@ export function getFirstEndnoteInEditor(
 /**
  * Insert a new empty endnote passage into the endnotes editor at the correct
  * position. Use `afterPassageUuid` to insert after a passage, or
- * `beforePassageUuid` to insert before one. Falls back to end of doc.
- * Increments labels and sort values of all subsequent passages.
+ * `beforePassageUuid` to insert before one. With neither, the passage is
+ * appended to the end of the doc.
+ *
+ * Increments labels and sort values of all subsequent passages **that are
+ * loaded in this editor**. The endnotes panel is paginated (a window of
+ * passages, not the whole series), so callers must guarantee the anchor
+ * passage is loaded before calling — see `waitForPassageNode`. When an anchor
+ * is named but absent, this returns `false` without touching the doc rather
+ * than appending to the end of the loaded window: a misplaced insert leaves
+ * the new note with a label that duplicates a note further down the series.
+ *
+ * Returns whether the passage was inserted.
  */
 export function insertEndnotePassage(
   editor: Editor,
@@ -187,7 +170,7 @@ export function insertEndnotePassage(
     afterPassageUuid?: string;
     beforePassageUuid?: string;
   },
-): void {
+): boolean {
   const { state } = editor;
   const { tr, schema } = state;
   const passageType = schema.nodes.passage;
@@ -195,7 +178,7 @@ export function insertEndnotePassage(
 
   if (!passageType || !paragraphType) {
     console.warn('Required node types not found in schema');
-    return;
+    return false;
   }
 
   const newPassage = passageType.create(
@@ -203,30 +186,29 @@ export function insertEndnotePassage(
     paragraphType.create(),
   );
 
-  // Find insertion position
-  let insertPos = state.doc.content.size;
-  if (beforePassageUuid) {
+  // Find insertion position. An anchor that isn't in the loaded window is a
+  // hard failure, not a reason to append — see the doc comment above.
+  const anchorUuid = beforePassageUuid ?? afterPassageUuid;
+  let insertPos = anchorUuid ? -1 : state.doc.content.size;
+  if (anchorUuid) {
     state.doc.descendants((node, pos) => {
-      if (
-        node.type.name === 'passage' &&
-        node.attrs.uuid === beforePassageUuid
-      ) {
-        insertPos = pos;
+      if (insertPos !== -1) {
+        return false;
+      }
+      if (node.type.name === 'passage' && node.attrs.uuid === anchorUuid) {
+        insertPos =
+          anchorUuid === beforePassageUuid ? pos : pos + node.nodeSize;
         return false;
       }
       return true;
     });
-  } else if (afterPassageUuid) {
-    state.doc.descendants((node, pos) => {
-      if (
-        node.type.name === 'passage' &&
-        node.attrs.uuid === afterPassageUuid
-      ) {
-        insertPos = pos + node.nodeSize;
-        return false;
-      }
-      return true;
-    });
+  }
+
+  if (insertPos === -1) {
+    console.warn(
+      `Endnote anchor passage ${anchorUuid} is not loaded in the endnotes editor; refusing to insert ${label} at the wrong position.`,
+    );
+    return false;
   }
 
   tr.insert(insertPos, newPassage);
@@ -240,6 +222,16 @@ export function insertEndnotePassage(
   const prefixWithDot = prefix ? prefix + '.' : '';
   const depth = parts.length;
   let expectedNext = incrementLabel(label);
+
+  // A label is a slot, not a passage. A work covering several Tohoku texts can
+  // hold per-text variants of one note — same label, distinguished by a
+  // non-null `toh` — and every variant of a slot must land on the same new
+  // number. Advancing per passage would fan one slot out across several
+  // numbers and cascade through the rest of the sequence. A `toh`-less passage
+  // always stands alone in its slot.
+  let previousLabel: string | undefined;
+  let previousToh: unknown = null;
+  let previousAssignedLabel: string | undefined;
 
   tr.doc.descendants((child, childPos) => {
     if (childPos < afterNewPos) return true;
@@ -256,17 +248,73 @@ export function insertEndnotePassage(
         sort: (child.attrs.sort ?? 0) + 1,
       });
     } else {
+      const childToh = child.attrs.toh ?? null;
+      const isSameSlot =
+        previousLabel !== undefined &&
+        childLabel === previousLabel &&
+        childToh !== null &&
+        previousToh !== null;
+      const assignedLabel = isSameSlot
+        ? (previousAssignedLabel as string)
+        : expectedNext;
+
       tr.setNodeMarkup(childPos, null, {
         ...child.attrs,
-        label: expectedNext,
+        label: assignedLabel,
         sort: (child.attrs.sort ?? 0) + 1,
       });
-      expectedNext = incrementLabel(expectedNext);
+
+      previousLabel = childLabel;
+      previousToh = childToh;
+      previousAssignedLabel = assignedLabel;
+      if (!isSameSlot) {
+        expectedNext = incrementLabel(expectedNext);
+      }
     }
     return true;
   });
 
   editor.view.dispatch(tr);
+  return true;
+}
+
+/**
+ * Poll `predicate` until it holds. Resolves `true` on the first pass, or
+ * `false` once the attempts are exhausted — callers treat the timeout as
+ * "it never became ready" rather than waiting indefinitely.
+ */
+export async function waitFor(
+  predicate: () => boolean,
+  {
+    timeoutMs = 5000,
+    intervalMs = 50,
+  }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<boolean> {
+  const attempts = Math.max(1, Math.ceil(timeoutMs / intervalMs));
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (predicate()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  return predicate();
+}
+
+/**
+ * Wait until `passageUuid` is a passage node in `editor`, e.g. while a
+ * paginated panel loads the window that contains it.
+ */
+export function waitForPassageNode(
+  editor: Editor,
+  passageUuid: string,
+  options?: { timeoutMs?: number; intervalMs?: number },
+): Promise<boolean> {
+  return waitFor(
+    () => !editor.isDestroyed && Boolean(findPassageNode(editor, passageUuid)),
+    options,
+  );
 }
 
 /**
@@ -299,6 +347,13 @@ export function deleteEndnotePassageNode(
     const prefixWithDot = prefix ? prefix + '.' : '';
     const depth = parts.length;
 
+    // Per-slot, not per-passage — see `insertEndnotePassage`. This also makes
+    // deleting one per-text variant of a slot a no-op for the numbering: the
+    // remaining variants keep the label, so nothing after them moves.
+    let previousLabel: string | undefined;
+    let previousToh: unknown = null;
+    let previousAssignedLabel: string | undefined;
+
     tr.doc.descendants((child, childPos) => {
       // Only process passages at or after the deletion point
       if (childPos < pos) return true;
@@ -314,13 +369,30 @@ export function deleteEndnotePassageNode(
         // Never change header labels
         return true;
       }
-      if (childLabel !== expectedNext) {
+
+      const childToh = child.attrs.toh ?? null;
+      const isSameSlot =
+        previousLabel !== undefined &&
+        childLabel === previousLabel &&
+        childToh !== null &&
+        previousToh !== null;
+      const assignedLabel = isSameSlot
+        ? (previousAssignedLabel as string)
+        : expectedNext;
+
+      if (childLabel !== assignedLabel) {
         tr.setNodeMarkup(childPos, null, {
           ...child.attrs,
-          label: expectedNext,
+          label: assignedLabel,
         });
       }
-      expectedNext = incrementLabel(expectedNext);
+
+      previousLabel = childLabel;
+      previousToh = childToh;
+      previousAssignedLabel = assignedLabel;
+      if (!isSameSlot) {
+        expectedNext = incrementLabel(expectedNext);
+      }
       return true;
     });
   }
@@ -388,6 +460,65 @@ export function syncEndnoteLinkLabels(
 
   if (changed) {
     editor.view.dispatch(tr);
+  }
+}
+
+/**
+ * Update the `label` attribute of loaded passage nodes to match `labelMap`.
+ * Only nodes whose label actually differs are touched, so a no-op call
+ * dispatches nothing.
+ */
+export function syncPassageLabels(
+  editor: Editor,
+  labelMap: Map<string, string>,
+): void {
+  const { tr } = editor.state;
+  let changed = false;
+
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name !== 'passage' || !node.attrs.uuid) {
+      return true;
+    }
+
+    const newLabel = labelMap.get(node.attrs.uuid);
+    if (newLabel !== undefined && newLabel !== node.attrs.label) {
+      tr.setNodeMarkup(pos, null, { ...node.attrs, label: newLabel });
+      changed = true;
+    }
+    return true;
+  });
+
+  if (changed) {
+    editor.view.dispatch(tr);
+  }
+}
+
+/**
+ * Apply labels the server assigned while renumbering a series to every editor
+ * that could be displaying them: the passage nodes themselves and the labels
+ * cached inside `endNoteLink` marks.
+ *
+ * A save only sends the passages the editor has loaded, but the server
+ * renumbers the whole series — so links to notes outside the loaded window keep
+ * showing their pre-save number until this runs. Callers must suppress dirty
+ * tracking around it; these labels come from the server, and marking the
+ * touched passages dirty would queue an immediate redundant save.
+ */
+export function applyRenumberedLabels(
+  editors: Editor[],
+  renumbered: { uuid: string; label: string }[],
+): void {
+  if (renumbered.length === 0) {
+    return;
+  }
+
+  const labelMap = new Map(renumbered.map(({ uuid, label }) => [uuid, label]));
+  for (const editor of editors) {
+    if (editor.isDestroyed) {
+      continue;
+    }
+    syncPassageLabels(editor, labelMap);
+    syncEndnoteLinkLabels(editor, labelMap);
   }
 }
 

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/EndNoteSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/EndNoteSelector.tsx
@@ -10,8 +10,14 @@ import {
   PopoverContent,
   PopoverTrigger,
   Separator,
+  toast,
 } from '@eightyfourthousand/design-system';
-import { AsteriskIcon, Loader2Icon, PlusIcon } from 'lucide-react';
+import {
+  AsteriskIcon,
+  Loader2Icon,
+  PlusIcon,
+  TriangleAlertIcon,
+} from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { createGraphQLClient } from '@eightyfourthousand/client-graphql';
@@ -22,9 +28,9 @@ import {
   findLastEndNoteLinkBefore,
   findPassageNode,
   getFirstEndnoteInEditor,
-  getLastEndnoteInEditor,
   insertEndnotePassage,
   syncEndnoteLinkLabelsAcrossEditors,
+  waitFor,
 } from '../../extensions/EndNoteLink/endnote-utils';
 import { incrementLabel } from '../../extensions/Passage/label';
 
@@ -59,7 +65,7 @@ export const EndNoteSelector = ({ editor }: { editor: Editor }) => {
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { getEditor } = useEditorState();
+  const { getEditor, isNavigating } = useEditorState();
   const { uuid: workUuid, updatePanel, fetchEndNote } = useNavigation();
 
   const editorState = useTiptapEditorState({
@@ -156,6 +162,13 @@ export const EndNoteSelector = ({ editor }: { editor: Editor }) => {
     };
   }, [searchQuery, searchEndnotes]);
 
+  /** Close the popover and clear its search state. */
+  const dismiss = useCallback(() => {
+    setOpen(false);
+    setSearchQuery('');
+    setResults([]);
+  }, []);
+
   const linkToExisting = useCallback(
     (endnoteUuid: string, endnoteLabel: string | null) => {
       const { to } = editor.state.selection;
@@ -165,17 +178,36 @@ export const EndNoteSelector = ({ editor }: { editor: Editor }) => {
         .setEndNoteLink(endnoteUuid, endnoteLabel ?? undefined)
         .setTextSelection(to)
         .run();
-      setOpen(false);
-      setSearchQuery('');
-      setResults([]);
+      dismiss();
     },
-    [editor],
+    [editor, dismiss],
   );
 
   const createNewEndnote = useCallback(async () => {
     const endnotesEditor = getEditor('endnotes');
     const { from, to } = editor.state.selection;
     const selectionIsRange = from !== to;
+
+    /**
+     * Give up rather than guess. The new note's position comes from a
+     * neighbouring note fetched by uuid; when we cannot establish that
+     * neighbour we have no way to know where the note belongs in the series,
+     * and guessing from the loaded window yields a label that duplicates a
+     * note further down — the DEV-720 failure.
+     */
+    const abort = (message: string) => {
+      toast(message, {
+        icon: <TriangleAlertIcon className="size-4 text-warning" />,
+      });
+      dismiss();
+    };
+
+    // Without an endnotes editor there is nothing to hold the new passage, so
+    // the link would be saved pointing at a passage that never gets created.
+    if (!endnotesEditor) {
+      abort('Open the Notes panel to add an endnote.');
+      return;
+    }
 
     // Check for an existing endNoteLink mark at the end of the selection.
     // Only the end matters — the endnote superscript renders there.
@@ -211,89 +243,112 @@ export const EndNoteSelector = ({ editor }: { editor: Editor }) => {
       const notes = endMark.attrs.notes as { endNote: string }[];
       const lastNote = notes[notes.length - 1];
       const passage = await fetchEndNote(lastNote.endNote);
-      if (passage) {
-        newLabel = incrementLabel(passage.label || 'n.0');
-        newSort = passage.sort + 1;
-        afterPassageUuid = passage.uuid;
-      } else if (endnotesEditor) {
-        const last = getLastEndnoteInEditor(endnotesEditor);
-        newLabel = last ? incrementLabel(last.label) : 'n.1';
-        newSort = last ? last.sort + 1 : 1;
-      } else {
-        newLabel = 'n.1';
-        newSort = 1;
+      if (!passage) {
+        abort('Could not read the neighbouring note. Try again.');
+        return;
       }
+      newLabel = incrementLabel(passage.label || 'n.0');
+      newSort = passage.sort + 1;
+      afterPassageUuid = passage.uuid;
     } else if (endNote && markContinues) {
       // `to` is in the middle of the mark — split. The new endnote takes
       // the existing passage's label and is inserted before it.
       const passage = await fetchEndNote(endNote.endNote);
-      if (passage) {
-        newLabel = passage.label || 'n.1';
-        newSort = passage.sort;
-        beforePassageUuid = passage.uuid;
-      } else if (endnotesEditor) {
-        const last = getLastEndnoteInEditor(endnotesEditor);
-        newLabel = last ? incrementLabel(last.label) : 'n.1';
-        newSort = last ? last.sort + 1 : 1;
-      } else {
-        newLabel = 'n.1';
-        newSort = 1;
+      if (!passage) {
+        abort('Could not read the neighbouring note. Try again.');
+        return;
       }
+      newLabel = passage.label || 'n.1';
+      newSort = passage.sort;
+      beforePassageUuid = passage.uuid;
     } else if (prevLink) {
-      // Try to get the label/sort from the endnotes editor or API
       const passage = await fetchEndNote(prevLink.endNote);
-      if (passage) {
-        newLabel = incrementLabel(passage.label || 'n.0');
-        newSort = passage.sort + 1;
-        afterPassageUuid = passage.uuid;
-      } else if (endnotesEditor) {
-        const last = getLastEndnoteInEditor(endnotesEditor);
-        newLabel = last ? incrementLabel(last.label) : 'n.1';
-        newSort = last ? last.sort + 1 : 1;
-      } else {
-        newLabel = 'n.1';
-        newSort = 1;
+      if (!passage) {
+        abort('Could not read the preceding note. Try again.');
+        return;
       }
-    } else if (endnotesEditor) {
-      // No previous link; insert before the first endnote passage
-      const first = getFirstEndnoteInEditor(endnotesEditor);
-      if (first) {
-        newLabel = 'n.1';
-        newSort = first.sort;
-        beforePassageUuid = first.uuid;
-      } else {
-        newLabel = 'n.1';
-        newSort = 1;
-      }
+      newLabel = incrementLabel(passage.label || 'n.0');
+      newSort = passage.sort + 1;
+      afterPassageUuid = passage.uuid;
     } else {
+      // No endnote link precedes the cursor in the loaded translation window,
+      // so this looks like the first note of the series. The translation editor
+      // is paginated too, and "no link above the cursor" is only trustworthy
+      // when the notes panel is showing the true start of the series — an
+      // endnote labelled n.1. Otherwise notes may well precede this position
+      // outside both windows, and inserting as n.1 would renumber the series
+      // from the wrong end.
+      const first = getFirstEndnoteInEditor(endnotesEditor);
+      if (first && first.label !== 'n.1') {
+        abort(
+          'Jump to the note just before this position, then add the new note.',
+        );
+        return;
+      }
       newLabel = 'n.1';
-      newSort = 1;
+      newSort = first ? first.sort : 1;
+      beforePassageUuid = first?.uuid;
+    }
+
+    // The endnotes panel holds a paginated window, not the whole series, so the
+    // anchor may not be loaded — the case that made this fail on works with
+    // more than a page of notes. Navigating the panel to the anchor loads the
+    // window around it (and keeps the panel's pagination cursors coherent,
+    // which fetching the blocks here would not).
+    const anchorUuid = beforePassageUuid ?? afterPassageUuid;
+    if (anchorUuid && !findPassageNode(endnotesEditor, anchorUuid)) {
+      updatePanel({
+        name: 'right',
+        state: { open: true, tab: 'endnotes', hash: anchorUuid },
+      });
+
+      // Wait for the navigation to finish, not just for the anchor to appear.
+      // Dirty tracking is suppressed for the duration of a navigation, so
+      // editing inside that window would leave the new note unsaveable: the
+      // Save button only appears once the document is dirty.
+      const ready = await waitFor(
+        () =>
+          !isNavigating() && Boolean(findPassageNode(endnotesEditor, anchorUuid)),
+      );
+
+      if (!ready) {
+        abort('Could not load the notes around this position. Try again.');
+        return;
+      }
     }
 
     const newPassageUuid = uuidv4();
 
-    // Insert endNoteLink mark in main editor with the label for immediate display,
-    // then collapse the selection to dismiss the bubble menu.
+    // Insert the passage before the link mark: if the insert is refused the
+    // document is left untouched instead of carrying a link to a note that
+    // does not exist.
+    const inserted = insertEndnotePassage(endnotesEditor, {
+      label: newLabel,
+      sort: newSort,
+      uuid: newPassageUuid,
+      afterPassageUuid,
+      beforePassageUuid,
+    });
+
+    if (!inserted) {
+      abort('Could not place the new note in the series. Try again.');
+      return;
+    }
+
+    // Insert endNoteLink mark in main editor with the label for immediate
+    // display, then collapse the selection to dismiss the bubble menu. The
+    // selection is restored explicitly because the awaits above give the
+    // editor a chance to lose it.
     editor
       .chain()
       .focus()
+      .setTextSelection(selectionIsRange ? { from, to } : to)
       .setEndNoteLink(newPassageUuid, newLabel)
       .setTextSelection(to)
       .run();
 
-    // Insert new passage in endnotes editor at the correct position
-    if (endnotesEditor) {
-      insertEndnotePassage(endnotesEditor, {
-        label: newLabel,
-        sort: newSort,
-        uuid: newPassageUuid,
-        afterPassageUuid,
-        beforePassageUuid,
-      });
-
-      // Sync updated labels into endNoteLink marks across front + translation
-      syncEndnoteLinkLabelsAcrossEditors(endnotesEditor, getEditor);
-    }
+    // Sync updated labels into endNoteLink marks across front + translation
+    syncEndnoteLinkLabelsAcrossEditors(endnotesEditor, getEditor);
 
     // Navigate to the new endnote
     updatePanel({
@@ -302,19 +357,15 @@ export const EndNoteSelector = ({ editor }: { editor: Editor }) => {
     });
 
     // Focus the new endnote passage after navigation
-    if (endnotesEditor) {
-      setTimeout(() => {
-        const found = findPassageNode(endnotesEditor, newPassageUuid);
-        if (found) {
-          endnotesEditor.commands.focus(found.pos + 2);
-        }
-      }, 200);
-    }
+    setTimeout(() => {
+      const found = findPassageNode(endnotesEditor, newPassageUuid);
+      if (found) {
+        endnotesEditor.commands.focus(found.pos + 2);
+      }
+    }, 200);
 
-    setOpen(false);
-    setSearchQuery('');
-    setResults([]);
-  }, [editor, getEditor, fetchEndNote, updatePanel]);
+    dismiss();
+  }, [editor, getEditor, fetchEndNote, updatePanel, dismiss, isNavigating]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
### Summary

Creating an endnote in a work with more than a page of notes produced a second note sharing an existing number instead of a new one. The notes panel holds a 100-passage window, but the insert resolved its anchor by scanning that window and silently appended to the end when the anchor was outside it. 64 of the 456 works with endnotes have more than 100.

### Linear

- [DEV-720](https://linear.app/84000/issue/DEV-720)

### Notes

- The insert selector now loads the window around where a new endnote will be inserted, if needed.
- The server's renumber walk no longer stops at the edge of the client's window, and reports what it relabelled so stale link numbers resolve without a reload.
- Renumbering advances per label slot rather than per passage, so per-text variants sharing a label (non-null `toh`) all move together.