### PR TITLE
Harden lib-persistence for production use

### DIFF
--- a/libs/lib-persistence/README.md
+++ b/libs/lib-persistence/README.md
@@ -15,8 +15,11 @@ The design follows Notion's browser-SQLite writeup. The spike set out to prove
 that SQLite was _more durable_ than IndexedDB for the unsynced-edit journal —
 and **it is not**. Measured over renderer-crash trials, SQLite, IndexedDB with
 `durability: 'strict'`, and IndexedDB with the relaxed default all lost zero
-acknowledged writes. Durability is not why this package uses SQLite. See
-`docs/spikes/dev-708-storage-durability.md`.
+acknowledged writes. Durability is not why this package uses SQLite. The full
+findings are recorded on
+[DEV-708](https://linear.app/84000/issue/DEV-708/spike-wasm-sqlite-storage-stack-durability-torture-test) —
+the spike's findings markdown was deliberately removed along with its harness, so
+the Linear issue is the record.
 
 The reasons that survived measurement:
 
@@ -95,6 +98,71 @@ payloads are: writes are last-write-wins upserts, and journal payloads are Yjs
 updates, which are idempotent on apply. A duplicated append replays harmlessly;
 a dropped one loses work.
 
+One known gap: if the browser restarts the SharedWorker, no tab re-announces
+itself, because a `MessagePort` fires no close event for a tab to notice. The
+owner tab is unaffected — its ownership comes from the Web Lock and its queries go
+to its own worker — but proxy tabs stop being introduced until they reload.
+Closing that needs a heartbeat on the coordinator port.
+
+## The journal is never swept up
+
+Two rules follow from the journal being the only copy of unsynced work, and both
+are load bearing:
+
+- **Deletes name their ids.** `clearJournal(ids)` and
+  `commitSynced(record, syncedJournalIds)` take explicit ids, never a high-water
+  mark. `journal.id` is one `AUTOINCREMENT` sequence shared by every passage, so
+  "clear everything through id N" silently deletes whatever other passages wrote
+  below N. Naming the ids makes it impossible to remove an entry the caller did
+  not just sync.
+- **No path drops the table.** The schema is split into `JOURNAL_STATEMENTS` and
+  the rebuildable rest precisely so that the recovery path below cannot touch it.
+
+## Schema versions
+
+`open()` reads `PRAGMA user_version` before writing it, and acts on what it finds:
+
+| Found                    | What happens                                          |
+| ------------------------ | ----------------------------------------------------- |
+| `0`                      | Fresh file. Create everything, stamp the version.     |
+| `SCHEMA_VERSION`         | Nothing to do.                                        |
+| Older                    | Drop and recreate the re-fetchable tables. Journal untouched. |
+| Older than `JOURNAL_LAST_CHANGED_AT` | `JournalMigrationRequiredError`.          |
+| Newer                    | `SchemaTooNewError`.                                  |
+
+The rebuild works because every table except `journal` is a local copy of server
+state, so a stale schema is fixed by re-fetching. That is why there is no
+per-version migration list: it would be dead code for tables that can always be
+thrown away. The seam that _does_ need hand-written migrations is the journal, and
+`JOURNAL_LAST_CHANGED_AT` is what forces the issue — raise it when the journal's
+columns change and the open refuses rather than guessing.
+
+Refusing a newer file matters more than it looks: a tab left open across a deploy
+would otherwise discard a cache written by newer code and reinterpret a journal
+whose shape it may not understand.
+
+## What integrity checking covers
+
+`open()` runs `PRAGMA integrity_check` and sweeps **the whole journal** against its
+per-entry checksums. It does **not** sweep the blob stores.
+
+That is a deliberate trade. The journal is bounded by how much has been written
+since the last sync and cannot be re-fetched, so it earns the cost every time. The
+blob stores are unbounded — they hold every cached work — and sweeping them means
+reading and CRC-ing the entire database. Doing that on open made cold-open time and
+peak worker memory scale with total cache size: on the 437 MB database DEV-708
+tested, seconds of work and roughly half a gigabyte of transient allocation, which
+is an OOM risk on mobile Safari.
+
+What actually protects a blob is `getPassageDoc` / `getSpine` / `getCache`
+verifying it on the way out and withholding anything that fails. Sweeping at open
+buys earlier notice, not more safety.
+
+`sweepAllBlobs()` runs the full sweep deliberately. It is the only way to find
+overflow-page corruption _before_ the affected record is read, since that damage
+leaves `integrity_check` reporting `ok` — check `blobsSwept` on the report before
+reading an empty `corruptBlobs` as a clean bill of health.
+
 ## Build step
 
 Two things cannot go through Next's bundler, so
@@ -121,8 +189,15 @@ Output is gitignored. Re-run it after changing the coordinator.
 Most of what matters here — OPFS, Web Locks, ownership handoff across a tab
 crash — cannot be tested from Node. DEV-708 validated it with a throwaway
 in-page harness driven by Playwright in Chromium, Playwright in Firefox, and by
-hand in Safari. That harness is not in this tree; recover it from the DEV-708
-branch history if a change needs the same scrutiny.
+hand in Safari (all three passed; Safari was confirmed manually). That harness is
+not in this tree; recover it from the DEV-708 branch history if a change needs the
+same scrutiny.
+
+There is no Playwright setup in this monorepo, so wiring the harness into CI is
+its own piece of work rather than something this library can carry. Until then,
+**a change to `storage-client.ts`, `opfs-driver.ts` or the coordinator's transport
+needs driving by hand in a browser** — the unit tests will not catch a regression
+in any of it.
 
 Two things to know if you do:
 
@@ -136,6 +211,20 @@ Two things to know if you do:
 ## Running unit tests
 
 Run `nx test lib-persistence` to execute the unit tests via [Jest](https://jestjs.io).
-They cover what is not a browser-runtime fact — the shared schema, per-record
-checksums, transaction rollback and FTS5 — by driving the same `LocalDatabase`
-against `node:sqlite`.
+They cover what is not a browser-runtime fact, in two files:
+
+- `lib/node/node-parity.spec.ts` drives the real `LocalDatabase` against
+  `node:sqlite`: the shared schema, per-record checksums, transaction rollback,
+  FTS5, the journal-id contract, and the schema-version decision table.
+- `lib/coordinator/coordinator.spec.ts` drives the coordinator's routing against
+  fake ports: owner announcements, the pending-port queue, and what the directory
+  does when a tab dies.
+
+Note that the coordinator's liveness detection is injectable
+(`setLivenessWatcher`) purely so it can be tested. Node implements Web Locks, and
+in a test nothing holds a tab's liveness lock, so the real watcher would be granted
+immediately and evict every client the moment it connected.
+
+Still not covered by anything in CI: the Web Lock election itself, Comlink
+proxying over real `MessagePort`s, OPFS, and ownership migration across a real tab
+crash. See below.

--- a/libs/lib-persistence/src/index.ts
+++ b/libs/lib-persistence/src/index.ts
@@ -6,9 +6,13 @@
  * currently holds the ownership lock, with other tabs proxying through a
  * SharedWorker coordinator.
  *
- * Spike status (DEV-708): this package exists to prove the architecture's
- * durability, not yet to serve production traffic. See `README.md` for what has
- * been validated and what has not.
+ * Consumers work through `StorageApi`, which names passages, spines, journal
+ * entries and cache records — not tables, statements, workers or VFSs. That is
+ * deliberate: the backend is meant to stay replaceable, so nothing above this
+ * barrel should be able to tell what is underneath it.
+ *
+ * See `README.md` for the architecture and what has been verified in which
+ * browser, and `errors.ts` for the failures that throw rather than return null.
  */
 
 export { StorageClient } from './lib/client/storage-client';
@@ -20,19 +24,24 @@ export type {
 export { createStorageClient } from './lib/client/create-client';
 export { crc32, verifyChecksum } from './lib/checksum';
 export {
-  DATABASE_FILE,
-  SCHEMA_VERSION,
-  VFS_DIRECTORY,
-  VFS_NAME,
-} from './lib/schema';
+  DatabaseNotOpenError,
+  JournalMigrationRequiredError,
+  PersistenceError,
+  SchemaTooNewError,
+} from './lib/errors';
+export { SCHEMA_VERSION } from './lib/schema';
 export type {
+  BlobSweepMode,
   CacheRecord,
   IntegrityReport,
   JournalAppend,
   JournalEntry,
+  MigrationReport,
   OpenReport,
   PassageDocRecord,
+  PassageTextRecord,
   QuotaReport,
+  SearchHit,
   SpineRecord,
   StorageApi,
 } from './lib/types';

--- a/libs/lib-persistence/src/lib/client/storage-client.ts
+++ b/libs/lib-persistence/src/lib/client/storage-client.ts
@@ -24,6 +24,17 @@ import type { OpenReport, StorageApi } from '../types';
 /** How long a single call may hang before the owner is presumed dead. */
 const CALL_TIMEOUT_MS = 10_000;
 
+/**
+ * Timeout for calls whose cost scales with the size of the database.
+ *
+ * A full blob sweep reads and checksums every row, which on a large cache runs
+ * for seconds. Under the normal timeout the client would give up on a worker that
+ * is in fact working, presume it dead, and retry — starting the same expensive
+ * sweep again. These calls get a budget generous enough that a timeout still
+ * means "dead" rather than "busy".
+ */
+const SWEEP_TIMEOUT_MS = 120_000;
+
 /** How many times a call is retried across ownership changes. */
 const MAX_ATTEMPTS = 3;
 
@@ -72,7 +83,16 @@ const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
     );
   });
 
-/** Factory for the two worker scripts, overridable so apps can bundle them. */
+/**
+ * Factory for the two worker scripts, overridable so apps can bundle them.
+ *
+ * This is the one place where a worker type reaches the public surface, and it
+ * has to: a bundler only rewrites `new Worker(new URL('./x.ts', import.meta.url))`
+ * when that expression appears literally in the app's own source, so the
+ * construction cannot be hidden inside this library for apps that need to
+ * override it. `createStorageClient()` supplies the defaults, and an app that is
+ * happy with them never sees this type.
+ */
 export type WorkerFactories = {
   createDedicatedWorker: () => Worker;
   createSharedWorker: () => SharedWorker;
@@ -305,16 +325,16 @@ export class StorageClient {
    * append therefore replays harmlessly, while a dropped one loses work — so
    * this retries rather than surfacing the error.
    */
-  async #invoke<T>(fn: (api: StorageApi) => Promise<T>): Promise<T> {
+  async #invoke<T>(
+    fn: (api: StorageApi) => Promise<T>,
+    timeoutMs = CALL_TIMEOUT_MS,
+  ): Promise<T> {
     let lastError: unknown;
 
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       const session = await this.#ready();
       try {
-        return await withTimeout(
-          fn(session.api as StorageApi),
-          CALL_TIMEOUT_MS,
-        );
+        return await withTimeout(fn(session.api as StorageApi), timeoutMs);
       } catch (error) {
         lastError = error;
 
@@ -346,20 +366,28 @@ export class StorageClient {
     getSpine: (workUuid) => this.#invoke((a) => a.getSpine(workUuid)),
     appendJournal: (entry) => this.#invoke((a) => a.appendJournal(entry)),
     readJournal: (limit) => this.#invoke((a) => a.readJournal(limit)),
-    clearJournal: (upToId) => this.#invoke((a) => a.clearJournal(upToId)),
+    clearJournal: (ids) => this.#invoke((a) => a.clearJournal(ids)),
     journalCount: () => this.#invoke((a) => a.journalCount()),
     putCache: (record) => this.#invoke((a) => a.putCache(record)),
     getCache: (key) => this.#invoke((a) => a.getCache(key)),
     evictExpiredCache: (now) => this.#invoke((a) => a.evictExpiredCache(now)),
-    commitSynced: (record, upToId) =>
-      this.#invoke((a) => a.commitSynced(record, upToId)),
+    commitSynced: (record, syncedJournalIds) =>
+      this.#invoke((a) => a.commitSynced(record, syncedJournalIds)),
     indexPassageText: (records) =>
       this.#invoke((a) => a.indexPassageText(records)),
     searchPassages: (query, limit) =>
       this.#invoke((a) => a.searchPassages(query, limit)),
     indexedPassageCount: () => this.#invoke((a) => a.indexedPassageCount()),
     quota: () => this.#invoke((a) => a.quota()),
-    integrityCheck: () => this.#invoke((a) => a.integrityCheck()),
+    integrityCheck: (blobs) =>
+      this.#invoke(
+        (a) => a.integrityCheck(blobs),
+        // Only an explicit 'always' makes this scale with database size; the
+        // default and 'never' stay on the normal budget.
+        blobs === 'always' ? SWEEP_TIMEOUT_MS : CALL_TIMEOUT_MS,
+      ),
+    sweepAllBlobs: () =>
+      this.#invoke((a) => a.sweepAllBlobs(), SWEEP_TIMEOUT_MS),
     databaseSize: () => this.#invoke((a) => a.databaseSize()),
   };
 }

--- a/libs/lib-persistence/src/lib/coordinator/coordinator.sharedworker.ts
+++ b/libs/lib-persistence/src/lib/coordinator/coordinator.sharedworker.ts
@@ -8,8 +8,16 @@
  * exists to do what a lock cannot: introduce tabs to each other and tell them
  * when the owner changed.
  *
- * Deliberately holds no database state. If the browser ever restarts it, the
- * tabs re-announce and the directory rebuilds itself.
+ * Deliberately holds no database state — but note that it does **not** currently
+ * rebuild its directory if the browser restarts it. A `MessagePort` fires no
+ * close event, so a tab cannot tell that its coordinator port has gone dead, and
+ * nothing re-sends `hello`.
+ *
+ * The consequence is bounded: the owner tab keeps working, because its ownership
+ * comes from the Web Lock rather than from here, and its queries go straight to
+ * its own worker. Proxy tabs stop being introduced to the owner until they
+ * reload. Closing that gap needs a liveness heartbeat on the coordinator port and
+ * is deliberately left to a follow-up.
  */
 
 import {
@@ -25,6 +33,23 @@ let ownerId: string | null = null;
 
 /** Ports waiting for an owner to exist, so their tabs can be introduced. */
 const pending: MessagePort[] = [];
+
+/**
+ * Discard all directory state.
+ *
+ * Exists for tests, which need each case to start from an empty directory — the
+ * module's state is top-level, so importing it once per file would otherwise leak
+ * clients between cases.
+ */
+export const resetDirectory = (): void => {
+  clients.clear();
+  pending.length = 0;
+  ownerId = null;
+  livenessWatcher = lockLivenessWatcher;
+};
+
+/** The current owner, for assertions in tests. */
+export const currentOwnerId = (): string | null => ownerId;
 
 const post = (
   client: Client,
@@ -59,13 +84,24 @@ const introduce = (port: MessagePort) => {
  * the next claim: tabs must stop issuing queries against a dead worker as soon
  * as possible, and one of them is already blocked on the ownership lock.
  */
-const forget = (clientId: string) => {
+export const forget = (clientId: string) => {
   clients.delete(clientId);
   if (ownerId === clientId) {
     ownerId = null;
     broadcast({ type: 'owner-changed', ownerId: null });
   }
 };
+
+/**
+ * Called with a tab's id and a callback to run once that tab is gone.
+ *
+ * A seam rather than a direct call because waiting on a Web Lock only means
+ * "the tab died" when something is actually holding that lock. In a browser the
+ * tab holds it for its whole lifetime; in a test nothing does, so the request
+ * would be granted immediately and every client would be evicted the moment it
+ * said hello. Tests substitute their own watcher and drive death explicitly.
+ */
+export type LivenessWatcher = (clientId: string, onGone: () => void) => void;
 
 /**
  * Detect a tab's death by waiting for its liveness lock.
@@ -75,23 +111,38 @@ const forget = (clientId: string) => {
  * so this is the only signal that works when a tab is crashed rather than
  * closed politely — which is precisely the case the durability tests exercise.
  */
-const watchLiveness = (clientId: string) => {
+const lockLivenessWatcher: LivenessWatcher = (clientId, onGone) => {
   navigator.locks
     ?.request(clientLockName(clientId), () => {
       // Granted only once the tab released it, i.e. the tab is gone.
-      forget(clientId);
+      onGone();
     })
     .catch((error) => {
       console.error('lib-persistence: liveness watch failed', error);
     });
 };
 
-const handleMessage = (message: ClientMessage, port: MessagePort) => {
+let livenessWatcher: LivenessWatcher = lockLivenessWatcher;
+
+/** Substitute the liveness watcher. For tests; production uses the Web Lock. */
+export const setLivenessWatcher = (watcher: LivenessWatcher): void => {
+  livenessWatcher = watcher;
+};
+
+/**
+ * Route one message from a tab.
+ *
+ * Exported so the routing can be tested directly against fake ports. Everything
+ * this coordinator does that is worth asserting — who gets told about an owner
+ * change, when a queued port is introduced, what happens to the directory when a
+ * tab dies — is decided here, and none of it needs a real browser.
+ */
+export const handleMessage = (message: ClientMessage, port: MessagePort) => {
   switch (message.type) {
     case 'hello': {
       const client = { id: message.clientId, port };
       clients.set(message.clientId, client);
-      watchLiveness(message.clientId);
+      livenessWatcher(message.clientId, () => forget(message.clientId));
       // Tell the newcomer who is in charge; null means "election in progress".
       post(client, { type: 'owner-changed', ownerId });
       break;
@@ -115,18 +166,31 @@ const handleMessage = (message: ClientMessage, port: MessagePort) => {
   }
 };
 
-(self as unknown as SharedWorkerGlobalScope).addEventListener(
-  'connect',
-  (event) => {
-    const port = (event as MessageEvent).ports[0];
+/**
+ * Accept a new tab's port.
+ *
+ * Split out from the listener registration so the same wiring can be driven
+ * directly by a test that has no `SharedWorkerGlobalScope` to dispatch on.
+ */
+export const acceptConnection = (port: MessagePort): void => {
+  port.addEventListener(
+    'message',
+    (messageEvent: MessageEvent<ClientMessage>) => {
+      if (messageEvent.data) handleMessage(messageEvent.data, port);
+    },
+  );
 
-    port.addEventListener(
-      'message',
-      (messageEvent: MessageEvent<ClientMessage>) => {
-        if (messageEvent.data) handleMessage(messageEvent.data, port);
-      },
-    );
+  port.start();
+};
 
-    port.start();
-  },
-);
+// Guarded because this module is also imported by unit tests running in Node,
+// where there is no `self` to register on. In a SharedWorker this is the entry
+// point; everywhere else the exports above are the whole module.
+if (typeof self !== 'undefined') {
+  (self as unknown as SharedWorkerGlobalScope).addEventListener(
+    'connect',
+    (event) => {
+      acceptConnection((event as MessageEvent).ports[0]);
+    },
+  );
+}

--- a/libs/lib-persistence/src/lib/coordinator/coordinator.spec.ts
+++ b/libs/lib-persistence/src/lib/coordinator/coordinator.spec.ts
@@ -1,0 +1,294 @@
+/**
+ * Coordinator routing, tested without a browser.
+ *
+ * Ownership itself is decided by a Web Lock in the tabs, so what this module
+ * actually decides is narrower than it looks: who gets told about an owner
+ * change, when a queued port is introduced to the owner, and what the directory
+ * does when a tab dies. All of that is message routing over ports, and none of it
+ * needs OPFS, a real SharedWorker, or a second tab.
+ *
+ * What these tests cannot reach is everything the routing sits on top of — the
+ * lock election, Comlink proxying, and ownership migration across a real tab
+ * crash. That was validated by hand and by Playwright during DEV-708; see
+ * `README.md`.
+ */
+
+import {
+  acceptConnection,
+  currentOwnerId,
+  forget,
+  handleMessage,
+  resetDirectory,
+  setLivenessWatcher,
+} from './coordinator.sharedworker';
+import type { ClientMessage, CoordinatorMessage } from './protocol';
+
+type Sent = { message: CoordinatorMessage; transfer: Transferable[] };
+
+type FakePort = MessagePort & {
+  /** Everything the coordinator posted to this port, in order. */
+  sent: Sent[];
+  /** Deliver a message as though the tab had sent it. */
+  deliver: (message: ClientMessage) => void;
+  started: boolean;
+};
+
+const fakePort = (): FakePort => {
+  const sent: Sent[] = [];
+  const listeners: ((event: MessageEvent) => void)[] = [];
+
+  const port = {
+    sent,
+    started: false,
+    postMessage: (message: CoordinatorMessage, transfer: Transferable[] = []) =>
+      sent.push({ message, transfer }),
+    addEventListener: (_type: string, fn: (event: MessageEvent) => void) =>
+      listeners.push(fn),
+    start: () => {
+      port.started = true;
+    },
+    close: () => undefined,
+    deliver: (message: ClientMessage) => {
+      for (const fn of listeners) fn({ data: message } as MessageEvent);
+    },
+  };
+
+  return port as unknown as FakePort;
+};
+
+/** Messages of one type that a port received. */
+const received = <T extends CoordinatorMessage['type']>(
+  port: FakePort,
+  type: T,
+) => port.sent.filter((entry) => entry.message.type === type);
+
+describe('coordinator', () => {
+  /** Tabs whose death the test will trigger by hand. */
+  let deaths: Map<string, () => void>;
+
+  beforeEach(() => {
+    resetDirectory();
+    deaths = new Map();
+    // Node implements Web Locks, and in a test nothing holds a tab's liveness
+    // lock, so the real watcher would be granted immediately and evict every
+    // client the moment it said hello.
+    setLivenessWatcher((clientId, onGone) => deaths.set(clientId, onGone));
+  });
+
+  afterEach(() => resetDirectory());
+
+  /** Connect a tab and say hello, as `StorageClient` does on start. */
+  const connect = (clientId: string) => {
+    const port = fakePort();
+    handleMessage({ type: 'hello', clientId }, port);
+    return port;
+  };
+
+  describe('hello', () => {
+    it('tells a newcomer that no owner exists yet', () => {
+      const a = connect('a');
+      expect(a.sent.map((entry) => entry.message)).toEqual([
+        { type: 'owner-changed', ownerId: null },
+      ]);
+    });
+
+    it('tells a newcomer who the existing owner is', () => {
+      connect('a');
+      handleMessage({ type: 'claim', clientId: 'a' }, fakePort());
+
+      const b = connect('b');
+      expect(b.sent.map((entry) => entry.message)).toEqual([
+        { type: 'owner-changed', ownerId: 'a' },
+      ]);
+    });
+  });
+
+  describe('claim', () => {
+    it('announces the new owner to every tab', () => {
+      const a = connect('a');
+      const b = connect('b');
+
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+
+      expect(currentOwnerId()).toBe('a');
+      expect(received(a, 'owner-changed').at(-1)?.message).toEqual({
+        type: 'owner-changed',
+        ownerId: 'a',
+      });
+      expect(received(b, 'owner-changed').at(-1)?.message).toEqual({
+        type: 'owner-changed',
+        ownerId: 'a',
+      });
+    });
+  });
+
+  describe('connect', () => {
+    it('hands the port to the owner so its worker can serve it', () => {
+      const a = connect('a');
+      connect('b');
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+
+      const proxyPort = fakePort();
+      handleMessage(
+        { type: 'connect', clientId: 'b', port: proxyPort },
+        fakePort(),
+      );
+
+      const serves = received(a, 'serve');
+      expect(serves).toHaveLength(1);
+      // The port must be transferred, not copied — the whole point is that the
+      // proxy tab's queries reach the owner's worker directly.
+      expect(serves[0].transfer).toEqual([proxyPort]);
+    });
+
+    it('queues a request made before any owner exists, then introduces it', () => {
+      const a = connect('a');
+      connect('b');
+
+      const proxyPort = fakePort();
+      handleMessage(
+        { type: 'connect', clientId: 'b', port: proxyPort },
+        fakePort(),
+      );
+      // Nobody owns the database yet, so there is nobody to introduce it to.
+      expect(received(a, 'serve')).toHaveLength(0);
+
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+
+      const serves = received(a, 'serve');
+      expect(serves).toHaveLength(1);
+      expect(serves[0].transfer).toEqual([proxyPort]);
+    });
+
+    it('drains every queued port on the first claim', () => {
+      const a = connect('a');
+      const first = fakePort();
+      const second = fakePort();
+      handleMessage({ type: 'connect', clientId: 'b', port: first }, fakePort());
+      handleMessage({ type: 'connect', clientId: 'c', port: second }, fakePort());
+
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+
+      expect(received(a, 'serve').map((entry) => entry.transfer)).toEqual([
+        [first],
+        [second],
+      ]);
+    });
+
+    it('does not re-introduce a drained port on a later claim', () => {
+      const a = connect('a');
+      const b = connect('b');
+      const proxyPort = fakePort();
+      handleMessage(
+        { type: 'connect', clientId: 'c', port: proxyPort },
+        fakePort(),
+      );
+
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+      expect(received(a, 'serve')).toHaveLength(1);
+
+      // Ownership moves; the queue was already emptied, so b inherits nothing.
+      handleMessage({ type: 'claim', clientId: 'b' }, b);
+      expect(received(b, 'serve')).toHaveLength(0);
+    });
+  });
+
+  describe('a tab dying', () => {
+    it('announces the vacancy immediately when the owner goes', () => {
+      const a = connect('a');
+      const b = connect('b');
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+
+      // Tabs must stop querying a dead worker as soon as possible, and one of
+      // them is already blocked on the ownership lock.
+      deaths.get('a')?.();
+
+      expect(currentOwnerId()).toBeNull();
+      expect(received(b, 'owner-changed').at(-1)?.message).toEqual({
+        type: 'owner-changed',
+        ownerId: null,
+      });
+    });
+
+    it('says nothing when a non-owner goes', () => {
+      const a = connect('a');
+      connect('b');
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+      const before = a.sent.length;
+
+      deaths.get('b')?.();
+
+      expect(currentOwnerId()).toBe('a');
+      expect(a.sent).toHaveLength(before);
+    });
+
+    it('stops addressing a departed tab', () => {
+      const a = connect('a');
+      const b = connect('b');
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+
+      deaths.get('b')?.();
+      const before = b.sent.length;
+
+      // A later announcement must not reach a tab that is gone.
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+      expect(b.sent).toHaveLength(before);
+    });
+
+    it('survives a tab dying twice', () => {
+      const a = connect('a');
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+
+      const onGone = deaths.get('a');
+      onGone?.();
+      expect(() => onGone?.()).not.toThrow();
+      expect(currentOwnerId()).toBeNull();
+    });
+  });
+
+  describe('acceptConnection', () => {
+    it('starts the port and routes messages arriving on it', () => {
+      const port = fakePort();
+      acceptConnection(port);
+
+      expect(port.started).toBe(true);
+
+      port.deliver({ type: 'hello', clientId: 'a' });
+      expect(port.sent.map((entry) => entry.message)).toEqual([
+        { type: 'owner-changed', ownerId: null },
+      ]);
+    });
+  });
+
+  describe('a restarted coordinator', () => {
+    it('has no memory of tabs that connected to the previous instance', () => {
+      // Documented limitation rather than a bug being asserted: the browser can
+      // restart a SharedWorker, and no `hello` is re-sent because a MessagePort
+      // fires no close event for a tab to notice. The owner tab keeps working —
+      // its ownership comes from the Web Lock, and its queries go to its own
+      // worker — but proxy tabs are not introduced again until they reload.
+      const a = connect('a');
+      handleMessage({ type: 'claim', clientId: 'a' }, a);
+      expect(currentOwnerId()).toBe('a');
+
+      resetDirectory();
+
+      expect(currentOwnerId()).toBeNull();
+      // The previously known owner is now a stranger: a connect request from
+      // another tab has nobody to be introduced to and is queued indefinitely.
+      const proxyPort = fakePort();
+      handleMessage(
+        { type: 'connect', clientId: 'b', port: proxyPort },
+        fakePort(),
+      );
+      expect(received(a, 'serve')).toHaveLength(0);
+    });
+  });
+
+  describe('forget', () => {
+    it('is idempotent for an unknown client', () => {
+      expect(() => forget('never-connected')).not.toThrow();
+      expect(currentOwnerId()).toBeNull();
+    });
+  });
+});

--- a/libs/lib-persistence/src/lib/errors.ts
+++ b/libs/lib-persistence/src/lib/errors.ts
@@ -1,0 +1,78 @@
+/**
+ * Typed failures for the cases where returning `null` would be dangerous.
+ *
+ * The repo convention is to return `null` and log rather than throw, and this
+ * library follows it for *reads*: a record that fails its checksum is withheld,
+ * because `null` means "not available locally" and every caller already handles
+ * that by re-fetching. Silence is the correct behaviour there.
+ *
+ * These errors cover the opposite case — a database that cannot be trusted to be
+ * read or written at all. Swallowing one of those would let the editor run
+ * against a store that is absent, stale, or written by code that understood the
+ * schema differently, and the first symptom would be lost work rather than a
+ * failed call. So they throw, loudly, and the caller decides.
+ */
+
+/** Base class for every failure this library raises deliberately. */
+export class PersistenceError extends Error {
+  constructor(message: string) {
+    super(`lib-persistence: ${message}`);
+    this.name = new.target.name;
+  }
+}
+
+/**
+ * A storage operation was attempted before `open()` succeeded.
+ *
+ * Almost always a lifecycle bug in the caller rather than a storage fault.
+ */
+export class DatabaseNotOpenError extends PersistenceError {
+  constructor() {
+    super('database is not open');
+  }
+}
+
+/**
+ * The database file was written by a newer build than this one.
+ *
+ * This is not migratable — forward migration would require knowing what a future
+ * schema means. It happens in practice when a tab stays open across a deploy and
+ * a reloaded tab has already upgraded the shared database.
+ *
+ * Deliberately *not* handled by rebuilding: the newer file may hold journal
+ * entries in a shape this build cannot read, and discarding a translator's
+ * unsynced work to resolve a version mismatch is the one outcome this library
+ * exists to prevent. The caller should tell the user to reload.
+ */
+export class SchemaTooNewError extends PersistenceError {
+  constructor(
+    readonly foundVersion: number,
+    readonly supportedVersion: number,
+  ) {
+    super(
+      `database schema is version ${foundVersion} but this build supports ` +
+        `${supportedVersion}; reload the page to get the newer build`,
+    );
+  }
+}
+
+/**
+ * An older database needs a change to the `journal` table itself.
+ *
+ * Every other table is a cache of server state, so the recovery path for a stale
+ * schema is to drop and re-fetch. The journal is not — it is the only copy of
+ * unsynced work, so it can never be rebuilt from elsewhere. A version step that
+ * alters it therefore needs a hand-written migration, and until one is
+ * registered this is a hard stop rather than a silent data loss.
+ */
+export class JournalMigrationRequiredError extends PersistenceError {
+  constructor(
+    readonly fromVersion: number,
+    readonly toVersion: number,
+  ) {
+    super(
+      `migrating the journal from version ${fromVersion} to ${toVersion} ` +
+        `needs a hand-written migration, which is not registered`,
+    );
+  }
+}

--- a/libs/lib-persistence/src/lib/node/node-parity.spec.ts
+++ b/libs/lib-persistence/src/lib/node/node-parity.spec.ts
@@ -17,7 +17,12 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { crc32 } from '../checksum';
-import { SCHEMA_VERSION } from '../schema';
+import { DatabaseNotOpenError, SchemaTooNewError } from '../errors';
+import {
+  JOURNAL_LAST_CHANGED_AT,
+  planSchemaReconciliation,
+  SCHEMA_VERSION,
+} from '../schema';
 import { LocalDatabase } from '../worker/database';
 import { createNodeDriver } from './node-driver';
 
@@ -50,6 +55,26 @@ describe('lib-persistence on node:sqlite', () => {
     expect(report.vfsName).toBe('node');
     expect(report.integrity.databaseOk).toBe(true);
     expect(report.integrity.corruptJournalIds).toEqual([]);
+    expect(report.integrity.sweepErrors).toEqual([]);
+  });
+
+  it('records an unreadable store as a finding rather than throwing', async () => {
+    await db.putPassageDoc({
+      uuid: 'p1',
+      workUuid: 'w1',
+      doc: bytes(1, 2, 3),
+      version: 1,
+    });
+    // Make one store unreadable. A sweep that threw here would lose the results
+    // for every other store along with it.
+    corrupt(db, 'DROP TABLE passage_docs', []);
+
+    const report = await db.sweepAllBlobs();
+    expect(report.sweepErrors).toHaveLength(1);
+    expect(report.sweepErrors[0]).toContain('passage_docs');
+    // The journal and the other stores were still assessed.
+    expect(report.blobsSwept).toBe(true);
+    expect(report.journalEntriesChecked).toBe(0);
   });
 
   it('round-trips passage docs and the spine', async () => {
@@ -174,7 +199,7 @@ describe('lib-persistence on node:sqlite', () => {
       expect(await db.getCache('k1')).toBeNull();
     });
 
-    it('reports corrupt blobs from the integrity sweep, which integrity_check cannot', async () => {
+    it('reports corrupt blobs from the explicit sweep, which integrity_check cannot', async () => {
       await db.putPassageDoc({
         uuid: 'p1',
         workUuid: 'w1',
@@ -195,8 +220,9 @@ describe('lib-persistence on node:sqlite', () => {
         'k1',
       ]);
 
-      const report = await db.integrityCheck();
+      const report = await db.sweepAllBlobs();
       expect(report.databaseOk).toBe(true); // structurally perfect
+      expect(report.blobsSwept).toBe(true);
       expect(report.corruptBlobs).toEqual(
         expect.arrayContaining([
           { store: 'passage_docs', key: 'p1' },
@@ -214,9 +240,77 @@ describe('lib-persistence on node:sqlite', () => {
         version: 1,
       });
       await db.putSpine({ workUuid: 'w1', doc: bytes(4), version: 1 });
-      const report = await db.integrityCheck();
+      const report = await db.sweepAllBlobs();
       expect(report.corruptBlobs).toEqual([]);
       expect(report.blobRecordsChecked).toBe(2);
+    });
+  });
+
+  describe('sweep cost', () => {
+    // The blob sweep reads and CRCs every row, so on a large cache it costs
+    // seconds and hundreds of megabytes of transient allocation. It used to run
+    // unconditionally on open, which made cold-open time scale with total
+    // database size. What actually protects a blob is verify-on-read.
+
+    it('does not sweep blobs on open', async () => {
+      await db.putPassageDoc({
+        uuid: 'p1',
+        workUuid: 'w1',
+        doc: bytes(1, 2, 3),
+        version: 1,
+      });
+      await db.close();
+
+      db = new LocalDatabase(async () => createNodeDriver(join(dir, 'test.db')));
+      const report = await db.open();
+
+      expect(report.integrity.blobsSwept).toBe(false);
+      expect(report.integrity.blobRecordsChecked).toBe(0);
+    });
+
+    it('still sweeps the whole journal on open, which is never re-fetchable', async () => {
+      await db.appendJournal({
+        passageUuid: 'p1',
+        workUuid: 'w1',
+        update: bytes(1),
+      });
+      await db.appendJournal({
+        passageUuid: 'p2',
+        workUuid: 'w1',
+        update: bytes(2),
+      });
+      await db.close();
+
+      db = new LocalDatabase(async () => createNodeDriver(join(dir, 'test.db')));
+      const report = await db.open();
+
+      expect(report.integrity.journalEntriesChecked).toBe(2);
+      expect(report.integrity.corruptJournalIds).toEqual([]);
+    });
+
+    it('reports blobs as unswept rather than clean when asked not to sweep', async () => {
+      await db.putPassageDoc({
+        uuid: 'p1',
+        workUuid: 'w1',
+        doc: bytes(1, 2, 3),
+        version: 1,
+      });
+      corrupt(db, 'UPDATE passage_docs SET doc = ? WHERE uuid = ?', [
+        bytes(1, 9, 3),
+        'p1',
+      ]);
+
+      const skipped = await db.integrityCheck('never');
+      // An empty corruptBlobs must not read as a clean bill of health when the
+      // sweep never ran — this record *is* damaged.
+      expect(skipped.blobsSwept).toBe(false);
+      expect(skipped.corruptBlobs).toEqual([]);
+
+      const swept = await db.integrityCheck('always');
+      expect(swept.blobsSwept).toBe(true);
+      expect(swept.corruptBlobs).toEqual([
+        { store: 'passage_docs', key: 'p1' },
+      ]);
     });
   });
 
@@ -235,10 +329,70 @@ describe('lib-persistence on node:sqlite', () => {
 
       await db.commitSynced(
         { uuid: 'p1', workUuid: 'w1', doc: bytes(8, 8), version: 5 },
-        first,
+        [first],
       );
 
       expect((await db.getPassageDoc('p1'))?.version).toBe(5);
+      expect(await db.journalCount()).toBe(1);
+    });
+
+    it('leaves another passage’s interleaved edits alone', async () => {
+      // The regression this signature exists for. `journal.id` is one
+      // AUTOINCREMENT sequence shared by every passage, so clearing "everything
+      // through id N" after syncing one passage silently deleted whatever else
+      // had been written below N. Here p2's edit sits between p1's two, and it is
+      // the only copy of that work.
+      const p1First = await db.appendJournal({
+        passageUuid: 'p1',
+        workUuid: 'w1',
+        update: bytes(1),
+      });
+      const p2Only = await db.appendJournal({
+        passageUuid: 'p2',
+        workUuid: 'w1',
+        update: bytes(2),
+      });
+      const p1Second = await db.appendJournal({
+        passageUuid: 'p1',
+        workUuid: 'w1',
+        update: bytes(3),
+      });
+
+      expect(p2Only).toBeGreaterThan(p1First);
+      expect(p1Second).toBeGreaterThan(p2Only);
+
+      await db.commitSynced(
+        { uuid: 'p1', workUuid: 'w1', doc: bytes(8, 8), version: 5 },
+        [p1First, p1Second],
+      );
+
+      const { entries } = await db.readJournal();
+      expect(entries.map((entry) => entry.id)).toEqual([p2Only]);
+      expect(entries[0].passageUuid).toBe('p2');
+      expect(entries[0].update).toEqual(bytes(2));
+    });
+
+    it('rolls the journal deletes back with the doc write', async () => {
+      const id = await db.appendJournal({
+        passageUuid: 'p1',
+        workUuid: 'w1',
+        update: bytes(1),
+      });
+
+      // A doc whose version violates NOT NULL fails mid-transaction, after the
+      // delete would have been issued.
+      await expect(
+        db.commitSynced(
+          {
+            uuid: 'p1',
+            workUuid: 'w1',
+            doc: bytes(8),
+            version: null as unknown as number,
+          },
+          [id],
+        ),
+      ).rejects.toThrow();
+
       expect(await db.journalCount()).toBe(1);
     });
 
@@ -361,11 +515,225 @@ describe('lib-persistence on node:sqlite', () => {
     });
   });
 
-  it('records the schema version and reports a real file size', async () => {
-    const driver = db.driver;
-    expect(driver?.name).toBe('node');
-    expect(driver?.rows('PRAGMA user_version')[0][0]).toBe(SCHEMA_VERSION);
-    expect(await db.databaseSize()).toBeGreaterThan(0);
+  describe('clearJournal', () => {
+    it('deletes only the ids it is given', async () => {
+      const ids = [];
+      for (const passage of ['p1', 'p2', 'p3']) {
+        ids.push(
+          await db.appendJournal({
+            passageUuid: passage,
+            workUuid: 'w1',
+            update: bytes(1),
+          }),
+        );
+      }
+
+      expect(await db.clearJournal([ids[0], ids[2]])).toBe(2);
+
+      const { entries } = await db.readJournal();
+      expect(entries.map((entry) => entry.passageUuid)).toEqual(['p2']);
+    });
+
+    it('is a no-op for an empty list rather than clearing everything', async () => {
+      await db.appendJournal({
+        passageUuid: 'p1',
+        workUuid: 'w1',
+        update: bytes(1),
+      });
+
+      expect(await db.clearJournal([])).toBe(0);
+      expect(await db.journalCount()).toBe(1);
+    });
+
+    it('reports only rows actually removed when ids are already gone', async () => {
+      const id = await db.appendJournal({
+        passageUuid: 'p1',
+        workUuid: 'w1',
+        update: bytes(1),
+      });
+
+      expect(await db.clearJournal([id])).toBe(1);
+      expect(await db.clearJournal([id])).toBe(0);
+    });
+
+    it('deletes more ids than fit in one statement', async () => {
+      // The delete is chunked because SQLite caps bound parameters per statement
+      // and a long offline session can outrun that cap.
+      const ids: number[] = [];
+      for (let i = 0; i < 1200; i++) {
+        ids.push(
+          await db.appendJournal({
+            passageUuid: `p${i}`,
+            workUuid: 'w1',
+            update: bytes(i % 256),
+          }),
+        );
+      }
+      const keep = ids.pop() as number;
+
+      expect(await db.clearJournal(ids)).toBe(1199);
+      expect(await db.journalCount()).toBe(1);
+      const { entries } = await db.readJournal();
+      expect(entries[0].id).toBe(keep);
+    });
+  });
+
+  describe('schema version', () => {
+    /** Reopen the same file with a fresh LocalDatabase. */
+    const reopen = async () => {
+      const next = new LocalDatabase(async () =>
+        createNodeDriver(join(dir, 'test.db')),
+      );
+      const report = await next.open();
+      return { db: next, report };
+    };
+
+    it('records the schema version and reports a real file size', async () => {
+      const driver = db.driver;
+      expect(driver?.name).toBe('node');
+      expect(driver?.rows('PRAGMA user_version')[0][0]).toBe(SCHEMA_VERSION);
+      expect(await db.databaseSize()).toBeGreaterThan(0);
+    });
+
+    it('reports a fresh database as version 0 and stamps it', async () => {
+      // `db` in beforeEach opened the file for the first time.
+      const driver = db.driver;
+      expect(driver?.rows('PRAGMA user_version')[0][0]).toBe(SCHEMA_VERSION);
+      await db.close();
+
+      const { db: again, report } = await reopen();
+      // Second open finds the stamp rather than treating it as new.
+      expect(report.migration.fromVersion).toBe(SCHEMA_VERSION);
+      expect(report.migration.rebuilt).toBe(false);
+      await again.close();
+    });
+
+    it('refuses to open a file written by a newer build', async () => {
+      corrupt(db, `PRAGMA user_version = ${SCHEMA_VERSION + 1}`, []);
+      await db.close();
+
+      const next = new LocalDatabase(async () =>
+        createNodeDriver(join(dir, 'test.db')),
+      );
+      // Rebuilding here would discard a cache written by newer code, and would be
+      // restoring a journal whose shape this build may not understand.
+      await expect(next.open()).rejects.toThrow(SchemaTooNewError);
+    });
+
+    it('leaves nothing usable behind when it refuses an open', async () => {
+      corrupt(db, `PRAGMA user_version = ${SCHEMA_VERSION + 1}`, []);
+      await db.close();
+
+      const next = new LocalDatabase(async () =>
+        createNodeDriver(join(dir, 'test.db')),
+      );
+      await expect(next.open()).rejects.toThrow(SchemaTooNewError);
+
+      // A refused open must not leave the driver attached, or every later call
+      // would run against a database this build just said it cannot read.
+      expect(next.driver).toBeNull();
+      await expect(next.journalCount()).rejects.toThrow(DatabaseNotOpenError);
+    });
+
+    it('rebuilds the re-fetchable tables on an older file but keeps the journal', async () => {
+      await db.putPassageDoc({
+        uuid: 'p1',
+        workUuid: 'w1',
+        doc: bytes(1, 2, 3),
+        version: 1,
+      });
+      await db.putSpine({ workUuid: 'w1', doc: bytes(4), version: 1 });
+      await db.putCache({
+        key: 'k1',
+        body: bytes(5),
+        expiresAt: Date.now() + 60_000,
+      });
+      await db.indexPassageText([
+        { passageUuid: 'p1', workUuid: 'w1', text: 'indexed text' },
+      ]);
+      await db.appendJournal({
+        passageUuid: 'p1',
+        workUuid: 'w1',
+        update: bytes(9, 9),
+      });
+
+      // Pose as an older file.
+      corrupt(db, 'PRAGMA user_version = 1', []);
+      await db.close();
+
+      const { db: migrated, report } = await reopen();
+      expect(report.migration.fromVersion).toBe(1);
+      expect(report.migration.toVersion).toBe(SCHEMA_VERSION);
+      expect(report.migration.rebuilt).toBe(true);
+
+      // Everything re-fetchable is gone...
+      expect(await migrated.getPassageDoc('p1')).toBeNull();
+      expect(await migrated.getSpine('w1')).toBeNull();
+      expect(await migrated.getCache('k1')).toBeNull();
+      expect(await migrated.indexedPassageCount()).toBe(0);
+
+      // ...and the one thing that is not re-fetchable survived intact.
+      const { entries } = await migrated.readJournal();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].passageUuid).toBe('p1');
+      expect(entries[0].update).toEqual(bytes(9, 9));
+
+      // And the file is now stamped current, so the next open is a no-op.
+      await migrated.close();
+      const { db: again, report: second } = await reopen();
+      expect(second.migration.rebuilt).toBe(false);
+      expect(await again.journalCount()).toBe(1);
+      await again.close();
+    });
+
+  });
+
+  describe('planSchemaReconciliation', () => {
+    // The decision table, tested directly rather than through a file, so that
+    // versions which cannot exist yet are still covered.
+
+    it('treats an unstamped file as fresh', () => {
+      expect(planSchemaReconciliation(0)).toBe('fresh');
+    });
+
+    it('treats the current version as nothing to do', () => {
+      expect(planSchemaReconciliation(SCHEMA_VERSION)).toBe('current');
+    });
+
+    it('rejects anything newer than this build', () => {
+      expect(planSchemaReconciliation(SCHEMA_VERSION + 1)).toBe(
+        'reject-too-new',
+      );
+      expect(planSchemaReconciliation(SCHEMA_VERSION + 99)).toBe(
+        'reject-too-new',
+      );
+    });
+
+    it('rebuilds an older version whose journal is unchanged', () => {
+      for (let v = JOURNAL_LAST_CHANGED_AT; v < SCHEMA_VERSION; v++) {
+        expect(planSchemaReconciliation(v)).toBe('rebuild');
+      }
+    });
+
+    it('refuses a version older than the journal’s last change', () => {
+      // Guards the case that arrives the first time the journal's own columns
+      // change: dropping caches cannot fix it, and the journal must not be
+      // reinterpreted or discarded to make the open succeed.
+      const older = JOURNAL_LAST_CHANGED_AT - 1;
+      // Only meaningful once the journal has changed at least once past v1.
+      if (older > 0) {
+        expect(planSchemaReconciliation(older)).toBe(
+          'reject-journal-migration',
+        );
+      }
+      // Whatever JOURNAL_LAST_CHANGED_AT becomes, a stamped file below it never
+      // rebuilds.
+      expect(
+        ['reject-journal-migration', 'fresh'].includes(
+          planSchemaReconciliation(older),
+        ),
+      ).toBe(true);
+    });
   });
 
   it('survives being closed and reopened, as a restarted agent would', async () => {

--- a/libs/lib-persistence/src/lib/schema.ts
+++ b/libs/lib-persistence/src/lib/schema.ts
@@ -11,6 +11,21 @@
 /** Bumped whenever `SCHEMA_STATEMENTS` changes in a way that needs migration. */
 export const SCHEMA_VERSION = 2;
 
+/**
+ * The version at which the `journal` table's own definition last changed.
+ *
+ * This is the pivot for the migration strategy. Every other table is a cache of
+ * server state, so a stale schema is recoverable by dropping and re-fetching.
+ * The journal is not — while offline it is the only copy of the user's work — so
+ * a step that alters the journal itself cannot be resolved that way and needs a
+ * hand-written migration instead.
+ *
+ * The journal was introduced at version 1 and unchanged by version 2, which only
+ * added checksum columns to the other stores. Raise this when the journal's
+ * columns change, and register the migration that carries its rows across.
+ */
+export const JOURNAL_LAST_CHANGED_AT = 1;
+
 /** The database file name inside the SAH pool VFS. */
 export const DATABASE_FILE = '/84000-local.sqlite3';
 
@@ -53,7 +68,34 @@ export const COORDINATOR_URL = '/storage-workers/coordinator.js';
  */
 export const FTS_TOKENIZER = 'unicode61 remove_diacritics 2';
 
-export const SCHEMA_STATEMENTS = [
+/**
+ * The full-text index over rendered passage text.
+ *
+ * Kept here beside the other tables, though it cannot go in the same list: FTS5
+ * is a virtual table and its tokenizer is interpolated rather than bound.
+ */
+export const FTS_STATEMENT = `CREATE VIRTUAL TABLE IF NOT EXISTS passage_text USING fts5(
+     passage_uuid UNINDEXED,
+     work_uuid UNINDEXED,
+     text,
+     tokenize="${FTS_TOKENIZER}"
+   )`;
+
+/**
+ * Tables holding nothing but a local copy of server state.
+ *
+ * Everything here is re-fetchable, which is what makes "drop it and rebuild"
+ * a safe answer to a stale schema. `passage_text` belongs to this set too and is
+ * listed separately only because of the FTS5 quirk above.
+ */
+export const REBUILDABLE_TABLES = [
+  'passage_docs',
+  'spine',
+  'cache',
+  'passage_text',
+];
+
+const REBUILDABLE_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS passage_docs (
      uuid       TEXT PRIMARY KEY,
      work_uuid  TEXT NOT NULL,
@@ -73,25 +115,6 @@ export const SCHEMA_STATEMENTS = [
      updated_at INTEGER NOT NULL
    )`,
 
-  // `checksum` covers `update_blob` only.
-  //
-  // Every blob store carries one, for the same reason: `PRAGMA integrity_check`
-  // verifies b-tree structure, page linkage and freelist consistency, but *not*
-  // BLOB payload bytes. Corruption inside an overflow page leaves the database
-  // structurally perfect and the content garbage — measured, and the reason
-  // these columns exist. Without them a damaged passage doc opens clean, reads
-  // as valid, and syncs to the server.
-  `CREATE TABLE IF NOT EXISTS journal (
-     id           INTEGER PRIMARY KEY AUTOINCREMENT,
-     passage_uuid TEXT NOT NULL,
-     work_uuid    TEXT NOT NULL,
-     update_blob  BLOB NOT NULL,
-     checksum     INTEGER NOT NULL,
-     created_at   INTEGER NOT NULL
-   )`,
-  `CREATE INDEX IF NOT EXISTS journal_passage
-     ON journal (passage_uuid)`,
-
   `CREATE TABLE IF NOT EXISTS cache (
      key        TEXT PRIMARY KEY,
      body       BLOB NOT NULL,
@@ -102,6 +125,75 @@ export const SCHEMA_STATEMENTS = [
   `CREATE INDEX IF NOT EXISTS cache_expiry
      ON cache (expires_at)`,
 ];
+
+/**
+ * The unsynced-edit journal, which is not a cache of anything.
+ *
+ * Separated from the rebuildable statements because the difference is load
+ * bearing: this table is never dropped by any path in this library. See
+ * `JOURNAL_LAST_CHANGED_AT`.
+ *
+ * `checksum` covers `update_blob` only.
+ *
+ * Every blob store carries one, for the same reason: `PRAGMA integrity_check`
+ * verifies b-tree structure, page linkage and freelist consistency, but *not*
+ * BLOB payload bytes. Corruption inside an overflow page leaves the database
+ * structurally perfect and the content garbage — measured, and the reason
+ * these columns exist. Without them a damaged passage doc opens clean, reads
+ * as valid, and syncs to the server.
+ */
+export const JOURNAL_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS journal (
+     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+     passage_uuid TEXT NOT NULL,
+     work_uuid    TEXT NOT NULL,
+     update_blob  BLOB NOT NULL,
+     checksum     INTEGER NOT NULL,
+     created_at   INTEGER NOT NULL
+   )`,
+  `CREATE INDEX IF NOT EXISTS journal_passage
+     ON journal (passage_uuid)`,
+];
+
+export const SCHEMA_STATEMENTS = [
+  ...REBUILDABLE_STATEMENTS,
+  ...JOURNAL_STATEMENTS,
+];
+
+/** Statements that recreate the re-fetchable tables after a rebuild. */
+export const REBUILD_STATEMENTS = [...REBUILDABLE_STATEMENTS, FTS_STATEMENT];
+
+/** What to do with a file stamped at a given `user_version`. */
+export type SchemaPlan =
+  /** Never written by this library: create everything and stamp it. */
+  | { action: 'fresh' }
+  /** Already at `SCHEMA_VERSION`: nothing to do. */
+  | { action: 'current' }
+  /** Older, and only caches are stale: drop and recreate those. */
+  | { action: 'rebuild' }
+  /** Written by a newer build: this one cannot safely read it. */
+  | { action: 'reject-too-new' }
+  /** Older than the journal's last change: needs a hand-written migration. */
+  | { action: 'reject-journal-migration' };
+
+/**
+ * Decide what an open should do about the version it found.
+ *
+ * Pure and separate from the database so the decision table can be read in one
+ * place and tested at every version, including the ones that cannot exist yet.
+ */
+export const planSchemaReconciliation = (
+  foundVersion: number,
+): SchemaPlan['action'] => {
+  if (foundVersion > SCHEMA_VERSION) return 'reject-too-new';
+  if (foundVersion === SCHEMA_VERSION) return 'current';
+  // Zero is the SQLite default, i.e. a file this library has never stamped.
+  if (foundVersion === 0) return 'fresh';
+  // Older. Dropping the caches fixes any change confined to them, but cannot fix
+  // a change to the journal, which is the only copy of unsynced work.
+  if (foundVersion < JOURNAL_LAST_CHANGED_AT) return 'reject-journal-migration';
+  return 'rebuild';
+};
 
 /**
  * Pragmas applied on every open.

--- a/libs/lib-persistence/src/lib/types.ts
+++ b/libs/lib-persistence/src/lib/types.ts
@@ -57,15 +57,38 @@ export type CacheRecord = {
   updatedAt: number;
 };
 
-/** Result of the integrity check performed when the database is opened. */
+/**
+ * When to sweep the blob stores against their checksums.
+ *
+ * The sweep reads the entire database, so it is not something to do casually.
+ * `'if-damaged'` runs it only once `PRAGMA integrity_check` has reported a
+ * problem; `'always'` is the deliberate diagnostic; `'never'` restricts the check
+ * to the journal.
+ */
+export type BlobSweepMode = 'if-damaged' | 'always' | 'never';
+
+/**
+ * Result of the integrity check performed when the database is opened.
+ *
+ * A database is only fully healthy when `databaseOk` is true, `sweepErrors` and
+ * `corruptJournalIds` are empty, and — if `blobsSwept` — `corruptBlobs` too.
+ * `databaseOk` alone covers structure, not contents.
+ */
 export type IntegrityReport = {
   /** `PRAGMA integrity_check` returned "ok". */
   databaseOk: boolean;
   /** Raw rows returned by `PRAGMA integrity_check`, for diagnostics. */
   databaseErrors: string[];
+  /**
+   * Sweeps that could not be completed, as opposed to sweeps that found damage.
+   *
+   * A store too damaged to read at all reports here rather than throwing, so one
+   * unreadable table cannot hide what the others would have found.
+   */
+  sweepErrors: string[];
   /** Journal entries whose stored checksum did not match their payload. */
   corruptJournalIds: number[];
-  /** Total journal entries examined. */
+  /** Total journal entries examined. Always the whole journal. */
   journalEntriesChecked: number;
   /**
    * Blob records whose stored checksum did not match their payload.
@@ -73,10 +96,34 @@ export type IntegrityReport = {
    * Separate from `databaseOk` because `PRAGMA integrity_check` cannot see
    * this: it verifies b-tree structure, not BLOB payload bytes, so a database
    * can be structurally perfect and still hold garbage in an overflow page.
+   *
+   * Only meaningful when `blobsSwept` is true.
    */
   corruptBlobs: { store: 'passage_docs' | 'spine' | 'cache'; key: string }[];
-  /** Total blob records examined. */
+  /** Total blob records examined. Zero when `blobsSwept` is false. */
   blobRecordsChecked: number;
+  /**
+   * Whether the blob stores were swept at all.
+   *
+   * Distinguishes "checked, all clean" from "not looked at" — without it, an
+   * empty `corruptBlobs` reads as a clean bill of health the check never gave.
+   */
+  blobsSwept: boolean;
+};
+
+/** What reconciling the file's schema against this build did. */
+export type MigrationReport = {
+  /** `user_version` found in the file. 0 means this library never wrote it. */
+  fromVersion: number;
+  /** The version the file is at now. */
+  toVersion: number;
+  /**
+   * Whether the re-fetchable tables were dropped and recreated.
+   *
+   * The `journal` table is never included — it holds the only copy of unsynced
+   * work, so no path in this library drops it.
+   */
+  rebuilt: boolean;
 };
 
 /** Outcome of opening the database. */
@@ -88,6 +135,7 @@ export type OpenReport = {
   /** Whether the SAH pool VFS installed successfully. */
   vfsName: string;
   integrity: IntegrityReport;
+  migration: MigrationReport;
 };
 
 /** Rendered passage text, for the offline full-text index. */
@@ -149,7 +197,15 @@ export type StorageApi = {
     entries: JournalEntry[];
     corruptIds: number[];
   }>;
-  clearJournal(upToId: number): Promise<number>;
+  /**
+   * Delete exactly the journal entries named, and nothing else.
+   *
+   * Ids rather than a high-water mark: `journal.id` is one AUTOINCREMENT sequence
+   * shared by every passage, so "clear everything through id N" silently takes
+   * other passages' interleaved, still-unsynced edits with it. Returns how many
+   * rows were removed.
+   */
+  clearJournal(ids: number[]): Promise<number>;
   journalCount(): Promise<number>;
 
   putCache(record: Omit<CacheRecord, 'updatedAt'>): Promise<void>;
@@ -160,10 +216,13 @@ export type StorageApi = {
    * Commit a passage doc and clear the journal entries it subsumes in one
    * transaction. This atomicity across stores is the reason for a single
    * engine rather than two.
+   *
+   * `syncedJournalIds` names the entries the caller read, sent and had
+   * acknowledged. No other entry is touched.
    */
   commitSynced(
     record: Omit<PassageDocRecord, 'updatedAt'>,
-    clearJournalUpToId: number,
+    syncedJournalIds: number[],
   ): Promise<void>;
 
   /**
@@ -187,7 +246,21 @@ export type StorageApi = {
   indexedPassageCount(): Promise<number>;
 
   quota(): Promise<QuotaReport>;
-  integrityCheck(): Promise<IntegrityReport>;
+  /**
+   * Check structural integrity and the journal checksums.
+   *
+   * Blob stores are swept only per `blobs`, which defaults to `'if-damaged'`,
+   * because sweeping them reads the whole database. Blob protection comes from
+   * verify-on-read, not from this.
+   */
+  integrityCheck(blobs?: BlobSweepMode): Promise<IntegrityReport>;
+  /**
+   * Sweep every blob against its checksum. Costs a full read of the database.
+   *
+   * The only way to detect overflow-page corruption before the affected record is
+   * read, and therefore a deliberate diagnostic rather than a routine check.
+   */
+  sweepAllBlobs(): Promise<IntegrityReport>;
   /** Raw byte size of the database file, via the SAH pool. */
   databaseSize(): Promise<number>;
 };

--- a/libs/lib-persistence/src/lib/worker/database.ts
+++ b/libs/lib-persistence/src/lib/worker/database.ts
@@ -13,17 +13,26 @@
 
 import { crc32, verifyChecksum } from '../checksum';
 import {
-  FTS_TOKENIZER,
+  JOURNAL_STATEMENTS,
+  planSchemaReconciliation,
   PRAGMAS,
-  SCHEMA_STATEMENTS,
+  REBUILD_STATEMENTS,
+  REBUILDABLE_TABLES,
   SCHEMA_VERSION,
 } from '../schema';
+import {
+  DatabaseNotOpenError,
+  JournalMigrationRequiredError,
+  SchemaTooNewError,
+} from '../errors';
 import type { SqlDriver } from '../driver';
 import type {
+  BlobSweepMode,
   CacheRecord,
   IntegrityReport,
   JournalAppend,
   JournalEntry,
+  MigrationReport,
   OpenReport,
   PassageDocRecord,
   PassageTextRecord,
@@ -32,6 +41,16 @@ import type {
   SpineRecord,
   StorageApi,
 } from '../types';
+
+/**
+ * How many journal ids to name in one `DELETE ... IN (...)`.
+ *
+ * SQLite caps bound parameters per statement, and a long offline session can
+ * accumulate more entries than that cap, so deletes are chunked. Every chunk runs
+ * inside the caller's transaction, so the whole set still commits or rolls back
+ * together.
+ */
+const JOURNAL_DELETE_CHUNK = 500;
 
 const asBytes = (value: unknown): Uint8Array => {
   if (value instanceof Uint8Array) return value;
@@ -77,7 +96,7 @@ export class LocalDatabase implements StorageApi {
   }
 
   #require(): SqlDriver {
-    if (!this.#driver) throw new Error('lib-persistence: database is not open');
+    if (!this.#driver) throw new DatabaseNotOpenError();
     return this.#driver;
   }
 
@@ -95,29 +114,29 @@ export class LocalDatabase implements StorageApi {
   }
 
   /**
-   * Install the VFS, open the database, apply the schema, and check integrity.
+   * Install the VFS, open the database, reconcile the schema, and check integrity.
    *
    * Integrity is checked on every open rather than lazily: a database that is
-   * damaged should be discovered before the editor starts writing into it.
+   * damaged should be discovered before the editor starts writing into it. What
+   * that check covers is deliberately bounded — see `integrityCheck`.
    */
   async open(): Promise<OpenReport> {
     const started = performance.now();
 
     this.#driver = await this.#connect();
 
-    for (const pragma of PRAGMAS) this.#run(pragma);
-    for (const statement of SCHEMA_STATEMENTS) this.#run(statement);
-    // The FTS5 table is created separately because its tokenizer is
-    // interpolated rather than bound, and it is a virtual table.
-    this.#run(
-      `CREATE VIRTUAL TABLE IF NOT EXISTS passage_text USING fts5(
-         passage_uuid UNINDEXED,
-         work_uuid UNINDEXED,
-         text,
-         tokenize="${FTS_TOKENIZER}"
-       )`,
-    );
-    this.#run(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    let migration: MigrationReport;
+    try {
+      // Outside the migration transaction: `journal_mode` cannot be set inside one.
+      for (const pragma of PRAGMAS) this.#run(pragma);
+      migration = this.#reconcileSchema();
+    } catch (error) {
+      // A refused open must leave nothing behind that looks usable. Otherwise the
+      // driver stays attached, `#require()` succeeds, and every later call runs
+      // against a database this build has just declared it cannot read.
+      await this.close();
+      throw error;
+    }
 
     const integrity = await this.integrityCheck();
     const persisted = await requestPersistence();
@@ -127,6 +146,61 @@ export class LocalDatabase implements StorageApi {
       persisted,
       vfsName: this.#driver.name,
       integrity,
+      migration,
+    };
+  }
+
+  /**
+   * Bring the file's schema to `SCHEMA_VERSION`, or refuse to touch it.
+   *
+   * The strategy turns on one asymmetry: every table except `journal` is a local
+   * copy of server state, so a stale schema is recoverable by dropping and
+   * re-fetching. The journal is the only copy of unsynced work, so it is never
+   * dropped — a version step that needs to change the journal itself is a hard
+   * stop instead.
+   *
+   * Reading `user_version` before writing it is the point. The previous code
+   * stamped the current version unconditionally, so a file written by any older
+   * build claimed to be current and was then read with the wrong column
+   * expectations.
+   */
+  #reconcileSchema(): MigrationReport {
+    const driver = this.#require();
+    const found = this.#rows('PRAGMA user_version')[0][0] as number;
+    const plan = planSchemaReconciliation(found);
+
+    // A newer build has already upgraded this file. Forward migration would mean
+    // guessing at a future schema, and discarding the journal to resolve a
+    // version mismatch is the one outcome this library exists to prevent.
+    if (plan === 'reject-too-new') {
+      throw new SchemaTooNewError(found, SCHEMA_VERSION);
+    }
+
+    if (plan === 'reject-journal-migration') {
+      throw new JournalMigrationRequiredError(found, SCHEMA_VERSION);
+    }
+
+    const stale = plan === 'rebuild';
+
+    driver.transaction(() => {
+      // First, always: the journal is created if absent and otherwise left
+      // exactly as it is. No branch below can drop it.
+      for (const statement of JOURNAL_STATEMENTS) this.#run(statement);
+
+      if (stale) {
+        for (const table of REBUILDABLE_TABLES) {
+          this.#run(`DROP TABLE IF EXISTS ${table}`);
+        }
+      }
+
+      for (const statement of REBUILD_STATEMENTS) this.#run(statement);
+      this.#run(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    });
+
+    return {
+      fromVersion: found,
+      toVersion: SCHEMA_VERSION,
+      rebuilt: stale,
     };
   }
 
@@ -297,11 +371,39 @@ export class LocalDatabase implements StorageApi {
     return { entries, corruptIds };
   }
 
-  async clearJournal(upToId: number): Promise<number> {
-    const rows = this.#rows(`DELETE FROM journal WHERE id <= ? RETURNING id`, [
-      upToId,
-    ]);
-    return rows.length;
+  /**
+   * Delete exactly the journal entries named, and nothing else.
+   *
+   * Ids rather than a high-water mark, because `journal.id` is one AUTOINCREMENT
+   * sequence shared by every passage. A watermark over a shared sequence sweeps up
+   * whatever else happens to sit below it: edit passage A, edit passage B, edit A
+   * again, then sync A and clear through A's latest id, and B's untouched edit is
+   * deleted with it. Naming the ids makes it impossible to remove an entry the
+   * caller did not just sync.
+   */
+  #deleteJournalEntries(ids: number[]): number {
+    let deleted = 0;
+    for (let i = 0; i < ids.length; i += JOURNAL_DELETE_CHUNK) {
+      const chunk = ids.slice(i, i + JOURNAL_DELETE_CHUNK);
+      const placeholders = chunk.map(() => '?').join(', ');
+      const rows = this.#rows(
+        `DELETE FROM journal WHERE id IN (${placeholders}) RETURNING id`,
+        chunk,
+      );
+      deleted += rows.length;
+    }
+    return deleted;
+  }
+
+  /**
+   * Drop the journal entries whose ids are given, after they have been synced.
+   *
+   * Returns how many rows were actually removed, which can be fewer than were
+   * asked for if a previous call already covered some.
+   */
+  async clearJournal(ids: number[]): Promise<number> {
+    if (!ids.length) return 0;
+    return this.#deleteJournalEntries(ids);
   }
 
   async journalCount(): Promise<number> {
@@ -363,10 +465,14 @@ export class LocalDatabase implements StorageApi {
    * The two writes are one transaction. If they were split across engines, a
    * crash between them would either lose edits (journal cleared first) or
    * replay them twice (doc written first).
+   *
+   * `syncedJournalIds` names the entries this doc subsumes — the ones the caller
+   * read, sent, and had acknowledged. Nothing else is touched, so another
+   * passage's unsynced edits cannot be caught up in the cleanup.
    */
   async commitSynced(
     record: Omit<PassageDocRecord, 'updatedAt'>,
-    clearJournalUpToId: number,
+    syncedJournalIds: number[],
   ): Promise<void> {
     const driver = this.#require();
     driver.transaction(() => {
@@ -387,7 +493,7 @@ export class LocalDatabase implements StorageApi {
           Date.now(),
         ],
       );
-      this.#run(`DELETE FROM journal WHERE id <= ?`, [clearJournalUpToId]);
+      this.#deleteJournalEntries(syncedJournalIds);
     });
   }
 
@@ -452,12 +558,34 @@ export class LocalDatabase implements StorageApi {
   }
 
   /**
-   * Check both SQLite's own integrity and every journal checksum.
+   * Check SQLite's own integrity, every journal checksum, and — conditionally —
+   * the blob stores.
    *
-   * `PRAGMA integrity_check` catches structural damage; the checksum sweep
-   * catches a payload that is structurally fine but wrong.
+   * `PRAGMA integrity_check` catches structural damage; the checksum sweeps catch
+   * a payload that is structurally fine but wrong.
+   *
+   * The journal is always swept in full. It is bounded by how much a translator
+   * has written since their last sync, and it is the one table that cannot be
+   * re-fetched, so it earns the cost unconditionally.
+   *
+   * The blob stores are not swept by default, because they are unbounded — they
+   * hold every cached work — and sweeping them means reading and CRC-ing the
+   * whole database. Doing that on every open made cold-open time and peak worker
+   * memory scale with total cache size, which on a 437 MB database measured
+   * multiple seconds and roughly half a gigabyte of transient allocation. What
+   * actually protects a blob is `getPassageDoc` / `getSpine` / `getCache`
+   * verifying it on the way out, which is unaffected by any of this.
+   *
+   * @param blobs `'if-damaged'` (the default) sweeps blobs only when
+   * `integrity_check` already reported a problem, where the extra detail helps
+   * decide whether the file is salvageable. Note that this will *not* pre-empt the
+   * failure mode the checksums exist for: overflow-page corruption leaves
+   * `integrity_check` reporting `ok`, so a damaged blob in an otherwise sound file
+   * is found on read rather than here. Use `sweepAllBlobs()` to check anyway.
    */
-  async integrityCheck(): Promise<IntegrityReport> {
+  async integrityCheck(
+    blobs: BlobSweepMode = 'if-damaged',
+  ): Promise<IntegrityReport> {
     let databaseErrors: string[] = [];
     try {
       const rows = this.#rows('PRAGMA integrity_check');
@@ -472,8 +600,17 @@ export class LocalDatabase implements StorageApi {
     let journalEntriesChecked = 0;
     const corruptBlobs: IntegrityReport['corruptBlobs'] = [];
     let blobRecordsChecked = 0;
+    let blobsSwept = false;
+    const sweepErrors: string[] = [];
 
-    if (!databaseErrors.length) {
+    const describe = (error: unknown) =>
+      error instanceof Error ? error.message : String(error);
+
+    // Attempted even when `integrity_check` already failed, and wrapped rather
+    // than guarded: a damaged database is precisely when the state of the journal
+    // matters most, and a read that throws part-way through is itself a finding
+    // rather than a reason to abandon the report.
+    try {
       const journalRows = this.#rows(
         `SELECT id, update_blob, checksum FROM journal ORDER BY id ASC`,
       );
@@ -483,6 +620,16 @@ export class LocalDatabase implements StorageApi {
           corruptJournalIds.push(id as number);
         }
       }
+    } catch (error) {
+      sweepErrors.push(`journal sweep failed: ${describe(error)}`);
+    }
+
+    const sweepBlobs =
+      blobs === 'always' ||
+      (blobs === 'if-damaged' && databaseErrors.length > 0);
+
+    if (sweepBlobs) {
+      blobsSwept = true;
 
       // The blob stores need their own sweep for the same reason they need
       // checksums at all — integrity_check does not read payload bytes.
@@ -493,14 +640,19 @@ export class LocalDatabase implements StorageApi {
       ] as const;
 
       for (const [store, keyColumn, blobColumn] of blobStores) {
-        const rows = this.#rows(
-          `SELECT ${keyColumn}, ${blobColumn}, checksum FROM ${store}`,
-        );
-        blobRecordsChecked += rows.length;
-        for (const [key, blob, checksum] of rows) {
-          if (!verifyChecksum(asBytes(blob), checksum as number)) {
-            corruptBlobs.push({ store, key: String(key) });
+        try {
+          const rows = this.#rows(
+            `SELECT ${keyColumn}, ${blobColumn}, checksum FROM ${store}`,
+          );
+          blobRecordsChecked += rows.length;
+          for (const [key, blob, checksum] of rows) {
+            if (!verifyChecksum(asBytes(blob), checksum as number)) {
+              corruptBlobs.push({ store, key: String(key) });
+            }
           }
+        } catch (error) {
+          // One unreadable store must not hide what the others would have found.
+          sweepErrors.push(`${store} sweep failed: ${describe(error)}`);
         }
       }
     }
@@ -512,7 +664,21 @@ export class LocalDatabase implements StorageApi {
       journalEntriesChecked,
       corruptBlobs,
       blobRecordsChecked,
+      blobsSwept,
+      sweepErrors,
     };
+  }
+
+  /**
+   * Sweep every blob in the database against its checksum.
+   *
+   * The diagnostic entry point, and the only way to detect overflow-page
+   * corruption before the affected record is read. Costs one full read of the
+   * database, so it belongs behind a deliberate action — a support tool, a
+   * "verify my offline data" button — never on the open path.
+   */
+  async sweepAllBlobs(): Promise<IntegrityReport> {
+    return this.integrityCheck('always');
   }
 
   async databaseSize(): Promise<number> {

--- a/libs/lib-persistence/src/node.ts
+++ b/libs/lib-persistence/src/node.ts
@@ -20,7 +20,18 @@ export { createNodeDriver } from './lib/node/node-driver';
 export { LocalDatabase } from './lib/worker/database';
 export type { SqlDriver } from './lib/driver';
 export { crc32, verifyChecksum } from './lib/checksum';
-export { FTS_TOKENIZER, SCHEMA_STATEMENTS, SCHEMA_VERSION } from './lib/schema';
+export {
+  DatabaseNotOpenError,
+  JournalMigrationRequiredError,
+  PersistenceError,
+  SchemaTooNewError,
+} from './lib/errors';
+export {
+  FTS_TOKENIZER,
+  JOURNAL_LAST_CHANGED_AT,
+  SCHEMA_STATEMENTS,
+  SCHEMA_VERSION,
+} from './lib/schema';
 export type * from './lib/types';
 
 /**


### PR DESCRIPTION
### Summary

Productionizes `lib-persistence` from its spike state: fixes the three durability defects in the journal and open paths, adds schema-version handling, covers the coordinator's routing, and stops the public surface naming SQLite.

### Linear

- [DEV-562](https://linear.app/84000/issue/DEV-562)

### Notes

- Blob corruption still has no proactive detection. Gating the sweep on `integrity_check` means it won't fire for overflow-page damage, which is the case the checksums exist for. verify-on-read remains the protection; a background sweep is a follow-up.
- No CI test covers the browser transport. Changes to `storage-client.ts`, `opfs-driver.ts` or the coordinator's transport still need driving by hand.