### PR TITLE
Fix node-scripts env loading and extract the publish driver

### DIFF
--- a/apps/node-scripts/README.md
+++ b/apps/node-scripts/README.md
@@ -16,12 +16,18 @@ backfills used to live here and was removed in DEV-719.
 
 ## Prerequisites
 
-Create a `.env` file with:
+Create `apps/node-scripts/.env` with:
 
 ```env
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
 ```
+
+`src/load-env.ts` loads it, resolving the path relative to itself rather than to the
+working directory — these scripts are run from the repo root, so dotenv's default lookup
+would miss the file and, because a missing file is a returned error rather than a throw,
+would do it silently. Exported environment variables still win over the file, which is how
+you point a single run at a different project without editing it.
 
 `SUPABASE_SERVICE_KEY` is also accepted as a fallback, so an existing `.env` that predates
 the rename keeps working. Either way it must

--- a/apps/node-scripts/src/load-env.ts
+++ b/apps/node-scripts/src/load-env.ts
@@ -1,0 +1,29 @@
+/**
+ * Loads `apps/node-scripts/.env` into the environment.
+ *
+ * Imported for its side effect and nothing else, so it belongs first in a script's import
+ * list — though in practice any top-level position works, since credentials are read when
+ * `createServiceRoleClient()` is called rather than at import time.
+ *
+ * The path is resolved relative to this module rather than left to dotenv's default. These
+ * scripts are documented as being run from the repo root:
+ *
+ *   npx tsx --tsconfig tsconfig.base.json apps/node-scripts/src/<script>.ts
+ *
+ * so `process.cwd()` is the repo root, not this directory, and the default lookup would
+ * miss the file — silently, because a missing file is a returned error object, not a throw.
+ *
+ * Real environment variables win: dotenv does not overwrite anything already set, so an
+ * exported `SUPABASE_URL` still beats the file. That ordering matters here, since it is
+ * what lets an operator point a run at a different project without editing the file.
+ */
+
+import { config } from 'dotenv';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+config({
+  path: join(dirname(fileURLToPath(import.meta.url)), '..', '.env'),
+  // The startup banner is noise in an operational command's output.
+  quiet: true,
+});

--- a/apps/node-scripts/src/publish-work.ts
+++ b/apps/node-scripts/src/publish-work.ts
@@ -12,6 +12,7 @@
  *   ... toh251 --check        # validate only, publish nothing
  */
 
+import './load-env';
 import {
   createServiceRoleClient,
   drivePublish,

--- a/apps/node-scripts/src/publish-work.ts
+++ b/apps/node-scripts/src/publish-work.ts
@@ -14,10 +14,8 @@
 
 import {
   createServiceRoleClient,
-  getJob,
+  drivePublish,
   resolveWork,
-  startPublish,
-  tickJob,
   validateWork,
 } from '@eightyfourthousand/lib-publishing/ssr';
 import { formatFindings } from '@eightyfourthousand/lib-publishing';
@@ -62,68 +60,40 @@ const main = async () => {
     return;
   }
 
-  const started = await startPublish({
+  // The CLI has no serverless time limit, so it drives the job all the way to completion
+  // rather than relying on an after() continuation.
+  const result = await drivePublish({
     client,
     options: {
       work,
       version: flag(args, 'version'),
       notes: flag(args, 'notes'),
     },
+    onProgress: (job) => console.log(`  ... ${job.phase} (job ${job.uuid})`),
   });
 
-  if (!started.ok) {
-    if (started.reason === 'work-not-found') {
+  if (!result.ok) {
+    if (result.reason === 'work-not-found') {
       console.error(`No work found for "${work}".`);
+    } else if (result.reason === 'already-running') {
+      console.error(
+        `A publish is already running for "${work}" ` +
+          `(job ${result.job.uuid}, phase ${result.job.phase}).`,
+      );
     } else {
       console.error(
-        `A publish is already running for "${work}"` +
-          (started.job ? ` (job ${started.job.uuid}, phase ${started.job.phase}).` : '.'),
+        `Publish job ${result.job.uuid} made no progress across successive ticks ` +
+          `(phase ${result.job.phase}). Another process may hold its lease; re-run to resume.`,
       );
     }
     process.exit(1);
   }
 
-  let { job, done } = started.result;
+  const final = result.job;
 
-  if (job.warnings.length) {
-    console.warn(`\n${formatFindings(job.warnings)}\n`);
+  if (final.warnings.length) {
+    console.warn(`\n${formatFindings(final.warnings)}\n`);
   }
-
-  // Unlike a serverless invocation, the CLI has no time limit, so it drives the job all the
-  // way to completion rather than relying on an after() continuation.
-  //
-  // The stall guard is not paranoia: a tick that cannot claim the job (someone else holds
-  // the lease) legitimately returns `done: false` having done nothing, and without this the
-  // loop becomes a hot spin. Progress is measured by the phase/cursor actually moving.
-  const MAX_STALLED_TICKS = 3;
-  let stalled = 0;
-  let signature = '';
-
-  while (!done) {
-    const next = `${job.phase}:${JSON.stringify(job.cursor)}:${job.files.length}`;
-    if (next === signature) {
-      stalled += 1;
-      if (stalled >= MAX_STALLED_TICKS) {
-        console.error(
-          `Publish job ${job.uuid} made no progress across ${MAX_STALLED_TICKS} ticks ` +
-            `(phase ${job.phase}). Another process may hold its lease; re-run to resume.`,
-        );
-        process.exit(1);
-      }
-      // Wait out a lease held by a concurrent tick rather than spinning against it.
-      await new Promise((resolve) => setTimeout(resolve, 2_000));
-    } else {
-      stalled = 0;
-      signature = next;
-      console.log(`  ... ${job.phase} (job ${job.uuid})`);
-    }
-
-    const result = await tickJob({ client, jobUuid: job.uuid });
-    job = result.job;
-    done = result.done;
-  }
-
-  const final = (await getJob({ client, jobUuid: job.uuid })) ?? job;
 
   if (final.status === 'failed') {
     if (final.errors.length) {

--- a/apps/node-scripts/src/rebuild-published-version.ts
+++ b/apps/node-scripts/src/rebuild-published-version.ts
@@ -17,6 +17,7 @@
  *   npx tsx --tsconfig tsconfig.base.json apps/node-scripts/src/rebuild-published-version.ts --verify --gc
  */
 
+import './load-env';
 import {
   createServiceRoleClient,
   rebuildPublishedVersion,

--- a/libs/lib-publishing/src/lib/publish/drive.spec.ts
+++ b/libs/lib-publishing/src/lib/publish/drive.spec.ts
@@ -1,0 +1,161 @@
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { drivePublish } from './drive';
+import { getJob } from '../jobs';
+import { startPublish } from './start';
+import { tickJob } from './tick';
+import type { PublishJob, PublishPhase } from '../types';
+
+jest.mock('../jobs', () => ({ getJob: jest.fn() }));
+jest.mock('./start', () => ({ startPublish: jest.fn() }));
+jest.mock('./tick', () => ({ tickJob: jest.fn(), DEFAULT_TICK_BUDGET_MS: 20_000 }));
+
+const mockGetJob = getJob as jest.MockedFunction<typeof getJob>;
+const mockStartPublish = startPublish as jest.MockedFunction<typeof startPublish>;
+const mockTickJob = tickJob as jest.MockedFunction<typeof tickJob>;
+
+const job = (overrides: Partial<PublishJob> = {}): PublishJob => ({
+  uuid: 'job-1',
+  workUuid: 'work-1',
+  versionUuid: null,
+  version: null,
+  status: 'running',
+  phase: 'validate' as PublishPhase,
+  cursor: {},
+  chunks: [],
+  files: [],
+  counts: {},
+  warnings: [],
+  errors: [],
+  error: null,
+  attempts: 1,
+  createdAt: '2026-08-10T00:00:00Z',
+  updatedAt: '2026-08-10T00:00:00Z',
+  finishedAt: null,
+  ...overrides,
+});
+
+const client = {} as DataClient;
+const options = { work: 'toh1' };
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('drivePublish', () => {
+  it('reports a work that does not exist', async () => {
+    mockStartPublish.mockResolvedValue({ ok: false, reason: 'work-not-found' });
+
+    expect(await drivePublish({ client, options })).toEqual({
+      ok: false,
+      reason: 'work-not-found',
+    });
+    expect(mockTickJob).not.toHaveBeenCalled();
+  });
+
+  it('reports a publish already in flight, carrying the job that holds it', async () => {
+    const running = job({ phase: 'artifact' });
+    mockStartPublish.mockResolvedValue({
+      ok: false,
+      reason: 'already-running',
+      job: running,
+    });
+
+    expect(await drivePublish({ client, options })).toEqual({
+      ok: false,
+      reason: 'already-running',
+      job: running,
+    });
+  });
+
+  it('ticks until done and returns the re-read job', async () => {
+    mockStartPublish.mockResolvedValue({
+      ok: true,
+      adopted: false,
+      result: { job: job(), done: false, advanced: [] },
+    });
+    mockTickJob.mockResolvedValue({
+      job: job({ phase: 'flip' }),
+      done: true,
+      advanced: ['flip'],
+    });
+
+    // The tick that finishes the job returns its pre-flip copy; the row carries the final
+    // status and version, so the driver must re-read rather than hand back what it has.
+    const settled = job({ phase: 'done', status: 'succeeded', version: '0.0.2' });
+    mockGetJob.mockResolvedValue(settled);
+
+    expect(await drivePublish({ client, options })).toEqual({ ok: true, job: settled });
+  });
+
+  it('falls back to the last tick when the job row cannot be re-read', async () => {
+    const finished = job({ phase: 'done', status: 'succeeded' });
+    mockStartPublish.mockResolvedValue({
+      ok: true,
+      adopted: false,
+      result: { job: finished, done: true, advanced: ['flip'] },
+    });
+    mockGetJob.mockResolvedValue(null);
+
+    expect(await drivePublish({ client, options })).toEqual({ ok: true, job: finished });
+  });
+
+  it('gives up instead of spinning when ticks stop making progress', async () => {
+    const stuck = job({ phase: 'artifact' });
+    mockStartPublish.mockResolvedValue({
+      ok: true,
+      adopted: false,
+      result: { job: stuck, done: false, advanced: [] },
+    });
+    // A tick that cannot claim the job returns `done: false` having changed nothing.
+    mockTickJob.mockResolvedValue({ job: stuck, done: false, advanced: [] });
+
+    const waits: number[] = [];
+    const result = await drivePublish({
+      client,
+      options,
+      wait: async (ms) => void waits.push(ms),
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'stalled', job: stuck });
+    expect(waits).toHaveLength(2);
+    expect(mockGetJob).not.toHaveBeenCalled();
+  });
+
+  it('keeps ticking while the cursor is still moving', async () => {
+    mockStartPublish.mockResolvedValue({
+      ok: true,
+      adopted: false,
+      result: {
+        job: job({ phase: 'artifact', cursor: { section: 'passages', offset: 0, chunk: 1 } }),
+        done: false,
+        advanced: [],
+      },
+    });
+    mockTickJob
+      .mockResolvedValueOnce({
+        job: job({
+          phase: 'artifact',
+          cursor: { section: 'passages', offset: 1000, chunk: 2 },
+        }),
+        done: false,
+        advanced: [],
+      })
+      .mockResolvedValueOnce({
+        job: job({ phase: 'done', status: 'succeeded' }),
+        done: true,
+        advanced: ['flip'],
+      });
+    mockGetJob.mockResolvedValue(job({ phase: 'done', status: 'succeeded' }));
+
+    const waits: number[] = [];
+    const result = await drivePublish({
+      client,
+      options,
+      wait: async (ms) => void waits.push(ms),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(waits).toHaveLength(0);
+    expect(mockTickJob).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/lib-publishing/src/lib/publish/drive.ts
+++ b/libs/lib-publishing/src/lib/publish/drive.ts
@@ -1,0 +1,97 @@
+/**
+ * Driving a publish job from start to finish.
+ *
+ * A serverless caller ticks once and returns, leaving an `after()` continuation to pick the
+ * job back up. A command line has no such limit and can run the job straight through, which
+ * is what both `publish-work` and the bulk initial publish need.
+ *
+ * This lives here rather than in either script so the loop — and in particular the stall
+ * guard, which is easy to get subtly wrong — has one implementation the two cannot drift
+ * apart from.
+ */
+
+import type { DataClient } from '@eightyfourthousand/data-access';
+import { getJob } from '../jobs';
+import type { PublishJob, PublishOptions } from '../types';
+import { startPublish } from './start';
+import { tickJob } from './tick';
+
+/**
+ * Ticks that may pass without progress before the driver gives up.
+ *
+ * A tick that cannot claim the job — someone else holds its lease — legitimately returns
+ * `done: false` having done nothing, so without this the loop becomes a hot spin. Progress
+ * is measured by the phase, cursor, or file count actually moving.
+ */
+const MAX_STALLED_TICKS = 3;
+
+/** How long to wait out a lease held by a concurrent tick, rather than spinning on it. */
+const STALL_WAIT_MS = 2_000;
+
+export type DrivePublishResult =
+  /** The job reached `done`. Inspect `job.status`: it may still have finished as `failed`. */
+  | { ok: true; job: PublishJob }
+  | { ok: false; reason: 'work-not-found' }
+  | { ok: false; reason: 'already-running'; job: PublishJob }
+  | { ok: false; reason: 'stalled'; job: PublishJob };
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Starts a publish and ticks it until the job is done.
+ *
+ * `onProgress` fires once per phase the job actually moves into, so a caller can log
+ * without the driver assuming anything about how it reports.
+ *
+ * Resolving with `ok: true` means the job stopped ticking, not that it succeeded — a
+ * validation hard fail is a completed job with `status: 'failed'` and findings in
+ * `job.errors`. Callers must check `status` before treating a work as published.
+ */
+export const drivePublish = async ({
+  client,
+  options,
+  onProgress,
+  wait = sleep,
+}: {
+  client: DataClient;
+  options: PublishOptions;
+  onProgress?: (job: PublishJob) => void;
+  /** Injectable so tests do not spend real time waiting out a lease. */
+  wait?: (ms: number) => Promise<unknown>;
+}): Promise<DrivePublishResult> => {
+  const started = await startPublish({ client, options });
+
+  if (!started.ok) {
+    return started.reason === 'work-not-found'
+      ? { ok: false, reason: 'work-not-found' }
+      : { ok: false, reason: 'already-running', job: started.job };
+  }
+
+  let { job, done } = started.result;
+  let stalled = 0;
+  let signature = '';
+
+  while (!done) {
+    const next = `${job.phase}:${JSON.stringify(job.cursor)}:${job.files.length}`;
+
+    if (next === signature) {
+      stalled += 1;
+      if (stalled >= MAX_STALLED_TICKS) {
+        return { ok: false, reason: 'stalled', job };
+      }
+      await wait(STALL_WAIT_MS);
+    } else {
+      stalled = 0;
+      signature = next;
+      onProgress?.(job);
+    }
+
+    const result = await tickJob({ client, jobUuid: job.uuid });
+    job = result.job;
+    done = result.done;
+  }
+
+  // Re-read rather than trusting the last tick's copy: the flip phase writes the final
+  // status, counts, and version onto the row after the tick that advanced into it.
+  return { ok: true, job: (await getJob({ client, jobUuid: job.uuid })) ?? job };
+};

--- a/libs/lib-publishing/src/lib/publish/index.ts
+++ b/libs/lib-publishing/src/lib/publish/index.ts
@@ -24,3 +24,4 @@
 export type { PhaseContext, PhaseRunner } from './context';
 export { DEFAULT_TICK_BUDGET_MS, tickJob } from './tick';
 export { startPublish, type StartPublishResult } from './start';
+export { drivePublish, type DrivePublishResult } from './drive';


### PR DESCRIPTION
### Summary

Two fixes to the publishing CLIs.

- Actually load a `.env` file when running the scripts
- Adds `drivePublish`, which starts and monitors publishing of a work

### Issue Tracking

[DEV-559](https://linear.app/84000/issue/DEV-559)
