### PR TITLE
Label the bibliography-entry-unheaded publish finding

### DIFF
--- a/libs/lib-editing/src/lib/components/shared/PublishChecksPanel.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/PublishChecksPanel.spec.tsx
@@ -100,6 +100,43 @@ describe('PublishChecksPanel', () => {
     expect(screen.queryByText(/blocking publication/i)).toBeNull();
   });
 
+  // The rule id falls back to itself when unlabelled, so a new SQL rule that reaches the UI
+  // without an entry here shows as raw kebab-case. This is the guard for that.
+  it('gives bibliography-entry-unheaded a readable title and an explanation', async () => {
+    seed(
+      readiness({
+        ok: false,
+        errors: [
+          {
+            rule: 'bibliography-entry-unheaded',
+            severity: 'error',
+            message:
+              'Bibliography entries have no heading in a work that has headings, so they would appear in no section.',
+            // No subjects: this test is about the label and the note, and subjects would
+            // pull in the finding-location lookup that other tests cover.
+            subjects: [],
+            count: 0,
+          },
+        ],
+      }),
+    );
+
+    await renderPanel();
+
+    // The title is the accordion trigger; the note lives in its content, so it only exists
+    // once expanded.
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: /Bibliography entries with no heading/i,
+      }),
+    );
+
+    expect(screen.queryByText('bibliography-entry-unheaded')).toBeNull();
+    expect(
+      screen.getByText(/would be published but shown nowhere/),
+    ).toBeTruthy();
+  });
+
   it('labels warnings as non-blocking and keeps them out of the blocking count', async () => {
     seed(
       readiness({

--- a/libs/lib-editing/src/lib/components/shared/PublishChecksPanel.tsx
+++ b/libs/lib-editing/src/lib/components/shared/PublishChecksPanel.tsx
@@ -55,6 +55,7 @@ const RULE_TITLES: Record<string, string> = {
     'References that exist only as an xmlId with no resolved uuid',
   'bibliography-heading-unresolved':
     'Bibliography headings that do not resolve',
+  'bibliography-entry-unheaded': 'Bibliography entries with no heading',
   'glossary-index-unavailable': 'Glossary index unavailable',
   'work-not-found': 'Work not found',
   'xmlid-stripped': 'Deprecated xmlIds',
@@ -75,6 +76,8 @@ const RULE_NOTES: Record<string, string> = {
   'inline-marker-unresolved':
     'Only markers that are always local are checked: end notes, abbreviations, and mentions or internal links explicitly flagged as same-work. Cross-work links are valid and not reported here.',
   'xmlid-stripped': 'XML ID values are not retained when a work is published.',
+  'bibliography-entry-unheaded':
+    'An entry appears only inside a heading section, and a work with any headings has no headingless section to fall back to — so these entries would be published but shown nowhere. Give them a heading, or remove the work’s headings.',
 };
 
 const findingKey = (finding: PublishFinding) => finding.rule;


### PR DESCRIPTION
### Summary

Gives the new `bibliography-entry-unheaded` publish rule a readable title and an explanatory note in `PublishChecksPanel`.

### Linear

- [DEV-746](https://linear.app/84000/issue/DEV-746)