### PR TITLE
Read published content in the reader, draft in the studio

### DIFF
--- a/apps/api-graphql/src/app/api/graphql/route.ts
+++ b/apps/api-graphql/src/app/api/graphql/route.ts
@@ -2,8 +2,25 @@ import { ApolloServer, HeaderMap } from '@apollo/server';
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default';
 import { NextRequest, NextResponse } from 'next/server';
 import depthLimit from 'graphql-depth-limit';
+import { CONTENT_SOURCE_HEADER } from '@eightyfourthousand/data-access';
 
 import { typeDefs, resolvers, createContext } from '../../../graphql';
+
+/**
+ * Headers a browser may send to this endpoint cross-origin.
+ *
+ * The reading room and the studio are on different origins to this API, so every
+ * request is preflighted and anything not listed here is rejected before the
+ * query runs. `CONTENT_SOURCE_HEADER` is spelled from the constant rather than
+ * written out, because a mismatch between the two fails only cross-origin —
+ * same-origin local work would keep passing while the reading room broke.
+ */
+const ALLOWED_REQUEST_HEADERS = [
+  'Content-Type',
+  'Authorization',
+  'apollo-require-preflight',
+  CONTENT_SOURCE_HEADER,
+].join(', ');
 
 function getCorsHeaders(req: NextRequest): Record<string, string> {
   const origin = req.headers.get('origin') || '*';
@@ -11,8 +28,7 @@ function getCorsHeaders(req: NextRequest): Record<string, string> {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers':
-      'Content-Type, Authorization, apollo-require-preflight',
+    'Access-Control-Allow-Headers': ALLOWED_REQUEST_HEADERS,
   };
 }
 

--- a/apps/api-graphql/src/graphql/context.ts
+++ b/apps/api-graphql/src/graphql/context.ts
@@ -4,7 +4,14 @@ import {
   createTokenClient,
   getSession,
 } from '@eightyfourthousand/data-access';
-import type { DataClient, UserClaims, UserRole } from '@eightyfourthousand/data-access';
+import {
+  CONTENT_SOURCE_HEADER,
+  contentSourceFromHeader,
+  type ContentSource,
+  type DataClient,
+  type UserClaims,
+  type UserRole,
+} from '@eightyfourthousand/data-access';
 import { jwtDecode } from 'jwt-decode';
 import { createLoaders, type Loaders } from './loaders';
 
@@ -12,6 +19,12 @@ export interface GraphQLContext {
   req: NextRequest;
   supabase: DataClient;
   loaders: Loaders;
+  /**
+   * Which copy of the content this request resolves against, taken from the
+   * `x-84000-content-source` header the calling app sets. Absent means
+   * published: a caller that does not ask is treated as public.
+   */
+  source: ContentSource;
   session: {
     claims: UserClaims;
     userId: string;
@@ -19,7 +32,11 @@ export interface GraphQLContext {
   } | null;
 }
 
+
+
 export async function createContext(req: NextRequest): Promise<GraphQLContext> {
+  const source = contentSourceFromHeader(req.headers.get(CONTENT_SOURCE_HEADER));
+
   // First, try to get session from Authorization header (for cross-domain requests)
   const authHeader = req.headers.get('authorization');
   if (authHeader?.startsWith('Bearer ')) {
@@ -43,7 +60,8 @@ export async function createContext(req: NextRequest): Promise<GraphQLContext> {
       return {
         req,
         supabase,
-        loaders: createLoaders(supabase),
+        loaders: createLoaders(supabase, source),
+        source,
         session,
       };
     } catch (error) {
@@ -79,7 +97,8 @@ export async function createContext(req: NextRequest): Promise<GraphQLContext> {
   return {
     req,
     supabase,
-    loaders: createLoaders(supabase),
+    loaders: createLoaders(supabase, source),
+    source,
     session,
   };
 }

--- a/apps/api-graphql/src/graphql/loaders.ts
+++ b/apps/api-graphql/src/graphql/loaders.ts
@@ -1,4 +1,7 @@
-import type { DataClient } from '@eightyfourthousand/data-access';
+import type {
+  ContentSource,
+  DataClient,
+} from '@eightyfourthousand/data-access';
 import { createPassageLoaders } from './schema/passage/passage.loader';
 import { createGlossaryNameLoader } from './schema/glossary/glossary-name.loader';
 import { createPassageReferencesLoader } from './schema/passage/passage-references.loader';
@@ -71,14 +74,27 @@ export interface Loaders {
   imprintsByWorkToh: ReturnType<typeof createImprintLoader>;
 }
 
-export function createLoaders(supabase: DataClient): Loaders {
+/**
+ * The request's loaders, all reading the one source the request asked for.
+ *
+ * A DataLoader caches by key alone, so a set can only ever serve one source —
+ * the same passage UUID means a different row in each. That is fine here
+ * because the source is fixed for the whole request.
+ */
+export function createLoaders(
+  supabase: DataClient,
+  source: ContentSource,
+): Loaders {
   return {
-    ...createPassageLoaders(supabase),
-    passageReferencesByPassageUuid: createPassageReferencesLoader(supabase),
+    ...createPassageLoaders(supabase, source),
+    passageReferencesByPassageUuid: createPassageReferencesLoader(
+      supabase,
+      source,
+    ),
     workTitlesByUuid: createWorkTitleLoader(supabase),
-    glossaryNamesByUuid: createGlossaryNameLoader(supabase),
+    glossaryNamesByUuid: createGlossaryNameLoader(supabase, source),
     foliosByUuid: createFolioLoader(supabase),
-    bibliographyLabelsByUuid: createBibliographyLabelLoader(supabase),
+    bibliographyLabelsByUuid: createBibliographyLabelLoader(supabase, source),
     imprintsByWorkToh: createImprintLoader(supabase),
   };
 }

--- a/apps/api-graphql/src/graphql/schema/annotation/annotation.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/annotation/annotation.loader.ts
@@ -2,14 +2,19 @@ import DataLoader from 'dataloader';
 import {
   getAnnotationsByPassageUuids,
   type AnnotationDTO,
+  type ContentSource,
   type DataClient,
 } from '@eightyfourthousand/data-access';
 
-export function createAnnotationLoader(supabase: DataClient) {
+export function createAnnotationLoader(
+  supabase: DataClient,
+  source: ContentSource,
+) {
   return new DataLoader<string, AnnotationDTO[]>(async (passageUuids) => {
     const annotationsByPassage = await getAnnotationsByPassageUuids({
       client: supabase,
       passageUuids,
+      source,
     });
     return passageUuids.map((uuid) => annotationsByPassage.get(uuid) ?? []);
   });

--- a/apps/api-graphql/src/graphql/schema/base.graphql
+++ b/apps/api-graphql/src/graphql/schema/base.graphql
@@ -3,6 +3,7 @@ JSON scalar for arbitrary JSON data
 """
 scalar JSON
 
+
 """
 Pagination information for connections.
 Used consistently across all paginated queries.

--- a/apps/api-graphql/src/graphql/schema/bibliography/bibliography-label.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/bibliography/bibliography-label.loader.ts
@@ -2,6 +2,7 @@ import DataLoader from 'dataloader';
 import {
   getBibliographyLabelsByUuids,
   type BibliographyLabel,
+  type ContentSource,
   type DataClient,
 } from '@eightyfourthousand/data-access';
 
@@ -10,11 +11,15 @@ import {
  * Used to enrich mention annotations with display text from target bibliography
  * entries.
  */
-export function createBibliographyLabelLoader(supabase: DataClient) {
+export function createBibliographyLabelLoader(
+  supabase: DataClient,
+  source: ContentSource,
+) {
   return new DataLoader<string, BibliographyLabel | null>(async (uuids) => {
     const labelsByUuid = await getBibliographyLabelsByUuids({
       client: supabase,
       uuids,
+      source,
     });
     return uuids.map((uuid) => labelsByUuid.get(uuid) ?? null);
   });

--- a/apps/api-graphql/src/graphql/schema/bibliography/bibliography.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/bibliography/bibliography.resolver.ts
@@ -13,6 +13,7 @@ export const bibliographyEntryResolver = async (
   const entry = await getBibliographyEntry({
     client: ctx.supabase,
     uuid: args.uuid,
+    source: ctx.source,
   });
 
   return entry;
@@ -29,6 +30,7 @@ export const workBibliographyResolver = async (
   const entries = await getBibliographyEntries({
     client: ctx.supabase,
     uuid: parent.uuid,
+    source: ctx.source,
   });
 
   return entries;

--- a/apps/api-graphql/src/graphql/schema/glossary/glossary-name.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/glossary/glossary-name.loader.ts
@@ -1,6 +1,7 @@
 import DataLoader from 'dataloader';
 import {
   getGlossaryDisplayNamesByUuids,
+  type ContentSource,
   type DataClient,
 } from '@eightyfourthousand/data-access';
 
@@ -9,11 +10,15 @@ import {
  * Joins via name_uuid to the names table to get the content.
  * Used to enrich mention annotations with display text from target glossary entries.
  */
-export function createGlossaryNameLoader(supabase: DataClient) {
+export function createGlossaryNameLoader(
+  supabase: DataClient,
+  source: ContentSource,
+) {
   return new DataLoader<string, string | null>(async (glossaryUuids) => {
     const namesByUuid = await getGlossaryDisplayNamesByUuids({
       client: supabase,
       glossaryUuids,
+      source,
     });
     return glossaryUuids.map((uuid) => namesByUuid.get(uuid) ?? null);
   });

--- a/apps/api-graphql/src/graphql/schema/glossary/glossary.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/glossary/glossary.resolver.ts
@@ -20,6 +20,7 @@ export const glossaryTermPassagesResolver = async (
     uuid: parent.uuid,
     first: args.first,
     after: args.after,
+    source: ctx.source,
   });
 };
 
@@ -31,6 +32,7 @@ export const glossaryInstanceResolver = async (
   const instance = await getGlossaryInstance({
     client: ctx.supabase,
     uuid: args.uuid,
+    source: ctx.source,
   });
 
   return instance ?? null;
@@ -46,6 +48,7 @@ export const glossaryTermPassagesPageResolver = async (
     uuid: args.uuid,
     first: args.first,
     after: args.after,
+    source: ctx.source,
   });
 };
 
@@ -54,6 +57,10 @@ export const workGlossaryResolver = async (
   args: { withAttestations?: boolean },
   ctx: GraphQLContext,
 ) => {
+  // NOTE: draft-only. `show_glossary_entries` has no published variant because
+  // no client selects this field — only `Work.glossaryTerms` is used — and it is
+  // slated for deletion rather than a published path. Do not select it from a
+  // reader context.
   const instances = await getGlossaryInstances({
     client: ctx.supabase,
     uuid: parent.uuid,
@@ -80,6 +87,7 @@ export const workGlossaryTermsResolver = async (
     cursor: args.cursor ?? null,
     direction: args.direction ?? 'FORWARD',
     withAttestations: args.withAttestations ?? false,
+    source: ctx.source,
   });
 };
 
@@ -98,5 +106,6 @@ export const searchWorkGlossaryTermsResolver = async (
     query: args.query,
     limit: args.limit,
     withAttestations: args.withAttestations ?? false,
+    source: ctx.source,
   });
 };

--- a/apps/api-graphql/src/graphql/schema/passage/passage-label.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage-label.loader.ts
@@ -1,6 +1,7 @@
 import DataLoader from 'dataloader';
 import {
   getPassageLabelsByUuids,
+  type ContentSource,
   type DataClient,
 } from '@eightyfourthousand/data-access';
 
@@ -8,11 +9,15 @@ import {
  * Creates a DataLoader for batch-fetching passage labels by UUID.
  * Used to enrich endNoteLink annotations with labels from target passages.
  */
-export function createPassageLabelLoader(supabase: DataClient) {
+export function createPassageLabelLoader(
+  supabase: DataClient,
+  source: ContentSource,
+) {
   return new DataLoader<string, string | null>(async (passageUuids) => {
     const labelsByUuid = await getPassageLabelsByUuids({
       client: supabase,
       passageUuids,
+      source,
     });
     return passageUuids.map((uuid) => labelsByUuid.get(uuid) ?? null);
   });

--- a/apps/api-graphql/src/graphql/schema/passage/passage-references.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage-references.loader.ts
@@ -1,16 +1,21 @@
 import DataLoader from 'dataloader';
 import {
   getPassageReferencesByTargetUuids,
+  type ContentSource,
   type DataClient,
   type Passages,
 } from '@eightyfourthousand/data-access';
 
-export function createPassageReferencesLoader(supabase: DataClient) {
+export function createPassageReferencesLoader(
+  supabase: DataClient,
+  source: ContentSource,
+) {
   return new DataLoader<string, Passages>(
     async (passageUuids) => {
       const referencesByTargetUuid = await getPassageReferencesByTargetUuids({
         client: supabase,
         passageUuids,
+        source,
       });
       return passageUuids.map((uuid) => referencesByTargetUuid.get(uuid) ?? []);
     },

--- a/apps/api-graphql/src/graphql/schema/passage/passage.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.loader.ts
@@ -1,12 +1,21 @@
-import type { DataClient } from '@eightyfourthousand/data-access';
+import type {
+  ContentSource,
+  DataClient,
+} from '@eightyfourthousand/data-access';
 import { createAlignmentLoader } from '../alignment/alignment.loader';
 import { createAnnotationLoader } from '../annotation/annotation.loader';
 import { createPassageLabelLoader } from './passage-label.loader';
 
-export function createPassageLoaders(supabase: DataClient) {
+export function createPassageLoaders(
+  supabase: DataClient,
+  source: ContentSource,
+) {
   return {
-    annotationsByPassageUuid: createAnnotationLoader(supabase),
+    annotationsByPassageUuid: createAnnotationLoader(supabase, source),
+    // Alignments are deliberately unversioned — there is no
+    // published_passage_alignments table, and the reader serves them from the
+    // same materialized view in both sources.
     alignmentsByPassageUuid: createAlignmentLoader(supabase),
-    passageLabelsByUuid: createPassageLabelLoader(supabase),
+    passageLabelsByUuid: createPassageLabelLoader(supabase, source),
   };
 }

--- a/apps/api-graphql/src/graphql/schema/passage/passage.query.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.query.ts
@@ -14,6 +14,7 @@ export const passageQueries = {
       client: ctx.supabase,
       uuid: args.uuid,
       xmlId: args.xmlId,
+      source: ctx.source,
     });
   },
 };

--- a/apps/api-graphql/src/graphql/schema/passage/passage.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/passage/passage.resolver.ts
@@ -55,6 +55,7 @@ export const passagesResolver = async (
     limit: args.limit,
     filter: args.filter,
     direction: args.direction ?? 'FORWARD',
+    source: ctx.source,
   });
 
   return buildPassageConnection(

--- a/apps/api-graphql/src/graphql/schema/toc/toc.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/toc/toc.resolver.ts
@@ -10,6 +10,7 @@ export const tocResolver = async (
   const toc = await getTranslationToc({
     client: ctx.supabase,
     uuid: parent.uuid,
+    source: ctx.source,
   });
 
   if (!toc) {

--- a/apps/api-graphql/src/graphql/schema/work/work.query.ts
+++ b/apps/api-graphql/src/graphql/schema/work/work.query.ts
@@ -56,6 +56,13 @@ export const workQueries = {
       throw new Error('Either uuid or toh must be provided');
     }
 
+    // A work with no published version is not public: the studio can open it,
+    // but the reading room shows its not-yet-published state rather than the
+    // draft. Resolving to null here is what produces that.
+    if (ctx.source === 'published' && !work?.publishedVersionUuid) {
+      return null;
+    }
+
     if (!work) return null;
     return {
       ...work,

--- a/apps/web-editor/next.config.js
+++ b/apps/web-editor/next.config.js
@@ -6,9 +6,10 @@ import { composePlugins, withNx } from '@nx/next';
 const nextConfig = {
   nx: {},
   // This app edits translations, so every read it makes resolves against the
-  // draft tables. Declared here rather than in .env.local so it is
-  // version-controlled and visible in review; apps that declare nothing read
-  // the published snapshot, which is the safe default.
+  // draft tables. That is also the default today, so this is a pin rather than a
+  // change: it keeps the editor on draft if the default is ever flipped to
+  // published. Declared here rather than in .env.local so it is
+  // version-controlled and visible in review.
   env: { NEXT_PUBLIC_CONTENT_SOURCE: 'draft' },
 };
 

--- a/apps/web-editor/next.config.js
+++ b/apps/web-editor/next.config.js
@@ -5,6 +5,11 @@ import { composePlugins, withNx } from '@nx/next';
  **/
 const nextConfig = {
   nx: {},
+  // This app edits translations, so every read it makes resolves against the
+  // draft tables. Declared here rather than in .env.local so it is
+  // version-controlled and visible in review; apps that declare nothing read
+  // the published snapshot, which is the safe default.
+  env: { NEXT_PUBLIC_CONTENT_SOURCE: 'draft' },
 };
 
 const plugins = [

--- a/apps/web-main/next.config.js
+++ b/apps/web-main/next.config.js
@@ -83,6 +83,11 @@ const studioRoutesPromise = fetchAndWriteStudioRoutes();
  **/
 const nextConfig = {
   nx: {},
+  // This app edits translations, so every read it makes resolves against the
+  // draft tables. Declared here rather than in .env.local so it is
+  // version-controlled and visible in review; apps that declare nothing read
+  // the published snapshot, which is the safe default.
+  env: { NEXT_PUBLIC_CONTENT_SOURCE: 'draft' },
   images: {
     remotePatterns: [
       { hostname: 'lh3.googleusercontent.com' },

--- a/apps/web-main/next.config.js
+++ b/apps/web-main/next.config.js
@@ -84,9 +84,10 @@ const studioRoutesPromise = fetchAndWriteStudioRoutes();
 const nextConfig = {
   nx: {},
   // This app edits translations, so every read it makes resolves against the
-  // draft tables. Declared here rather than in .env.local so it is
-  // version-controlled and visible in review; apps that declare nothing read
-  // the published snapshot, which is the safe default.
+  // draft tables. That is also the default today, so this is a pin rather than a
+  // change: it keeps the editor on draft if the default is ever flipped to
+  // published. Declared here rather than in .env.local so it is
+  // version-controlled and visible in review.
   env: { NEXT_PUBLIC_CONTENT_SOURCE: 'draft' },
   images: {
     remotePatterns: [

--- a/libs/client-graphql/src/lib/client-ssr.ts
+++ b/libs/client-graphql/src/lib/client-ssr.ts
@@ -1,6 +1,10 @@
 import 'server-only';
 import { GraphQLClient } from 'graphql-request';
 import { cookies } from 'next/headers';
+import {
+  CONTENT_SOURCE_HEADER,
+  contentSourceFromEnv,
+} from '@eightyfourthousand/data-access';
 import { getGraphQLUrl } from './config';
 
 /**
@@ -26,6 +30,7 @@ export async function createServerGraphQLClient(): Promise<GraphQLClient> {
     headers: {
       // Forward cookies for authentication
       ...(cookieHeader ? { cookie: cookieHeader } : {}),
+      [CONTENT_SOURCE_HEADER]: contentSourceFromEnv(),
     },
   });
 
@@ -40,5 +45,7 @@ export async function createServerGraphQLClient(): Promise<GraphQLClient> {
  */
 export function createBuildGraphQLClient(): GraphQLClient {
   const url = getGraphQLUrl();
-  return new GraphQLClient(url);
+  return new GraphQLClient(url, {
+    headers: { [CONTENT_SOURCE_HEADER]: contentSourceFromEnv() },
+  });
 }

--- a/libs/client-graphql/src/lib/client.ts
+++ b/libs/client-graphql/src/lib/client.ts
@@ -1,4 +1,8 @@
 import { GraphQLClient } from 'graphql-request';
+import {
+  CONTENT_SOURCE_HEADER,
+  contentSourceFromEnv,
+} from '@eightyfourthousand/data-access';
 import { getGraphQLUrl } from './config';
 
 let clientInstance: GraphQLClient | null = null;
@@ -31,6 +35,10 @@ export function createGraphQLClient(): GraphQLClient {
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
         'apollo-require-preflight': 'true',
+        // Which copy of the content this app reads. Declared once per app in
+        // next.config.js; every query in the request inherits it, so no query,
+        // data function or component has to carry it.
+        [CONTENT_SOURCE_HEADER]: contentSourceFromEnv(),
       };
 
       if (getAccessToken) {

--- a/libs/data-access/src/index.ts
+++ b/libs/data-access/src/index.ts
@@ -3,6 +3,7 @@ export * from './lib/bibliography';
 export * from './lib/client-browser';
 export * from './lib/client-server';
 export * from './lib/client-token';
+export * from './lib/content-source';
 export * from './lib/folio';
 export * from './lib/glossary';
 export * from './lib/imprint';

--- a/libs/data-access/src/lib/bibliography.ts
+++ b/libs/data-access/src/lib/bibliography.ts
@@ -5,15 +5,23 @@ import {
   bibliographyEntryItemFromDTO,
   DataClient,
 } from './types';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  relationFor,
+  rpcFor,
+  type ContentSource,
+} from './content-source';
 
 export const getBibliographyEntries = async ({
   client,
   uuid,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   uuid: string;
+  source?: ContentSource;
 }) => {
-  const { data, error } = await client.rpc('show_bibliographies', {
+  const { data, error } = await client.rpc(rpcFor('showBibliographies', source), {
     v_work_uuid: uuid,
   });
   if (error) {
@@ -31,12 +39,14 @@ export const getBibliographyEntries = async ({
 export const getBibliographyEntry = async ({
   client,
   uuid,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   uuid: string;
+  source?: ContentSource;
 }) => {
   const { data, error } = await client
-    .from('bibliographies')
+    .from(relationFor('bibliographies', source))
     .select(
       `
       uuid::uuid,
@@ -75,9 +85,11 @@ export type BibliographyLabel = {
 export const getBibliographyLabelsByUuids = async ({
   client,
   uuids,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   uuids: readonly string[];
+  source?: ContentSource;
 }): Promise<Map<string, BibliographyLabel>> => {
   const labelsByUuid = new Map<string, BibliographyLabel>();
 
@@ -85,7 +97,7 @@ export const getBibliographyLabelsByUuids = async ({
     return labelsByUuid;
   }
 
-  const { data, error } = await client.rpc('bibliography_labels', {
+  const { data, error } = await client.rpc(rpcFor('bibliographyLabels', source), {
     v_uuids: uuids as string[],
   });
 

--- a/libs/data-access/src/lib/content-source.ts
+++ b/libs/data-access/src/lib/content-source.ts
@@ -1,0 +1,148 @@
+/**
+ * Which copy of a work's content a read resolves against.
+ *
+ * - `draft` — the mutable editor tables. The studio and the editor read these,
+ *   and they are the only thing that is written.
+ * - `published` — the live snapshot of the currently published version.
+ *
+ * Published reads go through the `*_live` views rather than the `published_*`
+ * tables directly. Those tables are keyed on `(version_uuid, <domain uuid>)`, so
+ * a domain UUID is not unique in them: the publish pipeline writes a new
+ * version's rows before flipping `works.published_version_uuid`, and retires the
+ * previous version's rows only afterwards (non-fatally, so leftovers can outlive
+ * a failed retire). Each view joins `works` on that pointer, so a read cannot see
+ * a version that is staged but not live. Keeping the predicate there rather than
+ * at each call site also lets the cross-work reads express it at all — PostgREST
+ * cannot compare two columns.
+ *
+ * Every function taking a `source` defaults it to `draft`, so adding the
+ * parameter changes no existing caller. Reader contexts opt in explicitly.
+ */
+export const CONTENT_SOURCES = ['draft', 'published'] as const;
+
+export type ContentSource = (typeof CONTENT_SOURCES)[number];
+
+export const DEFAULT_CONTENT_SOURCE: ContentSource = 'draft';
+
+/**
+ * The header carrying the source across an API boundary.
+ *
+ * A request, not a query, chooses the source: an app reads one copy throughout —
+ * the studio and editor draft, the reading room and the public MCP API
+ * published — so the choice belongs to the caller rather than to each call site.
+ * Threading it through every query variable, data function and component prop
+ * bought nothing that this does not.
+ */
+export const CONTENT_SOURCE_HEADER = 'x-84000-content-source';
+
+/**
+ * How an app declares which copy it serves. Set in `next.config.js` rather than
+ * an env file so it is version-controlled and visible in review; apps that do
+ * not set it get `published`, which is the safe direction — a studio showing
+ * published content is a visible annoyance, a reading room showing drafts is a
+ * leak.
+ */
+export const CONTENT_SOURCE_ENV_VAR = 'NEXT_PUBLIC_CONTENT_SOURCE';
+
+/**
+ * Reads the ambient source for the app this code is running in. Works in both
+ * server and browser contexts because the variable is `NEXT_PUBLIC_`, and it is
+ * read at call time rather than module load so tests can vary it.
+ */
+export const contentSourceFromEnv = (): ContentSource => {
+  const declared = process.env[CONTENT_SOURCE_ENV_VAR];
+  return isContentSource(declared) ? declared : 'published';
+};
+
+/**
+ * Narrows a header value. Absent or unrecognised resolves to `published`: a
+ * caller that does not ask is treated as public.
+ */
+export const contentSourceFromHeader = (
+  value: string | null | undefined,
+): ContentSource => (isContentSource(value) ? value : 'published');
+
+/** Narrows arbitrary input (a GraphQL argument, a query param) to a ContentSource. */
+export const isContentSource = (value: unknown): value is ContentSource =>
+  typeof value === 'string' &&
+  (CONTENT_SOURCES as readonly string[]).includes(value);
+
+/**
+ * Relation names per source. The published entries are the `_live` views, never
+ * the underlying `published_*` tables — see the note above.
+ */
+const RELATIONS = {
+  draft: {
+    passages: 'passages',
+    passageAnnotations: 'passage_annotations',
+    glossaryTerms: 'glossary_term_index',
+    bibliographies: 'bibliographies',
+  },
+  published: {
+    passages: 'published_passages_live',
+    passageAnnotations: 'published_passage_annotations_live',
+    glossaryTerms: 'published_glossaries_live',
+    bibliographies: 'published_bibliographies_live',
+  },
+} as const satisfies Record<ContentSource, Record<string, string>>;
+
+export type ContentRelation = keyof (typeof RELATIONS)['draft'];
+
+/** The table or view holding `relation` for `source`. */
+export const relationFor = (
+  relation: ContentRelation,
+  source: ContentSource = DEFAULT_CONTENT_SOURCE,
+): string => RELATIONS[source][relation];
+
+/**
+ * RPC names per source. Only the functions still on the reader path have a
+ * published variant; anything reading unversioned data (titles, imprints, folios,
+ * alignments) is shared and absent here.
+ */
+const RPCS = {
+  draft: {
+    workToc: 'get_work_toc',
+    showBibliographies: 'show_bibliographies',
+    bibliographyLabels: 'bibliography_labels',
+    translationSearch: 'translation_search',
+    passageReferences: 'get_passage_annotations_by_content_uuids',
+    workGlossarySearch: 'search_work_glossary_terms',
+  },
+  published: {
+    workToc: 'get_work_toc_published',
+    showBibliographies: 'show_bibliographies_published',
+    bibliographyLabels: 'bibliography_labels_published',
+    translationSearch: 'translation_search_published',
+    passageReferences: 'get_passage_annotations_by_content_uuids_published',
+    workGlossarySearch: 'search_work_glossary_terms_published',
+  },
+} as const satisfies Record<ContentSource, Record<string, string>>;
+
+export type ContentRpc = keyof (typeof RPCS)['draft'];
+
+/** The Postgres function implementing `rpc` for `source`. */
+export const rpcFor = (
+  rpc: ContentRpc,
+  source: ContentSource = DEFAULT_CONTENT_SOURCE,
+): string => RPCS[source][rpc];
+
+/**
+ * Passage columns to select, per source.
+ *
+ * The published snapshot is UUID-only by design — DEV-557 gave `published_passages`
+ * no `xmlId` column — so selecting it there would error. Published passages
+ * therefore surface `xmlId` as null. Nothing in the reader render path reads it;
+ * hash deep links resolve through `lookup()`, which keys xmlIds against the draft
+ * tables and returns a UUID that is stable across both copies.
+ */
+// Callers pass the result to `.select<string, RowDTO>(...)`, declaring the row
+// type explicitly: supabase-js normally infers it by parsing the select string at
+// the type level, which a value chosen at runtime defeats. Nothing is lost —
+// DataClient is an untyped SupabaseClient, so that parse checks the string's shape
+// rather than the actual schema, and every call site already casts to a DTO.
+export const passageColumnsFor = (
+  source: ContentSource = DEFAULT_CONTENT_SOURCE,
+): string =>
+  source === 'published'
+    ? 'uuid, content, label, sort, type, toh, work_uuid'
+    : 'uuid, content, label, sort, type, toh, xmlId, work_uuid';

--- a/libs/data-access/src/lib/content-source.ts
+++ b/libs/data-access/src/lib/content-source.ts
@@ -15,32 +15,45 @@
  * at each call site also lets the cross-work reads express it at all — PostgREST
  * cannot compare two columns.
  *
- * Every function taking a `source` defaults it to `draft`, so adding the
- * parameter changes no existing caller. Reader contexts opt in explicitly.
+ * Every default funnels through DEFAULT_CONTENT_SOURCE, which is `draft`, so
+ * adding this changes no caller's behaviour. A surface reads the published
+ * snapshot only by declaring so.
  */
 export const CONTENT_SOURCES = ['draft', 'published'] as const;
 
 export type ContentSource = (typeof CONTENT_SOURCES)[number];
 
+/**
+ * What a caller gets when it does not choose: the draft tables, which is what
+ * every read did before there was a choice. Every default in this module funnels
+ * through here, so switching a surface to the published snapshot is a deliberate
+ * act at that surface rather than a side effect of this constant.
+ */
 export const DEFAULT_CONTENT_SOURCE: ContentSource = 'draft';
 
 /**
  * The header carrying the source across an API boundary.
  *
  * A request, not a query, chooses the source: an app reads one copy throughout —
- * the studio and editor draft, the reading room and the public MCP API
- * published — so the choice belongs to the caller rather than to each call site.
- * Threading it through every query variable, data function and component prop
- * bought nothing that this does not.
+ * the studio and editor draft, the reading room and the public MCP API published
+ * once each is switched — so the choice belongs to the caller rather than to each
+ * call site. Threading it through every query variable, data function and
+ * component prop bought nothing that this does not.
  */
 export const CONTENT_SOURCE_HEADER = 'x-84000-content-source';
 
 /**
  * How an app declares which copy it serves. Set in `next.config.js` rather than
- * an env file so it is version-controlled and visible in review; apps that do
- * not set it get `published`, which is the safe direction — a studio showing
- * published content is a visible annoyance, a reading room showing drafts is a
- * leak.
+ * an env file so it is version-controlled and visible in review.
+ *
+ * An app that declares nothing gets DEFAULT_CONTENT_SOURCE, which is `draft` —
+ * what every app reads today — so adding this machinery changes no behaviour on
+ * its own. Each surface opts into `published` explicitly when it is ready, which
+ * makes the reader switch a one-line change that can be reverted on its own.
+ *
+ * The cost of that choice: a *new* public surface that forgets to declare gets
+ * draft, so anything reader-facing must declare `published` deliberately rather
+ * than inherit it.
  */
 export const CONTENT_SOURCE_ENV_VAR = 'NEXT_PUBLIC_CONTENT_SOURCE';
 
@@ -51,16 +64,17 @@ export const CONTENT_SOURCE_ENV_VAR = 'NEXT_PUBLIC_CONTENT_SOURCE';
  */
 export const contentSourceFromEnv = (): ContentSource => {
   const declared = process.env[CONTENT_SOURCE_ENV_VAR];
-  return isContentSource(declared) ? declared : 'published';
+  return isContentSource(declared) ? declared : DEFAULT_CONTENT_SOURCE;
 };
 
 /**
- * Narrows a header value. Absent or unrecognised resolves to `published`: a
- * caller that does not ask is treated as public.
+ * Narrows a header value. Absent or unrecognised resolves to
+ * DEFAULT_CONTENT_SOURCE, so a caller that does not ask gets what it would have
+ * got before this header existed.
  */
 export const contentSourceFromHeader = (
   value: string | null | undefined,
-): ContentSource => (isContentSource(value) ? value : 'published');
+): ContentSource => (isContentSource(value) ? value : DEFAULT_CONTENT_SOURCE);
 
 /** Narrows arbitrary input (a GraphQL argument, a query param) to a ContentSource. */
 export const isContentSource = (value: unknown): value is ContentSource =>

--- a/libs/data-access/src/lib/glossary/batch.ts
+++ b/libs/data-access/src/lib/glossary/batch.ts
@@ -1,15 +1,49 @@
 import { DataClient } from '../types';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  relationFor,
+  type ContentSource,
+} from '../content-source';
 
 export const getGlossaryDisplayNamesByUuids = async ({
   client,
   glossaryUuids,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   glossaryUuids: readonly string[];
+  source?: ContentSource;
 }): Promise<Map<string, string>> => {
   const namesByUuid = new Map<string, string>();
   if (glossaryUuids.length === 0) return namesByUuid;
 
+  if (source === 'published') {
+    // The snapshot has no `names` table to join: glossary_term_index already
+    // flattened the term's own name into `english` (and `headword` when the term
+    // has no English name), and that flattening is what freezes the published
+    // display text against later edits to the shared name rows.
+    const { data, error } = await client
+      .from(relationFor('glossaryTerms', source))
+      .select('glossary_uuid, english, headword')
+      .in('glossary_uuid', glossaryUuids as string[]);
+
+    if (error) {
+      console.error('Error batch loading published glossary names:', error);
+      return namesByUuid;
+    }
+
+    for (const term of data ?? []) {
+      const content = term.english || term.headword;
+      if (content) {
+        namesByUuid.set(term.glossary_uuid, content);
+      }
+    }
+
+    return namesByUuid;
+  }
+
+  // Draft reads the raw rows rather than the term index, because the index only
+  // carries translationMain terms and mentions may target any of them.
   const { data, error } = await client
     .from('glossaries')
     .select('uuid, names:names!name_uuid(content)')

--- a/libs/data-access/src/lib/glossary/instance.ts
+++ b/libs/data-access/src/lib/glossary/instance.ts
@@ -4,6 +4,11 @@ import {
   GlossaryTermInstancesDTO,
   glossaryTermInstanceFromDTO,
 } from '../types';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  relationFor,
+  type ContentSource,
+} from '../content-source';
 
 export const getGlossaryInstances = async ({
   client,
@@ -69,9 +74,13 @@ const indexRowToDTO = (
   },
 });
 
-const fetchIndexRow = async (client: DataClient, uuid: string) => {
+const fetchIndexRow = async (
+  client: DataClient,
+  uuid: string,
+  source: ContentSource,
+) => {
   const { data, error } = await client
-    .from('glossary_term_index')
+    .from(relationFor('glossaryTerms', source))
     .select(GLOSSARY_INDEX_COLUMNS)
     .eq('glossary_uuid', uuid)
     .limit(1)
@@ -86,16 +95,23 @@ const fetchIndexRow = async (client: DataClient, uuid: string) => {
 export const getGlossaryInstance = async ({
   client,
   uuid,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   uuid: string;
+  source?: ContentSource;
 }) => {
-  // 1) Direct lookup in the glossary_term_index view.
-  let row = await fetchIndexRow(client, uuid);
+  // 1) Direct lookup in the term index (the published snapshot mirrors its shape).
+  let row = await fetchIndexRow(client, uuid, source);
 
   // 2) Fallback: the uuid may be a non-translationMain child that isn't
   //    represented in the index. Resolve its parent via glossary_edges and
   //    retry the index lookup with the parent uuid.
+  //
+  //    glossary_edges stays on the draft table in both sources: it is an
+  //    unversioned child→parent map, and the UUIDs it returns are stable across
+  //    the draft and published copies, so the retry below still resolves against
+  //    whichever source was asked for.
   if (!row) {
     const { data: edge, error: edgeError } = await client
       .from('glossary_edges')
@@ -106,7 +122,7 @@ export const getGlossaryInstance = async ({
     if (edgeError) {
       console.error(`Error fetching glossary edge: ${uuid} `, edgeError);
     } else if (edge?.parent_uuid) {
-      row = await fetchIndexRow(client, edge.parent_uuid);
+      row = await fetchIndexRow(client, edge.parent_uuid, source);
     }
   }
 

--- a/libs/data-access/src/lib/glossary/pagination.ts
+++ b/libs/data-access/src/lib/glossary/pagination.ts
@@ -1,4 +1,10 @@
 import { DataClient, Passage, PassageDTO, passageFromDTO } from '../types';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  passageColumnsFor,
+  relationFor,
+  type ContentSource,
+} from '../content-source';
 
 type ApiPaginationDirection = 'FORWARD' | 'BACKWARD' | 'AROUND';
 
@@ -131,17 +137,22 @@ export const getGlossaryTermPassagesPage = async ({
   uuid,
   first,
   after,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   uuid: string;
   first?: number;
   after?: string;
+  source?: ContentSource;
 }): Promise<GlossaryPassagesPage> => {
   const limit = Math.max(first ?? DEFAULT_GLOSSARY_PASSAGES_LIMIT, 1);
   const offset = parseOffsetCursor(after);
 
+  // Attestations span works: a term published in one work is cited from others,
+  // so neither query has a single work to scope by. The published relations are
+  // the pointer-resolving views for exactly this reason.
   const { data: annotations, error: annotationsError } = await client
-    .from('passage_annotations')
+    .from(relationFor('passageAnnotations', source))
     .select('passage_uuid')
     .eq('type', 'glossary-instance')
     .filter('content', 'cs', JSON.stringify([{ uuid }]));
@@ -163,8 +174,8 @@ export const getGlossaryTermPassagesPage = async ({
   }
 
   const { data: passages, error: passagesError } = await client
-    .from('passages')
-    .select('uuid, content, label, sort, type, xmlId, work_uuid, toh')
+    .from(relationFor('passages', source))
+    .select<string, PassageDTO>(passageColumnsFor(source))
     .in('uuid', passageUuids)
     .order('sort', { ascending: true })
     .range(offset, offset + limit);
@@ -179,7 +190,7 @@ export const getGlossaryTermPassagesPage = async ({
   const items = hasMore ? rows.slice(0, limit) : rows;
 
   return {
-    items: items.map((passage: PassageDTO) => passageFromDTO(passage)),
+    items: items.map((passage) => passageFromDTO(passage)),
     nextCursor: hasMore ? String(offset + limit) : null,
     hasMore,
   };
@@ -192,6 +203,7 @@ export const getWorkGlossaryTermsPage = async ({
   cursor,
   direction = 'FORWARD',
   withAttestations = false,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   workUuid: string;
@@ -199,8 +211,10 @@ export const getWorkGlossaryTermsPage = async ({
   cursor?: string | null;
   direction?: ApiPaginationDirection;
   withAttestations?: boolean;
+  source?: ContentSource;
 }): Promise<GlossaryTermConnection> => {
   const clampedLimit = Math.min(Math.max(limit, 1), MAX_GLOSSARY_LIMIT);
+  const relation = relationFor('glossaryTerms', source);
 
   if (direction === 'AROUND') {
     return getWorkGlossaryTermsAround({
@@ -209,6 +223,7 @@ export const getWorkGlossaryTermsPage = async ({
       limit: clampedLimit,
       cursor,
       withAttestations,
+      source,
     });
   }
 
@@ -217,12 +232,12 @@ export const getWorkGlossaryTermsPage = async ({
     { data: cursorRows, error: cursorError },
   ] = await Promise.all([
     client
-      .from('glossary_term_index')
+      .from(relation)
       .select('glossary_uuid', { count: 'exact', head: true })
       .eq('work_uuid', workUuid),
     cursor
       ? client
-          .from('glossary_term_index')
+          .from(relation)
           .select('glossary_uuid, term_number')
           .eq('work_uuid', workUuid)
           .eq('glossary_uuid', cursor)
@@ -265,7 +280,7 @@ export const getWorkGlossaryTermsPage = async ({
   const cursorTermNumber =
     cursorRow !== undefined ? parseCount(cursorRow.term_number) : null;
   let query = client
-    .from('glossary_term_index')
+    .from(relation)
     .select(
       `glossary_uuid,
        authority_uuid,
@@ -343,13 +358,17 @@ export const getWorkGlossaryTermsAround = async ({
   limit,
   cursor,
   withAttestations,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   workUuid: string;
   limit: number;
   cursor?: string | null;
   withAttestations: boolean;
+  source?: ContentSource;
 }): Promise<GlossaryTermConnection> => {
+  const relation = relationFor('glossaryTerms', source);
+
   if (!cursor) {
     return getWorkGlossaryTermsPage({
       client,
@@ -358,6 +377,7 @@ export const getWorkGlossaryTermsAround = async ({
       cursor: null,
       direction: 'FORWARD',
       withAttestations,
+      source,
     });
   }
 
@@ -366,11 +386,11 @@ export const getWorkGlossaryTermsAround = async ({
     { data: cursorRows, error: cursorError },
   ] = await Promise.all([
     client
-      .from('glossary_term_index')
+      .from(relation)
       .select('glossary_uuid', { count: 'exact', head: true })
       .eq('work_uuid', workUuid),
     client
-      .from('glossary_term_index')
+      .from(relation)
       .select('glossary_uuid, term_number')
       .eq('work_uuid', workUuid)
       .eq('glossary_uuid', cursor)
@@ -420,7 +440,7 @@ export const getWorkGlossaryTermsAround = async ({
   }
 
   const { data, error } = await client
-    .from('glossary_term_index')
+    .from(relation)
     .select(
       `glossary_uuid,
        authority_uuid,

--- a/libs/data-access/src/lib/glossary/search.ts
+++ b/libs/data-access/src/lib/glossary/search.ts
@@ -1,5 +1,10 @@
 import { DataClient } from '../types';
 import {
+  DEFAULT_CONTENT_SOURCE,
+  rpcFor,
+  type ContentSource,
+} from '../content-source';
+import {
   GlossaryTermIndexRow,
   GlossaryTermNode,
   rowToGlossaryTermNode,
@@ -30,12 +35,14 @@ export const searchWorkGlossaryTerms = async ({
   query,
   limit = DEFAULT_SEARCH_LIMIT,
   withAttestations = false,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   workUuid: string;
   query: string;
   limit?: number;
   withAttestations?: boolean;
+  source?: ContentSource;
 }): Promise<GlossaryTermNode[]> => {
   const trimmed = query.trim();
   if (!trimmed) {
@@ -46,7 +53,7 @@ export const searchWorkGlossaryTerms = async ({
   const pattern = `${escapeIlike(trimmed)}%`;
 
   const { data, error } = await client
-    .rpc('search_work_glossary_terms', {
+    .rpc(rpcFor('workGlossarySearch', source), {
       p_work_uuid: workUuid,
       p_pattern: pattern,
       p_limit: clampedLimit,

--- a/libs/data-access/src/lib/imprint.ts
+++ b/libs/data-access/src/lib/imprint.ts
@@ -5,15 +5,22 @@ import {
   imprintFromDTO,
   tocFromDTO,
 } from './types';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  rpcFor,
+  type ContentSource,
+} from './content-source';
 
 export const getTranslationToc = async ({
   client,
   uuid,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   uuid: string;
+  source?: ContentSource;
 }) => {
-  const { data, error } = await client.rpc('get_work_toc', {
+  const { data, error } = await client.rpc(rpcFor('workToc', source), {
     work_uuid_input: uuid,
   });
 

--- a/libs/data-access/src/lib/passage/batch.ts
+++ b/libs/data-access/src/lib/passage/batch.ts
@@ -7,13 +7,22 @@ import {
   Passages,
   passageFromDTO,
 } from '../types';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  passageColumnsFor,
+  relationFor,
+  rpcFor,
+  type ContentSource,
+} from '../content-source';
 
 export const getAnnotationsByPassageUuids = async ({
   client,
   passageUuids,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   passageUuids: readonly string[];
+  source?: ContentSource;
 }): Promise<Map<string, AnnotationDTO[]>> => {
   const annotationsByPassage = new Map<string, AnnotationDTO[]>();
 
@@ -28,9 +37,11 @@ export const getAnnotationsByPassageUuids = async ({
 
   while (hasMore) {
     const { data, error } = await client
-      .from('passage_annotations')
+      .from(relationFor('passageAnnotations', source))
       .select('uuid, passage_uuid, type, start, end, content, toh')
       .in('passage_uuid', passageUuids as string[])
+      // The published snapshot already excludes `deprecated%` types, so this is
+      // a no-op there; it stays unconditional to keep one code path.
       .not('type', 'like', 'deprecated%')
       // deterministic order is required for stable pagination; without it
       // postgres may return rows in a different order per page, skipping or
@@ -128,9 +139,11 @@ export const getAlignmentsByPassageUuids = async ({
 export const getPassageLabelsByUuids = async ({
   client,
   passageUuids,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   passageUuids: readonly string[];
+  source?: ContentSource;
 }): Promise<Map<string, string>> => {
   const labelsByUuid = new Map<string, string>();
 
@@ -138,8 +151,10 @@ export const getPassageLabelsByUuids = async ({
     return labelsByUuid;
   }
 
+  // Cross-work by nature: endnote and mention targets may live in another work,
+  // which is why the published relation resolves the version pointer itself.
   const { data, error } = await client
-    .from('passages')
+    .from(relationFor('passages', source))
     .select('uuid, label')
     .in('uuid', passageUuids as string[]);
 
@@ -160,9 +175,11 @@ export const getPassageLabelsByUuids = async ({
 export const getPassageReferencesByTargetUuids = async ({
   client,
   passageUuids,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   passageUuids: readonly string[];
+  source?: ContentSource;
 }): Promise<Map<string, Passages>> => {
   const referencesByTargetUuid = new Map<string, Passages>();
 
@@ -171,7 +188,7 @@ export const getPassageReferencesByTargetUuids = async ({
   }
 
   const { data: annotations, error: annotationsError } = await client.rpc(
-    'get_passage_annotations_by_content_uuids',
+    rpcFor('passageReferences', source),
     {
       annotation_type: 'end-note-link',
       target_uuids: passageUuids as string[],
@@ -208,8 +225,8 @@ export const getPassageReferencesByTargetUuids = async ({
   for (let i = 0; i < sourceUuidArray.length; i += inBatchSize) {
     const batch = sourceUuidArray.slice(i, i + inBatchSize);
     const { data, error } = await client
-      .from('passages')
-      .select('uuid, content, label, sort, type, toh, xmlId, work_uuid')
+      .from(relationFor('passages', source))
+      .select<string, PassageDTO>(passageColumnsFor(source))
       .in('uuid', batch);
 
     if (error) {
@@ -217,7 +234,7 @@ export const getPassageReferencesByTargetUuids = async ({
       return new Map();
     }
 
-    for (const row of (data ?? []) as PassageDTO[]) {
+    for (const row of data ?? []) {
       passageMap.set(row.uuid, passageFromDTO(row));
     }
   }

--- a/libs/data-access/src/lib/passage/pagination.ts
+++ b/libs/data-access/src/lib/passage/pagination.ts
@@ -1,4 +1,10 @@
 import { DataClient, PassageRowDTO } from '../types';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  passageColumnsFor,
+  relationFor,
+  type ContentSource,
+} from '../content-source';
 
 type ApiPaginationDirection = 'FORWARD' | 'BACKWARD' | 'AROUND';
 
@@ -71,6 +77,7 @@ export const getWorkPassagesConnection = async ({
   limit = DEFAULT_PASSAGE_CONNECTION_LIMIT,
   filter,
   direction = 'FORWARD',
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   workUuid: string;
@@ -78,11 +85,13 @@ export const getWorkPassagesConnection = async ({
   limit?: number;
   filter?: { type?: string; types?: string[]; label?: string };
   direction?: ApiPaginationDirection;
+  source?: ContentSource;
 }): Promise<PassageConnectionPage> => {
   const clampedLimit = Math.min(
     Math.max(limit, 1),
     MAX_PASSAGE_CONNECTION_LIMIT,
   );
+  const relation = relationFor('passages', source);
 
   if (direction === 'AROUND') {
     return getWorkPassagesAround({
@@ -91,6 +100,7 @@ export const getWorkPassagesConnection = async ({
       cursor,
       limit: clampedLimit,
       filter,
+      source,
     });
   }
 
@@ -98,7 +108,7 @@ export const getWorkPassagesConnection = async ({
   let cursorSort: number | null = null;
   if (cursor) {
     const { data: cursorPassage } = await client
-      .from('passages')
+      .from(relation)
       .select('sort')
       .eq('uuid', cursor)
       .single();
@@ -109,8 +119,8 @@ export const getWorkPassagesConnection = async ({
   }
 
   let query = client
-    .from('passages')
-    .select('uuid, content, label, sort, type, toh, xmlId, work_uuid')
+    .from(relation)
+    .select<string, PassageRowDTO>(passageColumnsFor(source))
     .eq('work_uuid', workUuid)
     .order('sort', { ascending: isForward })
     .limit(clampedLimit + 1);
@@ -138,7 +148,7 @@ export const getWorkPassagesConnection = async ({
     return EMPTY_PASSAGE_CONNECTION;
   }
 
-  const passages = (data ?? []) as PassageRowDTO[];
+  const passages = data ?? [];
   const hasMore = passages.length > clampedLimit;
   let resultPassages = hasMore ? passages.slice(0, clampedLimit) : passages;
 
@@ -174,20 +184,24 @@ export const getWorkPassagesAround = async ({
   cursor,
   limit,
   filter,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   workUuid: string;
   cursor?: string;
   limit: number;
   filter?: { type?: string; types?: string[]; label?: string };
+  source?: ContentSource;
 }): Promise<PassageConnectionPage> => {
   if (!cursor) {
     console.error('AROUND direction requires a cursor');
     return EMPTY_PASSAGE_CONNECTION;
   }
 
+  const relation = relationFor('passages', source);
+
   const { data: cursorPassage } = await client
-    .from('passages')
+    .from(relation)
     .select('sort')
     .eq('uuid', cursor)
     .single();
@@ -200,19 +214,19 @@ export const getWorkPassagesAround = async ({
   const cursorSort = cursorPassage.sort;
   const limitBefore = Math.floor(limit / 2);
   const limitAfter = limit - limitBefore;
-  const baseSelect = 'uuid, content, label, sort, type, toh, xmlId, work_uuid';
+  const baseSelect = passageColumnsFor(source);
 
   let beforeQuery = client
-    .from('passages')
-    .select(baseSelect)
+    .from(relation)
+    .select<string, PassageRowDTO>(baseSelect)
     .eq('work_uuid', workUuid)
     .lt('sort', cursorSort)
     .order('sort', { ascending: false })
     .limit(limitBefore + 1);
 
   let afterQuery = client
-    .from('passages')
-    .select(baseSelect)
+    .from(relation)
+    .select<string, PassageRowDTO>(baseSelect)
     .eq('work_uuid', workUuid)
     .gte('sort', cursorSort)
     .order('sort', { ascending: true })
@@ -245,8 +259,8 @@ export const getWorkPassagesAround = async ({
     return EMPTY_PASSAGE_CONNECTION;
   }
 
-  const passagesBefore = (beforeResult.data ?? []) as PassageRowDTO[];
-  const passagesAfter = (afterResult.data ?? []) as PassageRowDTO[];
+  const passagesBefore = beforeResult.data ?? [];
+  const passagesAfter = afterResult.data ?? [];
   const hasMoreBefore = passagesBefore.length > limitBefore;
   const hasMoreAfter = passagesAfter.length > limitAfter;
   const trimmedBefore = hasMoreBefore

--- a/libs/data-access/src/lib/passage/read.ts
+++ b/libs/data-access/src/lib/passage/read.ts
@@ -1,9 +1,16 @@
 import {
   DataClient,
   PassageDTO,
+  PassageRowDTO,
   annotationsFromDTO,
   passageFromDTO,
 } from '../types';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  passageColumnsFor,
+  relationFor,
+  type ContentSource,
+} from '../content-source';
 
 import { PassageConnectionNode } from './pagination';
 
@@ -36,18 +43,27 @@ export const getPassageByUuidOrXmlId = async ({
   client,
   uuid,
   xmlId,
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   uuid?: string;
   xmlId?: string;
+  source?: ContentSource;
 }): Promise<PassageConnectionNode | null> => {
   if (!uuid && !xmlId) {
     return null;
   }
 
+  // The published snapshot carries no xmlIds, so an xmlId lookup can only be
+  // answered from draft. Callers resolving a hash deep link go through
+  // `lookup()` for the same reason: it maps the xmlId to a UUID, which is
+  // stable across both copies and then resolves in whichever source was asked
+  // for.
+  const effectiveSource = xmlId && !uuid ? 'draft' : source;
+
   let query = client
-    .from('passages')
-    .select('uuid, content, label, sort, type, xmlId, toh, work_uuid');
+    .from(relationFor('passages', effectiveSource))
+    .select<string, PassageRowDTO>(passageColumnsFor(effectiveSource));
 
   if (uuid) {
     query = query.eq('uuid', uuid);

--- a/libs/data-access/src/lib/publications.ts
+++ b/libs/data-access/src/lib/publications.ts
@@ -237,7 +237,8 @@ export const getTranslationMetadataByUuid = async ({
       publicationVersion,
       pages:source_pages,
       restriction,
-      breadcrumb
+      breadcrumb,
+      published_version_uuid
     `,
     )
     .eq('uuid', uuid)
@@ -307,7 +308,8 @@ export const getTranslationsMetadata = async ({
       publicationVersion,
       pages:source_pages,
       restriction,
-      breadcrumb
+      breadcrumb,
+      published_version_uuid
     `,
     )
     .not('toh', 'like', 'toh00%');
@@ -345,7 +347,8 @@ export const getWorksPage = async ({
       publicationVersion,
       pages:source_pages,
       restriction,
-      breadcrumb
+      breadcrumb,
+      published_version_uuid
     `,
       { count: 'exact' },
     )

--- a/libs/data-access/src/lib/types/work.ts
+++ b/libs/data-access/src/lib/types/work.ts
@@ -14,6 +14,12 @@ export type Work = {
   pages: number;
   restriction: boolean;
   section: string;
+  /**
+   * The live published version, or undefined for a work that has never been
+   * published. The reader uses it to tell "not yet published" apart from
+   * "does not exist"; it is the same pointer the published_*_live views join on.
+   */
+  publishedVersionUuid?: string;
 };
 
 export type WorkDTO = {
@@ -26,6 +32,7 @@ export type WorkDTO = {
   pages: number;
   restriction: boolean;
   breadcrumb?: string;
+  published_version_uuid?: string | null;
 };
 
 export const workFromDTO = (dto: WorkDTO) => ({
@@ -38,4 +45,5 @@ export const workFromDTO = (dto: WorkDTO) => ({
   pages: dto.pages || 0,
   restriction: dto.restriction,
   section: dto.breadcrumb?.split('>').at(-2)?.trim() || '',
+  publishedVersionUuid: dto.published_version_uuid ?? undefined,
 });

--- a/libs/lib-editing/src/lib/components/shared/PublishDialog.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/PublishDialog.spec.tsx
@@ -333,6 +333,14 @@ describe('PublishDialog', () => {
     renderDialog();
 
     await userEvent.click(screen.getByRole('button', { name: 'Publish' }));
+    // The poll is registered by an effect that only runs once the publish
+    // mutation has resolved and the job is in state. Advancing the clock before
+    // that commit schedules nothing, so wait for the phase to render first —
+    // the same barrier 'keeps watching a job that is still running' uses.
+    await waitFor(() =>
+      expect(screen.getByText('Copying the draft…')).toBeTruthy(),
+    );
+
     jest.advanceTimersByTime(4000);
 
     await waitFor(() => expect(mockGetPublishJob).toHaveBeenCalled());

--- a/libs/lib-search/src/lib/data/search.ts
+++ b/libs/lib-search/src/lib/data/search.ts
@@ -2,21 +2,31 @@
 
 import { createServerClient } from '@eightyfourthousand/data-access/ssr';
 import { searchResultsFromDTO } from '../types';
-import { DataClient } from '@eightyfourthousand/data-access';
+import {
+  DEFAULT_CONTENT_SOURCE,
+  contentSourceFromEnv,
+  rpcFor,
+  type ContentSource,
+  type DataClient,
+} from '@eightyfourthousand/data-access';
 
 export const search = async ({
   text,
   uuid,
   toh,
   useRegex = false,
+  // Follows the app this action runs in: draft in the studio, published in the
+  // reading room.
+  source = contentSourceFromEnv(),
 }: {
   text: string;
   uuid: string;
   toh: string;
   useRegex?: boolean;
+  source?: ContentSource;
 }) => {
   const client = await createServerClient();
-  return await searchWithClient({ client, text, uuid, toh, useRegex });
+  return await searchWithClient({ client, text, uuid, toh, useRegex, source });
 };
 
 export const searchWithClient = async ({
@@ -25,14 +35,19 @@ export const searchWithClient = async ({
   uuid,
   toh,
   useRegex = false,
+  // Not env-derived: lib-agent calls this for the public MCP API, which reads
+  // draft throughout until that path is switched. Leaving it ambient here would
+  // make MCP search published while the rest of MCP stayed draft.
+  source = DEFAULT_CONTENT_SOURCE,
 }: {
   client: DataClient;
   text: string;
   uuid: string;
   toh: string;
   useRegex?: boolean;
+  source?: ContentSource;
 }) => {
-  const { data, error } = await client.rpc('translation_search', {
+  const { data, error } = await client.rpc(rpcFor('translationSearch', source), {
     search_term: text,
     work_uuid: uuid,
     toh: toh,

--- a/libs/lib-search/src/lib/data/search.ts
+++ b/libs/lib-search/src/lib/data/search.ts
@@ -15,8 +15,8 @@ export const search = async ({
   uuid,
   toh,
   useRegex = false,
-  // Follows the app this action runs in: draft in the studio, published in the
-  // reading room.
+  // Follows the app this action runs in, so public search tracks whatever that
+  // app serves rather than needing its own decision.
   source = contentSourceFromEnv(),
 }: {
   text: string;


### PR DESCRIPTION
### Summary

Adds the machinery for the reader to serve the published snapshot but lands it as a no-op to start. Every default funnels through `DEFAULT_CONTENT_SOURCE`, which is `draft` to start. Merging should result in no change. Switching a specific surface to published -- or all by default -- is a separate change.

### Linear

- [DEV-558](https://linear.app/84000/issue/DEV-558)