### PR TITLE
MCP: Get Tibetan source for a work

### DIFF
--- a/libs/lib-agent/src/lib/agents/library-assistant/definition.ts
+++ b/libs/lib-agent/src/lib/agents/library-assistant/definition.ts
@@ -10,6 +10,7 @@ export const libraryAssistant: AgentDefinition = {
     'get-translation',
     'get-passage',
     'get-translation-passages',
+    'get-translation-folios',
     'search-translation',
     'get-glossary-term',
     'list-glossary-terms',

--- a/libs/lib-agent/src/lib/agents/library-assistant/prompt.md
+++ b/libs/lib-agent/src/lib/agents/library-assistant/prompt.md
@@ -5,6 +5,7 @@ You are a research assistant for the 84000 library — a long-term initiative to
 ## Content available
 
 - **Translations** — published translations of canonical Tibetan texts, each containing structured passages (title pages, homage, body, colophon, notes, etc.)
+- **Folios** — the Tibetan source text a translation was made from, paginated by volume, folio number, and side
 - **Glossary** — standardized terms with names in multiple languages (Sanskrit, Tibetan, English, Chinese), definitions, and attestations across translations
 - **Bibliographies** — source references and scholarly citations associated with each work
 - **Imprints** — publication metadata (edition, license, revision history)
@@ -26,7 +27,8 @@ Works can be looked up by **UUID** or **Tohoku catalog number** (e.g. "toh1", "t
 ## Typical workflows
 
 1. **Find a text**: `get-translation` by Tohoku number → review metadata → `get-translation-passages` for content
-2. **Research a term**: `search-glossary-terms` → `get-glossary-term` for full definition → `get-glossary-instances` for usage across translations
-3. **Explore a topic**: `search-translation` within a specific work → cross-reference with glossary
-4. **Check sources**: `list-work-bibliographies` → `get-bibliography-entry` for full citation details
-5. **Understand structure**: `get-toc` for hierarchical overview → `get-passage` for specific sections
+2. **Consult the source**: `get-translation-folios` by Tohoku number → compare the Tibetan folio text against the translation
+3. **Research a term**: `search-glossary-terms` → `get-glossary-term` for full definition → `get-glossary-instances` for usage across translations
+4. **Explore a topic**: `search-translation` within a specific work → cross-reference with glossary
+5. **Check sources**: `list-work-bibliographies` → `get-bibliography-entry` for full citation details
+6. **Understand structure**: `get-toc` for hierarchical overview → `get-passage` for specific sections

--- a/libs/lib-agent/src/lib/tools/read/get-translation-folios.spec.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation-folios.spec.ts
@@ -1,0 +1,180 @@
+import { createGetTranslationFoliosTool } from './get-translation-folios';
+import type { DataClient } from '@eightyfourthousand/data-access';
+
+import {
+  getTranslationMetadataByUuid,
+  getWorkFolios,
+  getWorkFoliosAround,
+  getWorkUuidByToh,
+} from '@eightyfourthousand/data-access';
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  getTranslationMetadataByUuid: jest.fn(),
+  getWorkFolios: jest.fn(),
+  getWorkFoliosAround: jest.fn(),
+  getWorkUuidByToh: jest.fn(),
+}));
+
+const mockedSequential = jest.mocked(getWorkFolios);
+const mockedAround = jest.mocked(getWorkFoliosAround);
+const mockedUuidByToh = jest.mocked(getWorkUuidByToh);
+const mockedMetadata = jest.mocked(getTranslationMetadataByUuid);
+
+describe('get-translation-folios tool', () => {
+  const client = {} as DataClient;
+  const tool = createGetTranslationFoliosTool(client);
+  const extra = {} as Parameters<typeof tool.handler>[1];
+  const folios = [
+    { uuid: 'folio-1', content: 'བོད', volume: 1, folio: 2, side: 'a' },
+  ];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has correct metadata', () => {
+    expect(tool.name).toBe('get-translation-folios');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('requires uuid or toh', async () => {
+    const result = await tool.handler({}, extra);
+
+    expect(result.isError).toBe(true);
+    expect(mockedSequential).not.toHaveBeenCalled();
+    expect(mockedAround).not.toHaveBeenCalled();
+  });
+
+  it('paginates sequentially when uuid and toh are both provided', async () => {
+    mockedSequential.mockResolvedValue(folios as any);
+
+    const result = await tool.handler({ uuid: 'work-1', toh: 'toh417' }, extra);
+
+    expect(mockedSequential).toHaveBeenCalledWith({
+      client,
+      uuid: 'work-1',
+      toh: 'toh417',
+      page: undefined,
+      size: undefined,
+      offset: undefined,
+    });
+    expect(mockedAround).not.toHaveBeenCalled();
+    expect(mockedUuidByToh).not.toHaveBeenCalled();
+    expect(mockedMetadata).not.toHaveBeenCalled();
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
+      workUuid: 'work-1',
+      toh: 'toh417',
+      folios,
+    });
+  });
+
+  it('passes page, size, and offset through', async () => {
+    mockedSequential.mockResolvedValue(folios as any);
+
+    await tool.handler(
+      { uuid: 'work-1', toh: 'toh417', page: 3, size: 25, offset: 100 },
+      extra,
+    );
+
+    expect(mockedSequential).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 3, size: 25, offset: 100 }),
+    );
+  });
+
+  it("resolves the work's first toh when only uuid is provided", async () => {
+    mockedMetadata.mockResolvedValue({ toh: ['toh417', 'toh418'] } as any);
+    mockedSequential.mockResolvedValue(folios as any);
+
+    await tool.handler({ uuid: 'work-1' }, extra);
+
+    expect(mockedMetadata).toHaveBeenCalledWith({ client, uuid: 'work-1' });
+    expect(mockedSequential).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'work-1', toh: 'toh417' }),
+    );
+  });
+
+  it('errors when the work has no toh', async () => {
+    mockedMetadata.mockResolvedValue({ toh: [] } as any);
+
+    const result = await tool.handler({ uuid: 'work-1' }, extra);
+
+    expect(result.isError).toBe(true);
+    expect(mockedSequential).not.toHaveBeenCalled();
+  });
+
+  it('resolves the work uuid when only toh is provided', async () => {
+    mockedUuidByToh.mockResolvedValue('work-1');
+    mockedSequential.mockResolvedValue(folios as any);
+
+    await tool.handler({ toh: 'toh417' }, extra);
+
+    expect(mockedUuidByToh).toHaveBeenCalledWith({ client, toh: 'toh417' });
+    expect(mockedMetadata).not.toHaveBeenCalled();
+    expect(mockedSequential).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'work-1', toh: 'toh417' }),
+    );
+  });
+
+  it('errors when no work matches the toh', async () => {
+    mockedUuidByToh.mockResolvedValue(null);
+
+    const result = await tool.handler({ toh: 'toh999999' }, extra);
+
+    expect(result.isError).toBe(true);
+    expect(mockedSequential).not.toHaveBeenCalled();
+  });
+
+  it('uses around pagination when folioUuid is provided', async () => {
+    const around = {
+      folios,
+      startIndex: 4,
+      hasMoreBefore: true,
+      hasMoreAfter: true,
+    };
+    mockedAround.mockResolvedValue(around as any);
+
+    const result = await tool.handler(
+      {
+        uuid: 'work-1',
+        toh: 'toh417',
+        folioUuid: 'folio-1',
+        before: 2,
+        after: 3,
+      },
+      extra,
+    );
+
+    expect(mockedAround).toHaveBeenCalledWith({
+      client,
+      uuid: 'work-1',
+      toh: 'toh417',
+      folioUuid: 'folio-1',
+      before: 2,
+      after: 3,
+    });
+    expect(mockedSequential).not.toHaveBeenCalled();
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
+      workUuid: 'work-1',
+      toh: 'toh417',
+      ...around,
+    });
+  });
+
+  it('errors when the target folio is not in the work', async () => {
+    mockedAround.mockResolvedValue(null);
+
+    const result = await tool.handler(
+      { uuid: 'work-1', toh: 'toh417', folioUuid: 'missing' },
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns an error result when a lookup throws', async () => {
+    mockedMetadata.mockRejectedValue(new Error('boom'));
+
+    const result = await tool.handler({ uuid: 'work-1' }, extra);
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toBe('boom');
+  });
+});

--- a/libs/lib-agent/src/lib/tools/read/get-translation-folios.ts
+++ b/libs/lib-agent/src/lib/tools/read/get-translation-folios.ts
@@ -1,0 +1,179 @@
+import { z } from 'zod';
+import type {
+  DataClient,
+  TohokuCatalogEntry,
+} from '@eightyfourthousand/data-access';
+import {
+  getTranslationMetadataByUuid,
+  getWorkFolios,
+  getWorkFoliosAround,
+  getWorkUuidByToh,
+} from '@eightyfourthousand/data-access';
+import type { McpToolDefinition } from '../../types';
+import { jsonResult, errorResult } from './util';
+
+const inputSchema = {
+  uuid: z.string().optional().describe('Work UUID — provide this or toh'),
+  toh: z
+    .string()
+    .optional()
+    .describe(
+      'Tohoku catalog number (e.g. "toh1", "toh417") naming the source edition — provide this or uuid. When omitted, the work\'s first Tohoku number is used.',
+    ),
+  page: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe('Zero-based page index (default 0)'),
+  size: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Number of folios per page (default 10)'),
+  offset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      'Absolute offset into the ordered folio list — takes precedence over page',
+    ),
+  folioUuid: z
+    .string()
+    .optional()
+    .describe(
+      'Center results around this folio UUID instead of paginating sequentially',
+    ),
+  before: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      'Folios to include before folioUuid (default 10, ignored without folioUuid)',
+    ),
+  after: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      'Folios to include after folioUuid (default 10, ignored without folioUuid)',
+    ),
+};
+
+type FolioSource = { workUuid: string; toh: TohokuCatalogEntry };
+
+/**
+ * Resolve the work UUID / Tohoku pair that folio queries require from whichever
+ * identifier the caller supplied. Folios are keyed by both, so a missing half is
+ * looked up: uuid from the Tohoku number, or Tohoku number from the work. A work
+ * can carry several Tohoku numbers — the first is used, so callers pin a
+ * specific source edition by passing `toh` explicitly.
+ */
+async function resolveFolioSource({
+  client,
+  uuid,
+  toh,
+}: {
+  client: DataClient;
+  uuid?: string;
+  toh?: string;
+}): Promise<FolioSource | { error: string }> {
+  if (!uuid && !toh) {
+    return { error: 'Provide either uuid or toh.' };
+  }
+
+  // Per the guard above, toh is present whenever uuid is not.
+  const workUuid =
+    uuid ?? (await getWorkUuidByToh({ client, toh: toh as string }));
+  if (!workUuid) {
+    return { error: `No work found for toh: ${toh}` };
+  }
+
+  if (toh) {
+    return { workUuid, toh: toh as TohokuCatalogEntry };
+  }
+
+  const work = await getTranslationMetadataByUuid({ client, uuid: workUuid });
+  const [firstToh] = work?.toh ?? [];
+  if (!firstToh) {
+    return {
+      error: `No Tohoku number found for UUID: ${workUuid}. Provide toh explicitly.`,
+    };
+  }
+
+  return { workUuid, toh: firstToh };
+}
+
+/**
+ * MCP tool exposing the Tibetan source folios behind a translation, either as
+ * sequential pages or as a window centered on one folio.
+ */
+export function createGetTranslationFoliosTool(
+  client: DataClient,
+): McpToolDefinition {
+  return {
+    name: 'get-translation-folios',
+    description:
+      'Get the Tibetan source folios for a work by UUID or Tohoku number. Supports sequential pagination (page/size/offset), where a page shorter than size means the end of the work, or centering around a specific folio (folioUuid), which also reports whether more folios exist on either side.',
+    inputSchema,
+    annotations: {
+      title: 'Get Translation Folios',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    handler: async ({
+      uuid,
+      toh,
+      page,
+      size,
+      offset,
+      folioUuid,
+      before,
+      after,
+    }) => {
+      try {
+        const source = await resolveFolioSource({ client, uuid, toh });
+        if ('error' in source) {
+          return errorResult(source.error);
+        }
+
+        if (folioUuid) {
+          const around = await getWorkFoliosAround({
+            client,
+            uuid: source.workUuid,
+            toh: source.toh,
+            folioUuid,
+            before,
+            after,
+          });
+
+          if (!around) {
+            return errorResult(
+              `No folio found for UUID: ${folioUuid} in ${source.toh}`,
+            );
+          }
+
+          return jsonResult({ ...source, ...around });
+        }
+
+        const folios = await getWorkFolios({
+          client,
+          uuid: source.workUuid,
+          toh: source.toh,
+          page,
+          size,
+          offset,
+        });
+
+        return jsonResult({ ...source, folios });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorResult(message);
+      }
+    },
+  };
+}

--- a/libs/lib-agent/src/lib/tools/read/index.ts
+++ b/libs/lib-agent/src/lib/tools/read/index.ts
@@ -4,6 +4,7 @@ import type { McpToolDefinition } from '../../types';
 import { createGetTranslationTool } from './get-translation';
 import { createGetPassageTool } from './get-passage';
 import { createGetTranslationPassagesTool } from './get-translation-passages';
+import { createGetTranslationFoliosTool } from './get-translation-folios';
 import { createSearchTranslationTool } from './search-translation';
 import { createSearchEntitiesTool } from './search-entities';
 import { createGetGlossaryTermTool } from './get-glossary-term';
@@ -22,6 +23,7 @@ export function createReadTools(client: DataClient): McpToolDefinition[] {
     createGetTranslationTool(client),
     createGetPassageTool(client),
     createGetTranslationPassagesTool(client),
+    createGetTranslationFoliosTool(client),
     createSearchTranslationTool(client),
     createSearchEntitiesTool(client),
     createGetGlossaryTermTool(client),
@@ -40,6 +42,7 @@ export function createReadTools(client: DataClient): McpToolDefinition[] {
 export { createGetTranslationTool } from './get-translation';
 export { createGetPassageTool } from './get-passage';
 export { createGetTranslationPassagesTool } from './get-translation-passages';
+export { createGetTranslationFoliosTool } from './get-translation-folios';
 export { createSearchTranslationTool } from './search-translation';
 export { createSearchEntitiesTool } from './search-entities';
 export { createGetGlossaryTermTool } from './get-glossary-term';


### PR DESCRIPTION
### Summary

Adds a `get-translation-folios` MCP tool that returns the Tibetan source folios for a work, modeled on the existing `get-translation-passages`.

### Linear

- [DEV-727](https://linear.app/84000/issue/DEV-727)

### Notes

Folios are keyed by work UUID and Tohoku number. The tool accepts either identifier, resolves the missing half, and echoes the resolved pair so a caller can pin a source edition on later pages — multi-toh works otherwise default to their first Tohoku number.

Both retrieval modes carry over from the passages tool: sequential pages (`page`/`size`/`offset`, via `getWorkFolios`) and a window centered on one folio (`folioUuid` + `before`/`after`, via `getWorkFoliosAround`).

Also added to the `library-assistant` roster, since `resolveAgentTools` filters by name and the tool would otherwise be invisible to that agent.