### PR TITLE
Serve the live published version, and read publication status properly

### DIFF
--- a/apps/api-graphql/src/graphql/loaders.ts
+++ b/apps/api-graphql/src/graphql/loaders.ts
@@ -9,6 +9,7 @@ import { createWorkTitleLoader } from './schema/work/work-title.loader';
 import { createFolioLoader } from './schema/folio/folio.loader';
 import { createBibliographyLabelLoader } from './schema/bibliography/bibliography-label.loader';
 import { createImprintLoader } from './schema/imprint/imprint.loader';
+import { createPublishedVersionLoader } from './schema/work/published-version.loader';
 
 export interface Loaders {
   /**
@@ -72,6 +73,12 @@ export interface Loaders {
    * Batches the per-work imprint RPC into a single query for list results.
    */
   imprintsByWorkToh: ReturnType<typeof createImprintLoader>;
+
+  /**
+   * Load the live version label by version uuid.
+   * Used by Work.publishedVersion, which has only the pointer to work from.
+   */
+  publishedVersionsByUuid: ReturnType<typeof createPublishedVersionLoader>;
 }
 
 /**
@@ -96,5 +103,6 @@ export function createLoaders(
     foliosByUuid: createFolioLoader(supabase),
     bibliographyLabelsByUuid: createBibliographyLabelLoader(supabase, source),
     imprintsByWorkToh: createImprintLoader(supabase),
+    publishedVersionsByUuid: createPublishedVersionLoader(supabase),
   };
 }

--- a/apps/api-graphql/src/graphql/resolvers.ts
+++ b/apps/api-graphql/src/graphql/resolvers.ts
@@ -36,6 +36,7 @@ import {
 } from './schema/passage/passage.field-resolver';
 import { tocResolver } from './schema/toc/toc.resolver';
 import { titlesResolver } from './schema/work/title.resolver';
+import { publishedVersionResolver } from './schema/work/published-version.resolver';
 import { searchResolver } from './schema/search/search.resolver';
 
 export const resolvers = {
@@ -65,6 +66,7 @@ export const resolvers = {
     toc: tocResolver,
     passages: passagesResolver,
     titles: titlesResolver,
+    publishedVersion: publishedVersionResolver,
     glossary: workGlossaryResolver,
     glossaryTerms: workGlossaryTermsResolver,
     searchGlossaryTerms: searchWorkGlossaryTermsResolver,

--- a/apps/api-graphql/src/graphql/schema/work/published-version.loader.ts
+++ b/apps/api-graphql/src/graphql/schema/work/published-version.loader.ts
@@ -1,0 +1,21 @@
+import DataLoader from 'dataloader';
+import {
+  getVersionLabelsByUuids,
+  type DataClient,
+} from '@eightyfourthousand/data-access';
+
+/**
+ * Creates a DataLoader for the live version label, keyed by version uuid.
+ *
+ * `works` carries only the pointer, so the label is one join away and a list query
+ * selecting `publishedVersion` would otherwise make a round trip per work.
+ */
+export function createPublishedVersionLoader(supabase: DataClient) {
+  return new DataLoader<string, string | null>(async (versionUuids) => {
+    const labelsByUuid = await getVersionLabelsByUuids({
+      client: supabase,
+      versionUuids,
+    });
+    return versionUuids.map((uuid) => labelsByUuid.get(uuid) ?? null);
+  });
+}

--- a/apps/api-graphql/src/graphql/schema/work/published-version.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/work/published-version.resolver.ts
@@ -1,0 +1,24 @@
+import type { GraphQLContext } from '../../context';
+import type { WorkParent } from './work.types';
+
+/**
+ * Field resolver for Work.publishedVersion.
+ *
+ * Null means never published, which is why this field is nullable where
+ * `publicationVersion` is not: that column always carries a value, so it cannot express
+ * the difference between "published at 1.0.0" and "not published".
+ *
+ * Resolved from the pointer rather than from a column on works, so it is the version
+ * actually being served. `publicationVersion` is not written by the publish pipeline at
+ * all, and diverges from this the moment a work is republished.
+ */
+export const publishedVersionResolver = async (
+  parent: WorkParent,
+  _args: unknown,
+  ctx: GraphQLContext,
+) => {
+  if (!parent.publishedVersionUuid) {
+    return null;
+  }
+  return ctx.loaders.publishedVersionsByUuid.load(parent.publishedVersionUuid);
+};

--- a/apps/api-graphql/src/graphql/schema/work/work.graphql
+++ b/apps/api-graphql/src/graphql/schema/work/work.graphql
@@ -26,6 +26,26 @@ type Work {
   Semantic version of the publication (e.g., "1.0.0")
   """
   publicationVersion: String!
+    @deprecated(
+      reason: "Reads works.publicationVersion, which the publish pipeline never writes, so it does not identify the version being served. Use publishedVersion."
+    )
+
+  """
+  The version currently published, from work_versions via works.published_version_uuid.
+
+  Null for a work that has never been published — which is the difference from
+  publicationVersion, a text column that carries a value regardless.
+  """
+  publishedVersion: String
+
+  """
+  Editorial publication status code, e.g. "1", "1.a", "2.h", "3".
+
+  A major segment of "1" means published. This is the authority on publication status —
+  not the version number, and not the presence of a published snapshot, which a public
+  work can lack if it has never been through the versioning pipeline.
+  """
+  publicationStatus: String
 
   """
   Number of source pages

--- a/apps/api-graphql/src/graphql/schema/work/work.types.ts
+++ b/apps/api-graphql/src/graphql/schema/work/work.types.ts
@@ -8,6 +8,11 @@ export interface WorkParent {
   title: string;
   publicationDate: string;
   publicationVersion: string;
+  /**
+   * The live version's uuid, or undefined for a work never published. Work.publishedVersion
+   * resolves the label from it; the label itself lives on work_versions.
+   */
+  publishedVersionUuid?: string;
   pages: number;
   restriction: boolean;
   section: string;

--- a/libs/client-graphql/src/lib/functions/get-translation-metadata.ts
+++ b/libs/client-graphql/src/lib/functions/get-translation-metadata.ts
@@ -11,6 +11,8 @@ const GET_WORK_BY_UUID = gql`
       toh
       publicationDate
       publicationVersion
+      publishedVersion
+      publicationStatus
       pages
       restriction
       section
@@ -26,6 +28,8 @@ const GET_WORK_BY_TOH = gql`
       toh
       publicationDate
       publicationVersion
+      publishedVersion
+      publicationStatus
       pages
       restriction
       section

--- a/libs/client-graphql/src/lib/functions/get-translations-metadata.ts
+++ b/libs/client-graphql/src/lib/functions/get-translations-metadata.ts
@@ -12,6 +12,8 @@ const GET_ALL_WORKS = gql`
         toh
         publicationDate
         publicationVersion
+        publishedVersion
+        publicationStatus
         pages
         restriction
         section

--- a/libs/client-graphql/src/lib/graphql/fragments/work.graphql
+++ b/libs/client-graphql/src/lib/graphql/fragments/work.graphql
@@ -4,6 +4,8 @@ fragment WorkFields on Work {
   toh
   publicationDate
   publicationVersion
+  publishedVersion
+  publicationStatus
   pages
   restriction
   section

--- a/libs/client-graphql/src/lib/mappers/work.ts
+++ b/libs/client-graphql/src/lib/mappers/work.ts
@@ -9,6 +9,8 @@ export type GraphQLWork = {
   toh: string[];
   publicationDate: string | null;
   publicationVersion: string;
+  publishedVersion?: string | null;
+  publicationStatus?: string | null;
   pages: number;
   restriction: boolean;
   section: string;
@@ -36,6 +38,10 @@ export function workFromGraphQL(gqlWork: GraphQLWork): Work {
       ? new Date(gqlWork.publicationDate)
       : undefined,
     publicationVersion: gqlWork.publicationVersion as SemVer,
+    publishedVersion: (gqlWork.publishedVersion ?? undefined) as
+      | SemVer
+      | undefined,
+    publicationStatus: gqlWork.publicationStatus ?? undefined,
     pages: gqlWork.pages,
     restriction: gqlWork.restriction,
     section: gqlWork.section,

--- a/libs/data-access/src/lib/publications.ts
+++ b/libs/data-access/src/lib/publications.ts
@@ -238,7 +238,8 @@ export const getTranslationMetadataByUuid = async ({
       pages:source_pages,
       restriction,
       breadcrumb,
-      published_version_uuid
+      published_version_uuid,
+      publicationStatus
     `,
     )
     .eq('uuid', uuid)
@@ -309,7 +310,8 @@ export const getTranslationsMetadata = async ({
       pages:source_pages,
       restriction,
       breadcrumb,
-      published_version_uuid
+      published_version_uuid,
+      publicationStatus
     `,
     )
     .not('toh', 'like', 'toh00%');
@@ -348,7 +350,8 @@ export const getWorksPage = async ({
       pages:source_pages,
       restriction,
       breadcrumb,
-      published_version_uuid
+      published_version_uuid,
+      publicationStatus
     `,
       { count: 'exact' },
     )
@@ -404,4 +407,41 @@ export const getWorksPage = async ({
     },
     totalCount: count ?? 0,
   };
+};
+
+/**
+ * The live version label for each of `versionUuids`.
+ *
+ * The label lives on `work_versions`, one join away from the pointer a work carries, so a
+ * list query would otherwise make a round trip per work. Batched for the GraphQL loader.
+ *
+ * Absent from the map means the pointer names a row that is not there. That should not
+ * happen — the pointer is a foreign key — but the caller distinguishes it from "never
+ * published", which is a null pointer and never reaches here.
+ */
+export const getVersionLabelsByUuids = async ({
+  client,
+  versionUuids,
+}: {
+  client: DataClient;
+  versionUuids: readonly string[];
+}): Promise<Map<string, string>> => {
+  const labelsByUuid = new Map<string, string>();
+  if (versionUuids.length === 0) return labelsByUuid;
+
+  const { data, error } = await client
+    .from('work_versions')
+    .select('uuid, version')
+    .in('uuid', versionUuids as string[]);
+
+  if (error) {
+    console.error('Error batch loading version labels:', error);
+    return labelsByUuid;
+  }
+
+  for (const row of data ?? []) {
+    if (row.version) labelsByUuid.set(row.uuid, row.version);
+  }
+
+  return labelsByUuid;
 };

--- a/libs/data-access/src/lib/types/semver.ts
+++ b/libs/data-access/src/lib/types/semver.ts
@@ -1,14 +1,1 @@
 export type SemVer = `${number}.${number}.${number}`;
-
-/**
- * Whether a publication version represents a published work. A major version
- * below 1 (e.g. `0.x.x`) is considered in-progress / not yet published.
- * An undefined or unparseable version is treated as published (don't gate).
- */
-export const isPublishedVersion = (version?: SemVer): boolean => {
-  if (!version) {
-    return true;
-  }
-  const major = Number(version.split('.')[0]);
-  return Number.isFinite(major) && major >= 1;
-};

--- a/libs/data-access/src/lib/types/work.ts
+++ b/libs/data-access/src/lib/types/work.ts
@@ -20,6 +20,25 @@ export type Work = {
    * "does not exist"; it is the same pointer the published_*_live views join on.
    */
   publishedVersionUuid?: string;
+  /**
+   * The label of the version currently published, or undefined for a work never
+   * published.
+   *
+   * Prefer this over `publicationVersion`, which is a text column on `works` that
+   * the publish pipeline never writes: the two agree only until a work is
+   * republished, after which the legacy column names a version that is no longer
+   * being served.
+   */
+  publishedVersion?: SemVer;
+  /**
+   * The editorial publication status code, e.g. `1`, `1.a`, `2.h`, `3`.
+   *
+   * A major segment of `1` means published; everything else is a stage on the way
+   * there. This is the authority on whether a work is published — not the version
+   * number, and not the presence of a published snapshot, which a public work can
+   * lack if it has never been through the versioning pipeline.
+   */
+  publicationStatus?: string;
 };
 
 export type WorkDTO = {
@@ -33,6 +52,7 @@ export type WorkDTO = {
   restriction: boolean;
   breadcrumb?: string;
   published_version_uuid?: string | null;
+  publicationStatus?: string | null;
 };
 
 export const workFromDTO = (dto: WorkDTO) => ({
@@ -40,10 +60,29 @@ export const workFromDTO = (dto: WorkDTO) => ({
   title: dto.title || '<Untitled>',
   description: dto.description || '',
   toh: dto.tohs.map((t) => t.toh) as TohokuCatalogEntry[],
-  publicationDate: dto.publicationDate ? new Date(dto.publicationDate) : undefined,
+  publicationDate: dto.publicationDate
+    ? new Date(dto.publicationDate)
+    : undefined,
   publicationVersion: (dto.publicationVersion || '0.0.0') as SemVer,
   pages: dto.pages || 0,
   restriction: dto.restriction,
   section: dto.breadcrumb?.split('>').at(-2)?.trim() || '',
   publishedVersionUuid: dto.published_version_uuid ?? undefined,
+  publicationStatus: dto.publicationStatus ?? undefined,
 });
+
+/**
+ * Whether a work is published, per its `publicationStatus` code.
+ *
+ * A major segment of `1` (`1`, `1.a`, …) is published; `0`, `2.x`, `3` and `4` are stages
+ * before that. Measured against production: every one of the 456 works with a major of 1
+ * carries a publication date, and none of the other 3,833 does.
+ *
+ * Deliberately not derived from the version number, which the previous
+ * `isPublishedVersion` heuristic used: that read three works wrongly, because a published
+ * work can sit below 1.0.0 and an unpublished one can carry a legacy label above it. Nor
+ * from the published snapshot pointer, which two public works legitimately lack — they have
+ * never been through the versioning pipeline because their legacy label is not SemVer.
+ */
+export const isPublishedStatus = (status?: string | null): boolean =>
+  (status ?? '').split('.')[0] === '1';

--- a/libs/data-access/src/lib/version-label.spec.ts
+++ b/libs/data-access/src/lib/version-label.spec.ts
@@ -1,0 +1,112 @@
+import { getVersionLabelsByUuids } from './publications';
+import { isPublishedStatus } from './types/work';
+import { DataClient } from './types';
+
+const createMockClient = (result: { data: unknown; error: unknown }) => {
+  const inFn = jest.fn(() => Promise.resolve(result));
+  const select = jest.fn(() => ({ in: inFn }));
+  const from = jest.fn(() => ({ select }));
+  return { client: { from } as unknown as DataClient, from, select, in: inFn };
+};
+
+describe('getVersionLabelsByUuids', () => {
+  it('reads work_versions in one query and keys labels by version uuid', async () => {
+    const mock = createMockClient({
+      data: [
+        { uuid: 'v1', version: '1.2.3' },
+        { uuid: 'v2', version: '0.1.18' },
+      ],
+      error: null,
+    });
+
+    const labels = await getVersionLabelsByUuids({
+      client: mock.client,
+      versionUuids: ['v1', 'v2'],
+    });
+
+    expect(mock.from).toHaveBeenCalledTimes(1);
+    expect(mock.from).toHaveBeenCalledWith('work_versions');
+    expect(mock.in).toHaveBeenCalledWith('uuid', ['v1', 'v2']);
+    expect(labels.get('v1')).toBe('1.2.3');
+    // A published work below 1.0.0 is still published. The version number is a label,
+    // not a publication status, which is the assumption the old major-version heuristic made.
+    expect(labels.get('v2')).toBe('0.1.18');
+  });
+
+  it('makes no query for an empty batch', async () => {
+    const mock = createMockClient({ data: [], error: null });
+
+    const labels = await getVersionLabelsByUuids({
+      client: mock.client,
+      versionUuids: [],
+    });
+
+    expect(mock.from).not.toHaveBeenCalled();
+    expect(labels.size).toBe(0);
+  });
+
+  // A pointer naming a row that is not there should read as "unknown", not crash the query
+  // that asked for it — the caller renders an absent label rather than failing the work.
+  it('omits a uuid the query did not return', async () => {
+    const mock = createMockClient({
+      data: [{ uuid: 'v1', version: '1.0.0' }],
+      error: null,
+    });
+
+    const labels = await getVersionLabelsByUuids({
+      client: mock.client,
+      versionUuids: ['v1', 'missing'],
+    });
+
+    expect(labels.get('v1')).toBe('1.0.0');
+    expect(labels.has('missing')).toBe(false);
+  });
+
+  it('returns an empty map on error rather than throwing', async () => {
+    const spy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const mock = createMockClient({ data: null, error: { message: 'boom' } });
+
+    const labels = await getVersionLabelsByUuids({
+      client: mock.client,
+      versionUuids: ['v1'],
+    });
+
+    expect(labels.size).toBe(0);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('isPublishedStatus', () => {
+  // Measured against production: 456 works carry a major of 1 and all have a publication
+  // date; none of the other 3,833 does.
+  it.each([
+    ['1', true],
+    ['1.a', true],
+    ['0', false],
+    ['2', false],
+    ['2.h', false],
+    ['3', false],
+    ['4', false],
+  ])('reads %s as published=%s', (status, expected) => {
+    expect(isPublishedStatus(status)).toBe(expected);
+  });
+
+  // Unknown is not published. The old version heuristic did the opposite — it treated an
+  // absent value as published so as not to gate — which is how two unpublished works read
+  // as published.
+  it('treats an absent status as not published', () => {
+    expect(isPublishedStatus(undefined)).toBe(false);
+    expect(isPublishedStatus(null)).toBe(false);
+    expect(isPublishedStatus('')).toBe(false);
+  });
+
+  // A published work below 1.0.0 exists (0.1.18) and a public work can have a legacy label
+  // of 1.0 with no snapshot at all, so neither the version nor the pointer decides this.
+  it('does not depend on the version number', () => {
+    expect(isPublishedStatus('1.a')).toBe(true);
+    expect(isPublishedStatus('0.9')).toBe(false);
+  });
+});

--- a/libs/lib-editing/src/lib/components/reader/ReaderBodyPage.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBodyPage.tsx
@@ -7,6 +7,7 @@ import {
   getTranslationTitles,
 } from '@eightyfourthousand/client-graphql/ssr';
 import { ReaderBodyPanel } from './ReaderBodyPanel';
+import { isPublishedStatus } from '@eightyfourthousand/data-access';
 import { isUuid } from '@eightyfourthousand/lib-utils';
 import { notFound } from 'next/navigation';
 
@@ -53,7 +54,11 @@ export const ReaderBodyPage = async ({
       body={body}
       frontMatterHasMore={frontMatterHasMore}
       bodyHasMore={bodyHasMore}
-      publicationVersion={work?.publicationVersion}
+      // Publication status is the authority here, not the version number and not the
+      // presence of a snapshot: two public works have no snapshot because their legacy
+      // label is not SemVer, and they are published all the same. Absent work is not a
+      // judgement about publication, so it stays undefined.
+      isPublished={work ? isPublishedStatus(work.publicationStatus) : undefined}
     />
   );
 };

--- a/libs/lib-editing/src/lib/components/reader/ReaderBodyPanel.tsx
+++ b/libs/lib-editing/src/lib/components/reader/ReaderBodyPanel.tsx
@@ -6,8 +6,6 @@ import {
   createBrowserClient,
   FRONT_MATTER_FILTER,
   getSession,
-  isPublishedVersion,
-  SemVer,
   Titles as TitlesData,
   UserRole,
 } from '@eightyfourthousand/data-access';
@@ -34,7 +32,7 @@ export const ReaderBodyPanel = ({
   body,
   frontMatterHasMore,
   bodyHasMore,
-  publicationVersion,
+  isPublished,
 }: {
   titles: TitlesData;
   frontMatter: TranslationEditorContent;
@@ -42,7 +40,15 @@ export const ReaderBodyPanel = ({
   frontMatterHasMore?: boolean;
   bodyHasMore?: boolean;
   cursor?: string;
-  publicationVersion?: SemVer;
+  /**
+   * Whether the work is published, decided by the caller from `publicationStatus`.
+   *
+   * Replaces a heuristic on the version number — major >= 1 counted as published, an
+   * absent version counted as published too — which read three works wrongly, since a
+   * published work can sit below 1.0.0 and an unpublished one can carry a legacy label
+   * above it. Undefined while unknown, so nothing is gated on a guess.
+   */
+  isPublished?: boolean;
 }) => {
   // `undefined` while the role resolves. Gate as a reader until then so
   // unpublished content never flashes before the role is known.
@@ -58,13 +64,12 @@ export const ReaderBodyPanel = ({
 
   const translationState = useMemo<TranslationState>(() => {
     const isReader = role === undefined || role === 'reader';
-    const unpublished = !isPublishedVersion(publicationVersion);
-    if (isReader && unpublished) {
+    if (isReader && isPublished === false) {
       return 'unpublished';
     }
     const bodyEmpty = Array.isArray(body) ? body.length === 0 : !body;
     return bodyEmpty ? 'empty' : 'content';
-  }, [role, publicationVersion, body]);
+  }, [role, isPublished, body]);
 
   const renderTitles = useCallback(
     ({ titles, imprint, name }: TitlesRenderer) => (

--- a/libs/lib-editing/src/lib/components/shared/TranslationStructuredData.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationStructuredData.tsx
@@ -56,7 +56,9 @@ export const TranslationStructuredData = async ({
         url: 'https://84000.co',
       },
       datePublished: work.publicationDate?.toISOString().split('T')[0],
-      version: work.publicationVersion,
+      // The version actually being served. publicationVersion is a text column the
+      // publish pipeline never writes, so it can name a version that is not live.
+      version: work.publishedVersion ?? work.publicationVersion,
       numberOfPages: work.pages || undefined,
     },
     {

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TooltipProvider } from '@eightyfourthousand/design-system';
-import { Work } from '@eightyfourthousand/data-access';
+import { SemVer, Work } from '@eightyfourthousand/data-access';
 import { TranslationsTable } from './TranslationTable';
 
 let mockSearchParams: URLSearchParams;
@@ -140,24 +140,40 @@ describe('TranslationsTable', () => {
     });
   });
 
-  // The column shows the version being served, from work_versions, not the legacy
-  // works.publicationVersion the publish pipeline never writes.
-  it('shows the live published version, and a dash when there is none', async () => {
+  // The column prefers the version being served, from work_versions, over the legacy
+  // works.publicationVersion the publish pipeline never writes — but falls back to it
+  // while works are still being brought onto the pipeline, since a work with no snapshot
+  // yet has only that number and users know the text by it.
+  it('prefers the live version, falls back to the legacy one, then a dash', async () => {
     render(
       <TooltipProvider>
         <TranslationsTable
           works={[
-            work({ title: 'Has a live version', publishedVersion: '2.1.0' }),
-            work({ title: 'Never published', publishedVersion: undefined }),
+            work({
+              title: 'Live version wins',
+              publishedVersion: '2.1.0',
+              publicationVersion: '1.4.0',
+            }),
+            work({
+              title: 'No snapshot yet',
+              publishedVersion: undefined,
+              publicationVersion: '1.4.1',
+            }),
+            work({
+              title: 'Neither',
+              publishedVersion: undefined,
+              publicationVersion: undefined as unknown as SemVer,
+            }),
           ]}
         />
       </TooltipProvider>,
     );
 
     expect(screen.getByText('2.1.0')).toBeTruthy();
-    // The legacy value is 1.0.0 on every fixture, so its absence proves the column
-    // switched rather than coincidentally agreeing.
-    expect(screen.queryByText('1.0.0')).toBeNull();
+    // The live version wins over a legacy value that is present and different, which is
+    // what proves the preference rather than a coincidence.
+    expect(screen.queryByText('1.4.0')).toBeNull();
+    expect(screen.getByText('1.4.1')).toBeTruthy();
     expect(screen.getByText('—')).toBeTruthy();
   });
 

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.spec.tsx
@@ -140,6 +140,27 @@ describe('TranslationsTable', () => {
     });
   });
 
+  // The column shows the version being served, from work_versions, not the legacy
+  // works.publicationVersion the publish pipeline never writes.
+  it('shows the live published version, and a dash when there is none', async () => {
+    render(
+      <TooltipProvider>
+        <TranslationsTable
+          works={[
+            work({ title: 'Has a live version', publishedVersion: '2.1.0' }),
+            work({ title: 'Never published', publishedVersion: undefined }),
+          ]}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText('2.1.0')).toBeTruthy();
+    // The legacy value is 1.0.0 on every fixture, so its absence proves the column
+    // switched rather than coincidentally agreeing.
+    expect(screen.queryByText('1.0.0')).toBeNull();
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+
   it('hides unpublished works when the published-only switch is on', async () => {
     renderTable();
     expect(screen.getAllByText('Unpublished').length).toBeGreaterThan(0);

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
@@ -39,6 +39,11 @@ const SIZE_FOR_COL: { [key: string]: number } = {
 };
 
 const UNPUBLISHED = 'Unpublished';
+// A work with no live version. Deliberately not UNPUBLISHED: the "Published only" switch
+// filters on publicationDate, so a work can pass that filter and still have no published
+// version, and two cells in one row reading "Unpublished" for different reasons would not
+// tell an editor which fact was missing.
+const NO_VERSION = '—';
 
 type TableWork = {
   uuid: string;
@@ -219,6 +224,10 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
         toh: parseToh(w.toh.join(',')),
         tohSearch: w.toh.join(' '),
         publicationDate: w.publicationDate?.toLocaleDateString() || UNPUBLISHED,
+        // The live version, not works.publicationVersion — the publish pipeline
+        // never writes that column, so it can name a version no longer served. A
+        // work with no published version has no live version to show.
+        publicationVersion: w.publishedVersion || NO_VERSION,
       })),
     [works],
   );

--- a/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
+++ b/libs/lib-editing/src/lib/components/shared/TranslationTable.tsx
@@ -39,10 +39,10 @@ const SIZE_FOR_COL: { [key: string]: number } = {
 };
 
 const UNPUBLISHED = 'Unpublished';
-// A work with no live version. Deliberately not UNPUBLISHED: the "Published only" switch
-// filters on publicationDate, so a work can pass that filter and still have no published
-// version, and two cells in one row reading "Unpublished" for different reasons would not
-// tell an editor which fact was missing.
+// A work with neither a live version nor a legacy one. Deliberately not UNPUBLISHED: the
+// "Published only" switch filters on publicationDate, so a work can pass that filter and
+// still have no version, and two cells in one row reading "Unpublished" for different
+// reasons would not tell an editor which fact was missing.
 const NO_VERSION = '—';
 
 type TableWork = {
@@ -224,10 +224,13 @@ export const TranslationsTable = ({ works }: { works: Work[] }) => {
         toh: parseToh(w.toh.join(',')),
         tohSearch: w.toh.join(' '),
         publicationDate: w.publicationDate?.toLocaleDateString() || UNPUBLISHED,
-        // The live version, not works.publicationVersion — the publish pipeline
-        // never writes that column, so it can name a version no longer served. A
-        // work with no published version has no live version to show.
-        publicationVersion: w.publishedVersion || NO_VERSION,
+        // The live version where there is one, falling back to the legacy column.
+        // The pipeline never writes publicationVersion, so it can name a version
+        // that is not being served — but while works are still being brought onto
+        // the pipeline, a work with no snapshot yet has only that number, and it is
+        // still the one users know the text by.
+        publicationVersion:
+          w.publishedVersion || w.publicationVersion || NO_VERSION,
       })),
     [works],
   );


### PR DESCRIPTION
### Summary

Adds `Work.publishedVersion`, resolved from `work_versions` through the published pointer, and points the reader, the structured data and the studio column at it. Deprecates `Work.publicationVersion` rather than removing it. Separately replaces the `isPublishedVersion` heuristic with `isPublishedStatus`, reading `works."publicationStatus"`.

### Linear

- [DEV-747](https://linear.app/84000/issue/DEV-747)

### Notes

`works."publicationVersion"` is a text column the publish pipeline never writes, yet the reader displayed it and `TranslationStructuredData` emitted it as the work's `version` for search engines.

`publishedVersion` is nullable where `publicationVersion` is not: the column always carries a value, so it cannot express "never published". It is loader-batched because the label is one join past the pointer and a list query would otherwise make a round trip per work.

**The publication-status change is the more consequential half.** `isPublishedVersion` inferred publication from the version's major segment — `>= 1` meant published, and an absent version also meant published. Measured against production that read three works wrongly: one published work sits at `0.1.18` and read as unpublished, and two works with no snapshot read as published.

The studio version column prefers the live version and falls back to `publicationVersion`, showing an em dash only when there is neither. Works are still being brought onto the pipeline, and one with no snapshot yet still carries a legacy number users know the text by. The dash is deliberately not "Unpublished": the Published-only switch filters on `publicationDate`, so a work can pass that filter and still have no version, and two cells in one row reading "Unpublished" for different reasons would not say which fact was missing. `TranslationStructuredData` falls back the same way.