### PR TITLE
Handle passages sharing a label or a sort when renumbering endnotes

### DIFF
--- a/libs/data-access/src/lib/passage/save.spec.ts
+++ b/libs/data-access/src/lib/passage/save.spec.ts
@@ -35,6 +35,8 @@ class FakeQueryBuilder {
   private eqType?: string;
   private eqWorkUuid?: string;
   private gtSort?: number;
+  private gteSort?: number;
+  private rowLimit?: number;
   private filterContentUuid?: string;
 
   constructor(
@@ -123,11 +125,19 @@ class FakeQueryBuilder {
     return this;
   }
 
+  gte(column: string, value: number) {
+    if (column === 'sort') {
+      this.gteSort = value;
+    }
+    return this;
+  }
+
   order() {
     return this;
   }
 
-  limit() {
+  limit(value?: number) {
+    this.rowLimit = value;
     return this;
   }
 
@@ -142,7 +152,7 @@ class FakeQueryBuilder {
     }
 
     if (this.table === 'passages') {
-      return this.gtSort !== undefined
+      return this.gtSort !== undefined || this.gteSort !== undefined
         ? 'select:passages:renumber'
         : 'select:passages';
     }
@@ -213,15 +223,26 @@ class FakeQueryBuilder {
       };
     }
 
-    if (this.eqWorkUuid !== undefined && this.gtSort !== undefined) {
+    if (
+      this.eqWorkUuid !== undefined &&
+      (this.gtSort !== undefined || this.gteSort !== undefined)
+    ) {
       const gtSort = this.gtSort;
+      const gteSort = this.gteSort;
+      const matching = this.state.passages
+        .filter(
+          (passage) =>
+            passage.work_uuid === this.eqWorkUuid &&
+            (gtSort !== undefined
+              ? passage.sort > gtSort
+              : passage.sort >= (gteSort as number)),
+        )
+        .sort((a, b) => a.sort - b.sort);
       return {
-        data: this.state.passages
-          .filter(
-            (passage) =>
-              passage.work_uuid === this.eqWorkUuid && passage.sort > gtSort,
-          )
-          .sort((a, b) => a.sort - b.sort),
+        data:
+          this.rowLimit === undefined
+            ? matching
+            : matching.slice(0, this.rowLimit),
         error: null,
       };
     }
@@ -733,6 +754,54 @@ describe('savePassagesWithDeletions failure propagation', () => {
         { uuid: 'n4-141', label: 'n.5' },
         { uuid: 'n5', label: 'n.6' },
       ]);
+    });
+
+    // Paging read the next page with `sort > lastSort`, which drops any row
+    // sharing the last row's sort — and per-text variants of one label routinely
+    // share a sort. Only reachable past a full page, so this fills one exactly.
+    it('does not skip passages sharing the sort of the last paged row', async () => {
+      const pageSize = 500;
+      const passages: PassageRowDTO[] = [];
+
+      // A full page of notes each holding the label of the note before it, so
+      // every one of them needs renumbering and the walk cannot exit early.
+      for (let i = 0; i < pageSize; i++) {
+        passages.push(endnoteRow(`bulk-${i}`, `n.${843 + i}`, 844 + i));
+      }
+      const lastPagedSort = 844 + pageSize - 1;
+      const lastPagedLabel = `n.${843 + pageSize - 1}`;
+      // The final row of the page and a per-text variant of it share a sort, so
+      // the variant falls on page two.
+      passages[pageSize - 1] = {
+        ...passages[pageSize - 1],
+        toh: 'toh526',
+      };
+      passages.push({
+        ...endnoteRow('variant-sharing-sort', lastPagedLabel, lastPagedSort),
+        toh: 'toh916',
+      });
+
+      const state = createState({ passages });
+
+      const result = await savePassagesWithDeletions({
+        client: createFakeClient(state),
+        passages: [insertedNote],
+      });
+
+      expect(result.success).toBe(true);
+      const renumbered = new Map(
+        result.renumberedPassages.map((row) => [row.uuid, row.label]),
+      );
+
+      // It took more than one page to get there...
+      expect(
+        state.ops.filter((op) => op === 'select:passages:renumber').length,
+      ).toBeGreaterThan(1);
+      // ...and the variant landed on the same number as the sibling it shares a
+      // slot with, rather than being read past and left stale.
+      const siblingLabel = renumbered.get(`bulk-${pageSize - 1}`);
+      expect(siblingLabel).toBe(`n.${844 + pageSize - 1}`);
+      expect(renumbered.get('variant-sharing-sort')).toBe(siblingLabel);
     });
 
     it('omits passages returned in `passages` from `renumberedPassages`', async () => {

--- a/libs/data-access/src/lib/passage/save.ts
+++ b/libs/data-access/src/lib/passage/save.ts
@@ -55,12 +55,22 @@ async function normalizePassageLabelsAfter({
   let previousToh: unknown = null;
   let previousAssignedLabel: string | undefined;
 
+  // Passages can share a sort — per-text variants of one label routinely do —
+  // so paging with `sort > lastSort` silently drops the ones that share the
+  // last row of a page. Pages after the first are fetched with `>=` and the
+  // rows already handled are skipped by uuid instead.
+  const processedUuids = new Set<string>();
+  let isFirstPage = true;
+
   while (!done) {
-    const { data, error } = await client
+    const query = client
       .from('passages')
       .select('uuid, label, sort, toh')
-      .eq('work_uuid', workUuid)
-      .gt('sort', lastSort)
+      .eq('work_uuid', workUuid);
+
+    const { data, error } = await (
+      isFirstPage ? query.gt('sort', lastSort) : query.gte('sort', lastSort)
+    )
       .order('sort', { ascending: true })
       .limit(SAVE_PAGE_SIZE);
 
@@ -73,7 +83,15 @@ async function normalizePassageLabelsAfter({
     const labelUpdates: { uuid: string; label: string }[] = [];
     const prefixRenames: { oldPrefix: string; newPrefix: string }[] = [];
 
+    let newRowsThisPage = 0;
+
     for (const row of data) {
+      if (processedUuids.has(row.uuid)) {
+        continue;
+      }
+      processedUuids.add(row.uuid);
+      newRowsThisPage++;
+
       const rowParts = (row.label ?? '').split('.');
 
       if (rowParts.length < depth || !row.label?.startsWith(prefix)) {
@@ -158,7 +176,19 @@ async function normalizePassageLabelsAfter({
     }
 
     if (done || data.length < SAVE_PAGE_SIZE) break;
+
+    // A full page of rows already handled means every row shares one sort and
+    // the `>=` re-read cannot advance. Stop rather than loop forever; a single
+    // sort holding 500+ passages is malformed data, not a case to page through.
+    if (newRowsThisPage === 0) {
+      console.error(
+        `Passage label normalization stalled at sort ${lastSort} for work ${workUuid}: a full page of passages shares one sort.`,
+      );
+      break;
+    }
+
     lastSort = data[data.length - 1].sort;
+    isFirstPage = false;
   }
 
   return { renumbered };

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/endnote-utils.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/endnote-utils.spec.ts
@@ -238,6 +238,87 @@ describe('insertEndnotePassage', () => {
     ]);
   });
 
+  // The anchor is whichever variant the preceding link happened to point at, so
+  // it can be any member of its slot. The new note has to land outside the whole
+  // slot, never between two variants of one number.
+  it('inserts after every variant when the anchor is the first of its slot', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'n3', label: 'n.3', sort: 3 },
+      { uuid: 'n4-916', label: 'n.4', sort: 4, toh: 'toh916' },
+      { uuid: 'n4-526', label: 'n.4', sort: 5, toh: 'toh526' },
+      { uuid: 'n5', label: 'n.5', sort: 6 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.5',
+        // What the caller derives from the anchor alone — one short of clearing
+        // the slot.
+        sort: 5,
+        uuid: 'new',
+        afterPassageUuid: 'n4-916',
+      }),
+    ).toBe(true);
+
+    expect(passages()).toEqual([
+      ['n.3', 3, 'n3'],
+      ['n.4', 4, 'n4-916'],
+      ['n.4', 5, 'n4-526'],
+      ['n.5', 6, 'new'],
+      ['n.6', 7, 'n5'],
+    ]);
+  });
+
+  it('inserts before every variant when the anchor is later in its slot', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'n3', label: 'n.3', sort: 3 },
+      { uuid: 'n4-916', label: 'n.4', sort: 4, toh: 'toh916' },
+      { uuid: 'n4-526', label: 'n.4', sort: 5, toh: 'toh526' },
+      { uuid: 'n5', label: 'n.5', sort: 6 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.4',
+        sort: 5,
+        uuid: 'new',
+        beforePassageUuid: 'n4-526',
+      }),
+    ).toBe(true);
+
+    expect(passages()).toEqual([
+      ['n.3', 3, 'n3'],
+      ['n.4', 4, 'new'],
+      ['n.5', 5, 'n4-916'],
+      ['n.5', 6, 'n4-526'],
+      ['n.6', 7, 'n5'],
+    ]);
+  });
+
+  // Two `toh`-less notes sharing a label are not a slot — that is a transient
+  // duplicate, e.g. one the client has renumbered while the next is still
+  // stale. Treating it as a slot would place the new note past a note that
+  // ought to follow it.
+  it('does not treat two toh-less notes sharing a label as one slot', () => {
+    const { editor, passages } = createEditor([
+      { uuid: 'n842', label: 'n.842', sort: 842 },
+      { uuid: 'renumbered', label: 'n.843', sort: 843 },
+      { uuid: 'stale', label: 'n.843', sort: 844 },
+    ]);
+
+    expect(
+      insertEndnotePassage(editor, {
+        label: 'n.844',
+        sort: 844,
+        uuid: 'new',
+        afterPassageUuid: 'renumbered',
+      }),
+    ).toBe(true);
+
+    const order = passages().map(([, , uuid]) => uuid);
+    expect(order).toEqual(['n842', 'renumbered', 'new', 'stale']);
+  });
+
   it('leaves endnotesHeader labels alone while still shifting their sort', () => {
     const { editor, passages } = createEditor([
       { uuid: 'a', label: 'n.1', sort: 1 },

--- a/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/endnote-utils.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/EndNoteLink/endnote-utils.ts
@@ -1,4 +1,5 @@
 import { Editor } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { incrementLabel } from '../Passage/label';
 import { findPassageNode } from '../../util';
 
@@ -139,6 +140,79 @@ export function getFirstEndnoteInEditor(
   return first;
 }
 
+/** A passage node paired with its position, in document order. */
+type PositionedPassage = {
+  pos: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  node: any;
+};
+
+/** Every passage node in `doc`, in document order. */
+function collectPassages(doc: ProseMirrorNode): PositionedPassage[] {
+  const passages: PositionedPassage[] = [];
+  doc.descendants((node, pos) => {
+    if (node.type.name === 'passage') {
+      passages.push({ pos, node });
+    }
+    return true;
+  });
+  return passages;
+}
+
+/**
+ * Whether two passages are per-text variants of the same numbered slot: they
+ * share a label and both name a Tohoku text. A passage with no `toh` applies to
+ * every text in the work and so always stands alone in its slot — which is also
+ * what keeps a transiently duplicated label from being mistaken for a variant
+ * (a passage the client has just renumbered briefly shares a label with the
+ * stale passage behind it).
+ *
+ * The single definition of slot membership: positioning and both renumber loops
+ * go through it so they cannot drift apart.
+ */
+export function inSameSlot(
+  label: unknown,
+  toh: unknown,
+  otherLabel: unknown,
+  otherToh: unknown,
+): boolean {
+  return (
+    label === otherLabel && (toh ?? null) !== null && (otherToh ?? null) !== null
+  );
+}
+
+const isSameSlot = (a: PositionedPassage, b: PositionedPassage): boolean =>
+  inSameSlot(
+    a.node.attrs.label,
+    a.node.attrs.toh,
+    b.node.attrs.label,
+    b.node.attrs.toh,
+  );
+
+/**
+ * The run of passages around `index` that all belong to its slot, in document
+ * order. A passage that shares no slot returns just itself.
+ */
+function slotMembers(
+  passages: PositionedPassage[],
+  index: number,
+): PositionedPassage[] {
+  let start = index;
+  while (start > 0 && isSameSlot(passages[start - 1], passages[index])) {
+    start--;
+  }
+
+  let end = index;
+  while (
+    end < passages.length - 1 &&
+    isSameSlot(passages[end + 1], passages[index])
+  ) {
+    end++;
+  }
+
+  return passages.slice(start, end + 1);
+}
+
 /**
  * Insert a new empty endnote passage into the endnotes editor at the correct
  * position. Use `afterPassageUuid` to insert after a passage, or
@@ -152,6 +226,12 @@ export function getFirstEndnoteInEditor(
  * is named but absent, this returns `false` without touching the doc rather
  * than appending to the end of the loaded window: a misplaced insert leaves
  * the new note with a label that duplicates a note further down the series.
+ *
+ * An anchor may be one of several per-text variants sharing a label (see
+ * `slotMembers`). The insert lands outside the whole slot — after its last
+ * member, or before its first — never between two variants of one number, and
+ * `sort` is advanced past the slot when needed so the new passage sorts outside
+ * it too.
  *
  * Returns whether the passage was inserted.
  */
@@ -181,27 +261,31 @@ export function insertEndnotePassage(
     return false;
   }
 
-  const newPassage = passageType.create(
-    { label, sort, uuid, type: 'endnotes' },
-    paragraphType.create(),
-  );
-
   // Find insertion position. An anchor that isn't in the loaded window is a
   // hard failure, not a reason to append — see the doc comment above.
   const anchorUuid = beforePassageUuid ?? afterPassageUuid;
   let insertPos = anchorUuid ? -1 : state.doc.content.size;
+  let insertSort = sort;
+
   if (anchorUuid) {
-    state.doc.descendants((node, pos) => {
-      if (insertPos !== -1) {
-        return false;
+    const passages = collectPassages(state.doc);
+    const anchorIndex = passages.findIndex(
+      (passage) => passage.node.attrs.uuid === anchorUuid,
+    );
+
+    if (anchorIndex !== -1) {
+      const slot = slotMembers(passages, anchorIndex);
+
+      if (anchorUuid === beforePassageUuid) {
+        const first = slot[0];
+        insertPos = first.pos;
+        insertSort = Math.min(insertSort, first.node.attrs.sort ?? insertSort);
+      } else {
+        const last = slot[slot.length - 1];
+        insertPos = last.pos + last.node.nodeSize;
+        insertSort = Math.max(insertSort, (last.node.attrs.sort ?? 0) + 1);
       }
-      if (node.type.name === 'passage' && node.attrs.uuid === anchorUuid) {
-        insertPos =
-          anchorUuid === beforePassageUuid ? pos : pos + node.nodeSize;
-        return false;
-      }
-      return true;
-    });
+    }
   }
 
   if (insertPos === -1) {
@@ -210,6 +294,11 @@ export function insertEndnotePassage(
     );
     return false;
   }
+
+  const newPassage = passageType.create(
+    { label, sort: insertSort, uuid, type: 'endnotes' },
+    paragraphType.create(),
+  );
 
   tr.insert(insertPos, newPassage);
 
@@ -249,12 +338,10 @@ export function insertEndnotePassage(
       });
     } else {
       const childToh = child.attrs.toh ?? null;
-      const isSameSlot =
+      const sameSlot =
         previousLabel !== undefined &&
-        childLabel === previousLabel &&
-        childToh !== null &&
-        previousToh !== null;
-      const assignedLabel = isSameSlot
+        inSameSlot(childLabel, childToh, previousLabel, previousToh);
+      const assignedLabel = sameSlot
         ? (previousAssignedLabel as string)
         : expectedNext;
 
@@ -267,7 +354,7 @@ export function insertEndnotePassage(
       previousLabel = childLabel;
       previousToh = childToh;
       previousAssignedLabel = assignedLabel;
-      if (!isSameSlot) {
+      if (!sameSlot) {
         expectedNext = incrementLabel(expectedNext);
       }
     }
@@ -371,12 +458,10 @@ export function deleteEndnotePassageNode(
       }
 
       const childToh = child.attrs.toh ?? null;
-      const isSameSlot =
+      const sameSlot =
         previousLabel !== undefined &&
-        childLabel === previousLabel &&
-        childToh !== null &&
-        previousToh !== null;
-      const assignedLabel = isSameSlot
+        inSameSlot(childLabel, childToh, previousLabel, previousToh);
+      const assignedLabel = sameSlot
         ? (previousAssignedLabel as string)
         : expectedNext;
 
@@ -390,7 +475,7 @@ export function deleteEndnotePassageNode(
       previousLabel = childLabel;
       previousToh = childToh;
       previousAssignedLabel = assignedLabel;
-      if (!isSameSlot) {
+      if (!sameSlot) {
         expectedNext = incrementLabel(expectedNext);
       }
       return true;


### PR DESCRIPTION
### Summary

Follow-up to DEV-720. Fixes assumptions that a label and a sort each belong to one passage, when per-text variants of a note share both.

### Linear

- [DEV-720](https://linear.app/84000/issue/DEV-720)