### PR TITLE
Read the cached verdict when the publishing tab opens

### DIFF
--- a/apps/api-graphql/src/graphql/schema/publish/publish.graphql
+++ b/apps/api-graphql/src/graphql/schema/publish/publish.graphql
@@ -205,6 +205,16 @@ extend type Query {
   publishStatuses: [WorkPublishStatus!]!
 
   """
+  One work's cached readiness, including its findings, without validating.
+
+  This is what the editor's publishing view reads on open, so that looking at a tab does
+  not trigger a validation costing seconds on a large work. Null means the work has never
+  been written to; a row whose `stale` is true has a verdict that predates the latest edit
+  and must be presented as unchecked. Requires editor.admin.
+  """
+  publishStatus(work: String!): WorkPublishStatus
+
+  """
   Resolve finding subject uuids to the passages they sit in, scoped to one work.
   Requires editor.admin.
   """

--- a/apps/api-graphql/src/graphql/schema/publish/publish.query.ts
+++ b/apps/api-graphql/src/graphql/schema/publish/publish.query.ts
@@ -8,6 +8,7 @@
 import {
   getJob,
   readFindingLocations,
+  readPublishStatus,
   readPublishStatuses,
   resolveWork,
   validateAndRecordWork,
@@ -78,6 +79,35 @@ export const publishQueries = {
       errors: status.errors.map(findingToGraphQL),
       warnings: status.warnings.map(findingToGraphQL),
     }));
+  },
+
+  publishStatus: async (
+    _parent: unknown,
+    args: { work: string },
+    ctx: GraphQLContext,
+  ) => {
+    await requirePublishPermission(ctx);
+
+    const work = await resolveWork({ client: ctx.supabase, work: args.work });
+    if (!work) {
+      return null;
+    }
+
+    // A read, deliberately: unlike publishReadiness this never validates, so opening the
+    // publishing tab costs one indexed row lookup.
+    const status = await readPublishStatus({
+      client: ctx.supabase,
+      workUuid: work.uuid,
+    });
+    if (!status) {
+      return null;
+    }
+
+    return {
+      ...status,
+      errors: status.errors.map(findingToGraphQL),
+      warnings: status.warnings.map(findingToGraphQL),
+    };
   },
 
   findingLocations: async (

--- a/libs/client-graphql/src/index.ts
+++ b/libs/client-graphql/src/index.ts
@@ -39,6 +39,7 @@ export {
   replace,
   savePassages,
   getPublishReadiness,
+  getPublishStatus,
   getPublishStatuses,
   isReadinessUndetermined,
   publishStatusKind,

--- a/libs/client-graphql/src/lib/functions/get-publish-statuses.ts
+++ b/libs/client-graphql/src/lib/functions/get-publish-statuses.ts
@@ -100,3 +100,61 @@ export const publishStatusKind = (
   }
   return status.ok ? 'publishable' : 'blocked';
 };
+
+const GET_PUBLISH_STATUS = gql`
+  query PublishStatus($work: String!) {
+    publishStatus(work: $work) {
+      workUuid
+      ok
+      errorCount
+      warningCount
+      errorOccurrences
+      warningOccurrences
+      checkedAt
+      draftTouchedAt
+      stale
+      errors { rule severity message subjects count }
+      warnings { rule severity message subjects count }
+    }
+  }
+`;
+
+interface GetPublishStatusResponse {
+  publishStatus: WorkPublishStatus | null;
+}
+
+/**
+ * One work's cached verdict, findings included, without validating.
+ *
+ * Read this before considering a live check: validation costs roughly 0.8 ms per passage
+ * and seconds on the largest works, so it should happen when an editor asks for it, not
+ * because a tab was opened.
+ *
+ * Null means the work has never been written to, which — like a stale row — is "no verdict"
+ * rather than "publishable".
+ */
+export async function getPublishStatus({
+  client,
+  work,
+}: {
+  client: GraphQLClient;
+  work: string;
+}): Promise<WorkPublishStatus | null> {
+  try {
+    const response = await client.request<GetPublishStatusResponse>(
+      GET_PUBLISH_STATUS,
+      { work },
+    );
+    const status = response.publishStatus;
+    return status
+      ? {
+          ...status,
+          errors: status.errors ?? [],
+          warnings: status.warnings ?? [],
+        }
+      : null;
+  } catch (error) {
+    console.error('Error fetching publish status:', error);
+    return null;
+  }
+}

--- a/libs/client-graphql/src/lib/functions/index.ts
+++ b/libs/client-graphql/src/lib/functions/index.ts
@@ -47,6 +47,7 @@ export {
   type PublishReadiness,
 } from './get-publish-readiness';
 export {
+  getPublishStatus,
   getPublishStatuses,
   publishStatusKind,
   type PublishStatusKind,

--- a/libs/client-graphql/src/ssr.ts
+++ b/libs/client-graphql/src/ssr.ts
@@ -24,6 +24,7 @@ export {
   getWorkBibliography,
   getWorkFolios,
   getPublishReadiness,
+  getPublishStatus,
   getPublishStatuses,
   isReadinessUndetermined,
   publishStatusKind,

--- a/libs/lib-editing/src/lib/components/shared/PublishChecksPanel.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/PublishChecksPanel.spec.tsx
@@ -5,6 +5,7 @@ import { PublishChecksPanel } from './PublishChecksPanel';
 
 const mockGetPublishReadiness = jest.fn();
 const mockGetFindingLocations = jest.fn();
+const mockGetPublishStatus = jest.fn();
 
 // Only the network functions are stubbed. isReadinessUndetermined is deliberately left as
 // the real implementation: it encodes the "could not check" rule this suite is testing, so
@@ -14,7 +15,23 @@ jest.mock('@eightyfourthousand/client-graphql', () => ({
   createGraphQLClient: () => ({}),
   getPublishReadiness: (args: unknown) => mockGetPublishReadiness(args),
   getFindingLocations: (args: unknown) => mockGetFindingLocations(args),
+  getPublishStatus: (args: unknown) => mockGetPublishStatus(args),
 }));
+
+// A cached row carrying the same findings the live check would have produced.
+const cached = (readinessValue: PublishReadiness) => ({
+  workUuid: WORK,
+  ok: readinessValue.ok,
+  errorCount: readinessValue.errors.length,
+  warningCount: readinessValue.warnings.length,
+  errorOccurrences: readinessValue.errors.reduce((t, f) => t + f.count, 0),
+  warningOccurrences: readinessValue.warnings.reduce((t, f) => t + f.count, 0),
+  errors: readinessValue.errors,
+  warnings: readinessValue.warnings,
+  checkedAt: '2026-08-04T10:00:00.000Z',
+  draftTouchedAt: '2026-08-04T10:00:00.000Z',
+  stale: false,
+});
 
 const mockUpdatePanel = jest.fn();
 jest.mock('./NavigationProvider', () => ({
@@ -33,18 +50,31 @@ const readiness = (overrides: Partial<PublishReadiness>): PublishReadiness => ({
 beforeEach(() => {
   jest.clearAllMocks();
   mockGetFindingLocations.mockResolvedValue([]);
+  mockGetPublishStatus.mockResolvedValue(null);
 });
+
+/**
+ * Puts a verdict in the cache, and makes a live check return the same thing.
+ *
+ * The panel reads the cache on open and validates only on request, so presentation tests
+ * go through the cached path; seeding both keeps them indifferent to which produced it.
+ */
+const seed = (value: PublishReadiness) => {
+  mockGetPublishStatus.mockResolvedValue(cached(value));
+  mockGetPublishReadiness.mockResolvedValue(value);
+  return value;
+};
 
 const renderPanel = async () => {
   render(<PublishChecksPanel workUuid={WORK} />);
-  await waitFor(() => expect(mockGetPublishReadiness).toHaveBeenCalled());
+  await waitFor(() => expect(mockGetPublishStatus).toHaveBeenCalled());
 };
 
 describe('PublishChecksPanel', () => {
   it('reports an unpopulated glossary index as "could not check", not as a broken work', async () => {
     // The rule fires as an ERROR, so anything keying off severity alone would render this
     // as a validation failure. It means two glossary rules went unevaluated.
-    mockGetPublishReadiness.mockResolvedValue(
+    seed(
       readiness({
         ok: false,
         errors: [
@@ -71,7 +101,7 @@ describe('PublishChecksPanel', () => {
   });
 
   it('labels warnings as non-blocking and keeps them out of the blocking count', async () => {
-    mockGetPublishReadiness.mockResolvedValue(
+    seed(
       readiness({
         ok: true,
         warnings: [
@@ -95,7 +125,7 @@ describe('PublishChecksPanel', () => {
   });
 
   it('counts blocking rules and occurrences separately', async () => {
-    mockGetPublishReadiness.mockResolvedValue(
+    seed(
       readiness({
         ok: false,
         errors: [
@@ -129,7 +159,7 @@ describe('PublishChecksPanel', () => {
   it('reports the true occurrence total when the rule set capped the subject list', async () => {
     // The SQL caps subjects at 20 while counting them all. Showing 20 silently would read
     // as "20 affected" for a problem that touches 415.
-    mockGetPublishReadiness.mockResolvedValue(
+    seed(
       readiness({
         ok: false,
         errors: [
@@ -156,7 +186,7 @@ describe('PublishChecksPanel', () => {
   });
 
   it('paginates subjects rather than truncating them', async () => {
-    mockGetPublishReadiness.mockResolvedValue(
+    seed(
       readiness({
         ok: false,
         errors: [
@@ -201,7 +231,7 @@ describe('PublishChecksPanel', () => {
   });
 
   it('navigates to the passage a finding sits in', async () => {
-    mockGetPublishReadiness.mockResolvedValue(
+    seed(
       readiness({
         ok: false,
         errors: [
@@ -246,7 +276,7 @@ describe('PublishChecksPanel', () => {
   });
 
   it('shows a subject that no longer exists rather than dropping it', async () => {
-    mockGetPublishReadiness.mockResolvedValue(
+    seed(
       readiness({
         ok: false,
         errors: [
@@ -285,7 +315,7 @@ describe('PublishChecksPanel', () => {
 
   describe('routes each subject to the panel it actually lives in', () => {
     const openFinding = async (locations: unknown[]) => {
-      mockGetPublishReadiness.mockResolvedValue(
+      seed(
         readiness({
           ok: false,
           errors: [
@@ -372,7 +402,7 @@ describe('PublishChecksPanel', () => {
 
     it('opens a bibliography entry in the bibliography tab, keyed by its own uuid', async () => {
       // These have no passage at all, and were previously rendered as dead text.
-      mockGetPublishReadiness.mockResolvedValue(
+      seed(
         readiness({
           ok: false,
           errors: [
@@ -411,6 +441,98 @@ describe('PublishChecksPanel', () => {
         name: 'right',
         state: { open: true, tab: 'bibliography', hash: 'b1' },
       });
+    });
+  });
+
+  describe('reads the cache before validating', () => {
+    const blocked = () =>
+      readiness({
+        ok: false,
+        errors: [
+          {
+            rule: 'passage-sort-missing',
+            severity: 'error',
+            message: 'Passages have no sort value.',
+            subjects: ['p1'],
+            count: 1,
+          },
+        ],
+      });
+
+    it('shows the cached verdict without running a check', async () => {
+      // Validation costs ~0.8 ms per passage — seconds on a long text — so merely opening
+      // the tab must not trigger it.
+      seed(blocked());
+
+      await renderPanel();
+
+      expect(
+        await screen.findByText('1 rule, 1 blocking publication'),
+      ).toBeTruthy();
+      expect(mockGetPublishReadiness).not.toHaveBeenCalled();
+    });
+
+    it('says when the cached verdict was recorded', async () => {
+      seed(blocked());
+
+      await renderPanel();
+
+      expect(await screen.findByText(/^Checked /)).toBeTruthy();
+    });
+
+    it('offers a check, and no verdict, when the work has never been checked', async () => {
+      mockGetPublishStatus.mockResolvedValue(null);
+
+      await renderPanel();
+
+      expect(await screen.findByText('Not checked')).toBeTruthy();
+      expect(screen.queryByText(/blocking publication/i)).toBeNull();
+      expect(mockGetPublishReadiness).not.toHaveBeenCalled();
+    });
+
+    it('treats a superseded verdict as no verdict', async () => {
+      // Checked, then edited. Showing the old answer as current is the failure this whole
+      // view exists to avoid, so it is presented exactly like never-checked.
+      mockGetPublishStatus.mockResolvedValue({
+        ...cached(blocked()),
+        stale: true,
+        draftTouchedAt: '2026-08-04T12:00:00.000Z',
+      });
+
+      await renderPanel();
+
+      expect(await screen.findByText('Not checked')).toBeTruthy();
+      expect(screen.queryByText('1 rule, 1 blocking publication')).toBeNull();
+    });
+
+    it('validates when the editor asks, and then shows the result', async () => {
+      mockGetPublishStatus.mockResolvedValue(null);
+      mockGetPublishReadiness.mockResolvedValue(blocked());
+
+      await renderPanel();
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Run check' }),
+      );
+
+      expect(
+        await screen.findByText('1 rule, 1 blocking publication'),
+      ).toBeTruthy();
+      expect(mockGetPublishReadiness).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-checks a cached verdict on request', async () => {
+      seed(blocked());
+
+      await renderPanel();
+      await screen.findByText('1 rule, 1 blocking publication');
+
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Re-check' }),
+      );
+
+      await waitFor(() =>
+        expect(mockGetPublishReadiness).toHaveBeenCalledTimes(1),
+      );
     });
   });
 });

--- a/libs/lib-editing/src/lib/components/shared/PublishChecksPanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/PublishChecksPanel.tsx
@@ -15,6 +15,7 @@ import {
   createGraphQLClient,
   getFindingLocations,
   getPublishReadiness,
+  getPublishStatus,
   isReadinessUndetermined,
   type FindingLocation,
   type PublishFinding,
@@ -24,11 +25,12 @@ import { cn } from '@eightyfourthousand/lib-utils';
 import {
   CircleAlertIcon,
   CircleCheckIcon,
+  CircleDashedIcon,
   CircleHelpIcon,
   RotateCwIcon,
   TriangleAlertIcon,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigation } from './NavigationProvider';
 import { locationForPassageType, type PanelName, type TabName } from './types';
 
@@ -265,40 +267,61 @@ export const PublishChecksPanel = ({ workUuid }: { workUuid: string }) => {
   );
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
-  // Bumping this re-runs the effect. The check lives entirely inside the effect so it can
-  // be cancelled: validation of a large work takes tens of seconds, easily long enough for
-  // the editor to switch works first, and a late response must not overwrite the new one.
-  const [checkNonce, setCheckNonce] = useState(0);
+  const [checking, setChecking] = useState(false);
+  // When the displayed verdict was recorded, and whether it came from the cache. Null while
+  // there is no verdict to show.
+  const [checkedAt, setCheckedAt] = useState<string | null>(null);
 
-  const runCheck = useCallback(() => setCheckNonce((n) => n + 1), []);
+  const applyFindings = useCallback(
+    async (findings: PublishFinding[], cancelled: () => boolean) => {
+      const subjects = findings.flatMap((finding) => finding.subjects ?? []);
+      const resolved = await getFindingLocations({
+        client,
+        work: workUuid,
+        uuids: subjects,
+      });
+      if (cancelled()) {
+        return;
+      }
+      setLocations(new Map(resolved.map((entry) => [entry.uuid, entry])));
+    },
+    [client, workUuid],
+  );
 
+  // Opening the tab reads the cached verdict and stops there. Validating costs roughly
+  // 0.8 ms per passage — seconds on a large work — so it happens when an editor asks for
+  // it, not because a tab was opened.
+  //
+  // A row that is absent, or whose verdict predates the latest edit, yields no readiness at
+  // all rather than a stale one. Showing a superseded answer as though it still held is the
+  // failure this whole feature is built to avoid.
   useEffect(() => {
     let cancelled = false;
+    const isCancelled = () => cancelled;
 
     (async () => {
       setLoading(true);
       setFailed(false);
+      setReadiness(null);
+      setCheckedAt(null);
+      setLocations(new Map());
 
-      const result = await getPublishReadiness({ client, work: workUuid });
+      const status = await getPublishStatus({ client, work: workUuid });
       if (cancelled) {
         return;
       }
-      setReadiness(result);
-      setFailed(!result);
 
-      if (result) {
-        const subjects = [...result.errors, ...result.warnings].flatMap(
-          (finding) => finding.subjects ?? [],
-        );
-        const resolved = await getFindingLocations({
-          client,
-          work: workUuid,
-          uuids: subjects,
+      if (status && status.checkedAt !== null && !status.stale) {
+        setReadiness({
+          ok: !!status.ok,
+          errors: status.errors,
+          warnings: status.warnings,
         });
+        setCheckedAt(status.checkedAt);
+        await applyFindings([...status.errors, ...status.warnings], isCancelled);
         if (cancelled) {
           return;
         }
-        setLocations(new Map(resolved.map((entry) => [entry.uuid, entry])));
       }
 
       setLoading(false);
@@ -307,7 +330,40 @@ export const PublishChecksPanel = ({ workUuid }: { workUuid: string }) => {
     return () => {
       cancelled = true;
     };
-  }, [client, workUuid, checkNonce]);
+  }, [client, workUuid, applyFindings]);
+
+  // The live check, run only on request. Kept cancellable because validating a large work
+  // takes seconds, easily long enough for the editor to move on first, and a late response
+  // must not overwrite whatever they moved to.
+  const cancelledRef = useRef(false);
+  useEffect(() => {
+    cancelledRef.current = false;
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, [workUuid]);
+
+  const runCheck = useCallback(async () => {
+    setChecking(true);
+    setFailed(false);
+
+    const result = await getPublishReadiness({ client, work: workUuid });
+    if (cancelledRef.current) {
+      return;
+    }
+    setReadiness(result);
+    setFailed(!result);
+    setCheckedAt(result ? new Date().toISOString() : null);
+
+    if (result) {
+      await applyFindings(
+        [...result.errors, ...result.warnings],
+        () => cancelledRef.current,
+      );
+    }
+
+    setChecking(false);
+  }, [client, workUuid, applyFindings]);
 
   const onNavigate = useCallback(
     (location: FindingLocation) => {
@@ -339,8 +395,42 @@ export const PublishChecksPanel = ({ workUuid }: { workUuid: string }) => {
         <MutedText className="text-sm">
           {'The publish check could not be run for this work.'}
         </MutedText>
-        <Button size="sm" variant="outline" className="mt-3" onClick={runCheck}>
-          {'Try again'}
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-3"
+          disabled={checking}
+          onClick={runCheck}
+        >
+          {checking ? 'Checking…' : 'Try again'}
+        </Button>
+      </div>
+    );
+  }
+
+  // No verdict that describes the work as it stands: either never checked, or checked and
+  // then edited. Both are offered a check rather than shown an answer, because a superseded
+  // verdict presented as current is the one failure this view must not have.
+  if (!readiness) {
+    return (
+      <div className="py-4">
+        <div className="flex items-center gap-2">
+          <CircleDashedIcon className="size-4 text-muted-foreground" />
+          <span className="text-sm font-semibold">{'Not checked'}</span>
+        </div>
+        <MutedText className="mt-2 block text-sm">
+          {
+            'Nothing has been checked for this work since it was last edited. Running the check reads every annotation, so it can take a few seconds on a long text.'
+          }
+        </MutedText>
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-3"
+          disabled={checking}
+          onClick={runCheck}
+        >
+          {checking ? 'Checking…' : 'Run check'}
         </Button>
       </div>
     );
@@ -361,8 +451,14 @@ export const PublishChecksPanel = ({ workUuid }: { workUuid: string }) => {
             'The glossary index is not populated, so glossary references cannot be verified. This says nothing about whether the work is publishable — it is the check that is unavailable, not the work that is broken.'
           }
         </MutedText>
-        <Button size="sm" variant="outline" className="mt-3" onClick={runCheck}>
-          {'Check again'}
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-3"
+          disabled={checking}
+          onClick={runCheck}
+        >
+          {checking ? 'Checking…' : 'Check again'}
         </Button>
       </div>
     );
@@ -390,10 +486,24 @@ export const PublishChecksPanel = ({ workUuid }: { workUuid: string }) => {
               : `${errors.length} ${errors.length === 1 ? 'rule' : 'rules'}, ${errorOccurrences} blocking publication`}
           </span>
         </div>
-        <Button size="icon" variant="ghost" onClick={runCheck}>
-          <RotateCwIcon />
+        <Button
+          size="icon"
+          variant="ghost"
+          disabled={checking}
+          aria-label={checking ? 'Checking' : 'Re-check'}
+          onClick={runCheck}
+        >
+          <RotateCwIcon className={cn(checking && 'animate-spin')} />
         </Button>
       </div>
+
+      {/* Says when, because this verdict is usually read from cache rather than produced
+          just now — and a reader who assumes it is live would misjudge how current it is. */}
+      {checkedAt && (
+        <MutedText className="-mt-2 text-xs">
+          {`Checked ${new Date(checkedAt).toLocaleString()}`}
+        </MutedText>
+      )}
 
       <Separator className="bg-border" />
 

--- a/libs/lib-publishing/src/lib/publish-status.ts
+++ b/libs/lib-publishing/src/lib/publish-status.ts
@@ -90,6 +90,35 @@ export const readPublishStatuses = async ({
 };
 
 /**
+ * One work's cached status, or null if it has never been written to.
+ *
+ * Unlike `readPublishStatuses` this carries the findings themselves, because the per-work
+ * view renders them. It is what the editor's publishing tab reads on open: validating costs
+ * roughly 0.8 ms per passage and up to several seconds on the largest works, which is not a
+ * price to pay for merely looking at a tab.
+ */
+export const readPublishStatus = async ({
+  client,
+  workUuid,
+}: {
+  client: DataClient;
+  workUuid: string;
+}): Promise<WorkPublishStatus | null> => {
+  const { data, error } = await client
+    .from('work_publish_status')
+    .select(STATUS_COLUMNS)
+    .eq('work_uuid', workUuid)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Error reading publish status:', error);
+    return null;
+  }
+
+  return data ? fromRow(data as WorkPublishStatusRow) : null;
+};
+
+/**
  * Validates a work and caches the result, returning the live result.
  *
  * This is `validateWork` plus a write: the rules are still `validate_work_for_publish`, so


### PR DESCRIPTION
### Summary

The publishing tab ran a full validation on every open. It now reads the cached verdict — one indexed lookup — and validates only when asked.

### Linear

- [DEV-718](https://linear.app/84000/issue/DEV-718) (follow-up)