### PR TITLE
Edit and save titles

### DIFF
--- a/apps/api-graphql/src/graphql/schema/work/title.graphql
+++ b/apps/api-graphql/src/graphql/schema/work/title.graphql
@@ -21,6 +21,12 @@ type Title {
   Type of title (e.g., "mainTitle", "longTitle", "otherTitle", "toh", "shortcode")
   """
   type: String!
+
+  """
+  How the wording is attested ("reconstructedPhonetic" or
+  "reconstructedSemantic"). Null when the title is directly attested.
+  """
+  attestation: String
 }
 
 extend type Work {

--- a/apps/api-graphql/src/graphql/schema/work/title.resolver.ts
+++ b/apps/api-graphql/src/graphql/schema/work/title.resolver.ts
@@ -7,6 +7,7 @@ type TitleResult = {
   content: string;
   language: string;
   type: string;
+  attestation: string | null;
 };
 
 export const titlesResolver = async (
@@ -14,11 +15,15 @@ export const titlesResolver = async (
   _args: Record<string, never>,
   ctx: GraphQLContext,
 ): Promise<TitleResult[]> => {
-  const titles = await getWorkTitles({ client: ctx.supabase, uuid: parent.uuid });
+  const titles = await getWorkTitles({
+    client: ctx.supabase,
+    uuid: parent.uuid,
+  });
   return titles.map((title) => ({
     uuid: title.uuid,
     content: title.title,
     language: title.language,
     type: title.type,
+    attestation: title.attestation ?? null,
   }));
 };

--- a/libs/client-graphql/src/lib/functions/get-translation-titles.ts
+++ b/libs/client-graphql/src/lib/functions/get-translation-titles.ts
@@ -11,6 +11,7 @@ const GET_WORK_TITLES = gql`
         content
         language
         type
+        attestation
       }
     }
   }
@@ -23,6 +24,7 @@ type GetWorkTitlesResponse = {
       content: string;
       language: string;
       type: string;
+      attestation: string | null;
     }>;
   } | null;
 };

--- a/libs/client-graphql/src/lib/graphql/fragments/title.graphql
+++ b/libs/client-graphql/src/lib/graphql/fragments/title.graphql
@@ -3,4 +3,5 @@ fragment TitleFields on Title {
   content
   language
   type
+  attestation
 }

--- a/libs/client-graphql/src/lib/mappers/title.ts
+++ b/libs/client-graphql/src/lib/mappers/title.ts
@@ -1,8 +1,10 @@
-import type {
-  Title,
-  Titles,
-  TitleType,
-  ExtendedTranslationLanguage,
+import {
+  TITLE_ATTESTATIONS,
+  type Title,
+  type TitleAttestation,
+  type Titles,
+  type TitleType,
+  type ExtendedTranslationLanguage,
 } from '@eightyfourthousand/data-access';
 
 /**
@@ -13,17 +15,25 @@ export type GraphQLTitle = {
   content: string;
   language: string;
   type: string;
+  attestation?: string | null;
 };
 
 /**
  * Convert a GraphQL title to the internal Title type
  */
 export function titleFromGraphQL(gqlTitle: GraphQLTitle): Title {
+  const attestation = (TITLE_ATTESTATIONS as readonly string[]).includes(
+    gqlTitle.attestation ?? '',
+  )
+    ? (gqlTitle.attestation as TitleAttestation)
+    : undefined;
+
   return {
     uuid: gqlTitle.uuid,
     title: gqlTitle.content,
     language: gqlTitle.language as ExtendedTranslationLanguage,
     type: gqlTitle.type as TitleType,
+    ...(attestation ? { attestation } : {}),
   };
 }
 

--- a/libs/data-access/src/index.ts
+++ b/libs/data-access/src/index.ts
@@ -15,6 +15,7 @@ export * from './lib/publications';
 export * from './lib/replace';
 export * from './lib/search';
 export * from './lib/storage';
+export * from './lib/titles';
 export * from './lib/types';
 export * from './lib/local-storage';
 export * from './lib/use-bookmark';

--- a/libs/data-access/src/lib/publications.ts
+++ b/libs/data-access/src/lib/publications.ts
@@ -2,7 +2,7 @@ import {
   BodyItemType,
   DataClient,
   Title,
-  TitlesDTO,
+  TitleDTO,
   WorkDTO,
   titlesFromDTO,
   workFromDTO,
@@ -156,20 +156,27 @@ export const getTranslationPassagesAround = async ({
   return passagesPageAroundFromDTO(data as PassagesPageAroundDTO);
 };
 
-export const getTranslationTitles = async ({
-  client,
-  uuid,
-}: {
-  client: DataClient;
-  uuid: string;
-}) => {
-  const { data } = await client.rpc('get_work_titles', {
-    work_uuid_input: uuid,
-  });
+/**
+ * Columns a title is read with. `content` is aliased to `title` because that is
+ * what the domain type calls it — the alias is the only thing the old
+ * `get_work_titles` RPC was doing that a plain select does not.
+ */
+const TITLE_COLUMNS = 'uuid, title:content, language, type, attestation';
 
-  return titlesFromDTO(data as TitlesDTO);
-};
-
+/**
+ * Read every title belonging to a work.
+ *
+ * Selects the table directly rather than going through the `get_work_titles`
+ * RPC. The RPC was a plain select behind an alias, so every column added to
+ * `titles` needed a schema migration before the app could see it — which is how
+ * `attestation` came to be invisible to the whole read path. Choosing columns
+ * here keeps that in application code.
+ *
+ * The RPC still exists and is intentionally not dropped: apps running an older
+ * published `data-access` still call it.
+ *
+ * Titles are unversioned, so there is no published/draft variant to resolve.
+ */
 export const getWorkTitles = async ({
   client,
   uuid,
@@ -177,17 +184,30 @@ export const getWorkTitles = async ({
   client: DataClient;
   uuid: string;
 }): Promise<Title[]> => {
-  const { data, error } = await client.rpc('get_work_titles', {
-    work_uuid_input: uuid,
-  });
+  const { data, error } = await client
+    .from('titles')
+    .select<string, TitleDTO>(TITLE_COLUMNS)
+    .eq('work_uuid', uuid)
+    // The table carries no natural order, and an updated row moves to the end of
+    // the heap, so an unordered read would reshuffle after every edit. Order
+    // explicitly, down to the UUID, so the sequence is total and stable.
+    .order('type', { ascending: true })
+    .order('language', { ascending: true })
+    .order('uuid', { ascending: true });
 
   if (error) {
     console.error('Error fetching work titles:', error);
     return [];
   }
 
-  return titlesFromDTO(data as TitlesDTO);
+  return titlesFromDTO(data ?? []);
 };
+
+/** @deprecated Prefer {@link getWorkTitles}, which this now delegates to. */
+export const getTranslationTitles = async (args: {
+  client: DataClient;
+  uuid: string;
+}) => getWorkTitles(args);
 
 export const getWorkTitlesByUuids = async ({
   client,

--- a/libs/data-access/src/lib/titles.spec.ts
+++ b/libs/data-access/src/lib/titles.spec.ts
@@ -1,0 +1,310 @@
+import { saveWorkTitles } from './titles';
+import type { DataClient, Title } from './types';
+
+type InsertCall = { rows: Record<string, unknown>[] };
+type UpdateCall = { patch: Record<string, unknown>; uuid: unknown };
+type DeleteCall = { uuids: unknown };
+
+interface Calls {
+  inserts: InsertCall[];
+  updates: UpdateCall[];
+  deletes: DeleteCall[];
+}
+
+/**
+ * Minimal chainable Supabase stub. Each terminal call records what it was
+ * given and resolves with the error configured for that operation, so the diff
+ * and the failure handling can both be exercised without a database.
+ */
+const makeFakeClient = (
+  calls: Calls,
+  errors: Partial<Record<'insert' | 'update' | 'delete', string>> = {},
+  /**
+   * UUIDs RLS lets through. `undefined` means every row is returned, matching a
+   * caller that holds `editor.admin`.
+   */
+  visible?: string[],
+): DataClient => {
+  return {
+    from(table: string) {
+      if (table !== 'titles') {
+        throw new Error(`unexpected table: ${table}`);
+      }
+      const ctx: {
+        op?: 'insert' | 'update' | 'delete';
+        patch?: Record<string, unknown>;
+        uuid?: unknown;
+        uuids?: string[];
+      } = {};
+      const builder = {
+        insert(rows: Record<string, unknown>[]) {
+          ctx.op = 'insert';
+          calls.inserts.push({ rows });
+          return builder;
+        },
+        update(patch: Record<string, unknown>) {
+          ctx.op = 'update';
+          ctx.patch = patch;
+          return builder;
+        },
+        delete() {
+          ctx.op = 'delete';
+          return builder;
+        },
+        eq(_col: string, val: unknown) {
+          ctx.uuid = val;
+          return builder;
+        },
+        in(_col: string, vals: unknown) {
+          ctx.uuids = vals as string[];
+          calls.deletes.push({ uuids: vals });
+          return builder;
+        },
+        select(_cols?: string) {
+          return builder;
+        },
+        then(
+          resolve: (value: {
+            data: { uuid: string }[] | null;
+            error: { message: string } | null;
+          }) => void,
+        ) {
+          if (ctx.op === 'update') {
+            calls.updates.push({ patch: ctx.patch ?? {}, uuid: ctx.uuid });
+          }
+          const message = ctx.op ? errors[ctx.op] : undefined;
+          if (message) {
+            resolve({ data: null, error: { message } });
+            return;
+          }
+          // The rows the statement targeted, minus anything RLS filters out.
+          const targeted =
+            ctx.op === 'delete' ? (ctx.uuids ?? []) : [ctx.uuid as string];
+          const returned = visible
+            ? targeted.filter((uuid) => visible.includes(uuid))
+            : targeted;
+          resolve({ data: returned.map((uuid) => ({ uuid })), error: null });
+        },
+      };
+      return builder;
+    },
+  } as unknown as DataClient;
+};
+
+const title = (overrides: Partial<Title> = {}): Title => ({
+  uuid: 'title-1',
+  title: 'The Perfection of Wisdom',
+  language: 'en',
+  type: 'mainTitle',
+  ...overrides,
+});
+
+const emptyCalls = (): Calls => ({ inserts: [], updates: [], deletes: [] });
+
+describe('saveWorkTitles', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('inserts a title that has no counterpart in the original set', async () => {
+    const calls = emptyCalls();
+    const existing = title();
+    const added = title({ uuid: 'title-2', title: 'Toh 12', type: 'toh' });
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [existing, added],
+      original: [existing],
+    });
+
+    expect(result).toEqual({ inserted: 1, updated: 0, deleted: 0 });
+    expect(calls.inserts).toEqual([
+      {
+        rows: [
+          {
+            uuid: 'title-2',
+            work_uuid: 'work-1',
+            content: 'Toh 12',
+            type: 'eft:toh',
+            language: 'en',
+          },
+        ],
+      },
+    ]);
+    expect(calls.updates).toEqual([]);
+    expect(calls.deletes).toEqual([]);
+  });
+
+  it('updates a title whose text, type, or language changed', async () => {
+    const calls = emptyCalls();
+    const original = title();
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [title({ title: 'The Noble Perfection of Wisdom' })],
+      original: [original],
+    });
+
+    expect(result).toEqual({ inserted: 0, updated: 1, deleted: 0 });
+    expect(calls.updates).toEqual([
+      {
+        uuid: 'title-1',
+        patch: {
+          content: 'The Noble Perfection of Wisdom',
+          type: 'eft:mainTitle',
+          language: 'en',
+        },
+      },
+    ]);
+  });
+
+  it('leaves an untouched title alone', async () => {
+    const calls = emptyCalls();
+    const original = title();
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [title()],
+      original: [original],
+    });
+
+    expect(result).toEqual({ inserted: 0, updated: 0, deleted: 0 });
+    expect(calls.inserts).toEqual([]);
+    expect(calls.updates).toEqual([]);
+    expect(calls.deletes).toEqual([]);
+  });
+
+  it('deletes a title dropped from the edited set', async () => {
+    const calls = emptyCalls();
+    const kept = title();
+    const dropped = title({ uuid: 'title-2', title: 'Toh 12', type: 'toh' });
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [kept],
+      original: [kept, dropped],
+    });
+
+    expect(result).toEqual({ inserted: 0, updated: 0, deleted: 1 });
+    expect(calls.deletes).toEqual([{ uuids: ['title-2'] }]);
+  });
+
+  it('applies an insert, an update, and a delete in one save', async () => {
+    const calls = emptyCalls();
+    const edited = title();
+    const dropped = title({ uuid: 'title-2', title: 'Toh 12', type: 'toh' });
+    const added = title({ uuid: 'title-3', title: 'ཤེས་རབ།', language: 'bo' });
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [title({ title: 'Renamed' }), added],
+      original: [edited, dropped],
+    });
+
+    expect(result).toEqual({ inserted: 1, updated: 1, deleted: 1 });
+    expect(calls.inserts[0].rows[0]).toMatchObject({ uuid: 'title-3' });
+    expect(calls.updates[0]).toMatchObject({ uuid: 'title-1' });
+    expect(calls.deletes[0]).toEqual({ uuids: ['title-2'] });
+  });
+
+  it('reports the error and stops when a write is rejected', async () => {
+    const calls = emptyCalls();
+    const kept = title();
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls, {
+        insert: 'new row violates row-level security policy',
+      }),
+      workUuid: 'work-1',
+      titles: [kept, title({ uuid: 'title-2', title: 'Toh 12', type: 'toh' })],
+      original: [kept, title({ uuid: 'title-3', title: 'gone' })],
+    });
+
+    expect(result).toEqual({
+      inserted: 0,
+      updated: 0,
+      deleted: 0,
+      error: 'new row violates row-level security policy',
+    });
+    // The delete must not run once the insert failed.
+    expect(calls.deletes).toEqual([]);
+  });
+
+  it('reports a refusal when an update silently affects no rows', async () => {
+    const calls = emptyCalls();
+    const original = title();
+
+    // RLS filters UPDATE rather than rejecting it, so a caller without
+    // editor.admin sees no error and no returned rows.
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls, {}, []),
+      workUuid: 'work-1',
+      titles: [title({ title: 'Renamed' })],
+      original: [original],
+    });
+
+    expect(result.updated).toBe(0);
+    expect(result.error).toContain('editor.admin');
+  });
+
+  it('reports a refusal when a delete silently affects no rows', async () => {
+    const calls = emptyCalls();
+    const kept = title();
+    const dropped = title({ uuid: 'title-2', title: 'Toh 12', type: 'toh' });
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls, {}, []),
+      workUuid: 'work-1',
+      titles: [kept],
+      original: [kept, dropped],
+    });
+
+    expect(result.deleted).toBe(0);
+    expect(result.error).toContain('editor.admin');
+  });
+
+  it('reports a refusal when only some deletes get through', async () => {
+    const calls = emptyCalls();
+    const kept = title();
+    const a = title({ uuid: 'title-2', title: 'Toh 12', type: 'toh' });
+    const b = title({ uuid: 'title-3', title: 'Short', type: 'shortcode' });
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls, {}, ['title-2']),
+      workUuid: 'work-1',
+      titles: [kept],
+      original: [kept, a, b],
+    });
+
+    expect(result.deleted).toBe(1);
+    expect(result.error).toContain('editor.admin');
+  });
+
+  it('keeps the counts already applied when a later write fails', async () => {
+    const calls = emptyCalls();
+    const kept = title();
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls, { delete: 'permission denied' }),
+      workUuid: 'work-1',
+      titles: [kept, title({ uuid: 'title-2', title: 'Toh 12', type: 'toh' })],
+      original: [kept, title({ uuid: 'title-3', title: 'gone' })],
+    });
+
+    expect(result).toEqual({
+      inserted: 1,
+      updated: 0,
+      deleted: 0,
+      error: 'permission denied',
+    });
+  });
+});

--- a/libs/data-access/src/lib/titles.spec.ts
+++ b/libs/data-access/src/lib/titles.spec.ts
@@ -132,6 +132,7 @@ describe('saveWorkTitles', () => {
             content: 'Toh 12',
             type: 'eft:toh',
             language: 'en',
+            attestation: null,
           },
         ],
       },
@@ -159,6 +160,7 @@ describe('saveWorkTitles', () => {
           content: 'The Noble Perfection of Wisdom',
           type: 'eft:mainTitle',
           language: 'en',
+          attestation: null,
         },
       },
     ]);
@@ -214,6 +216,91 @@ describe('saveWorkTitles', () => {
     expect(calls.inserts[0].rows[0]).toMatchObject({ uuid: 'title-3' });
     expect(calls.updates[0]).toMatchObject({ uuid: 'title-1' });
     expect(calls.deletes[0]).toEqual({ uuids: ['title-2'] });
+  });
+
+  it('carries attestation on an inserted title', async () => {
+    const calls = emptyCalls();
+    const existing = title();
+
+    await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [
+        existing,
+        title({
+          uuid: 'title-2',
+          title: 'Praj\u00f1\u0101p\u0101ramit\u0101',
+          attestation: 'reconstructedPhonetic',
+        }),
+      ],
+      original: [existing],
+    });
+
+    expect(calls.inserts[0].rows[0]).toMatchObject({
+      attestation: 'reconstructedPhonetic',
+    });
+  });
+
+  it('writes null for a title with no attestation', async () => {
+    const calls = emptyCalls();
+
+    await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [title({ uuid: 'title-2' })],
+      original: [],
+    });
+
+    expect(calls.inserts[0].rows[0]).toMatchObject({ attestation: null });
+  });
+
+  it('updates a title whose attestation changed', async () => {
+    const calls = emptyCalls();
+    const original = title();
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [title({ attestation: 'reconstructedSemantic' })],
+      original: [original],
+    });
+
+    expect(result.updated).toBe(1);
+    expect(calls.updates[0].patch).toMatchObject({
+      attestation: 'reconstructedSemantic',
+    });
+  });
+
+  it('clears an attestation by writing null', async () => {
+    const calls = emptyCalls();
+    const original = title({ attestation: 'reconstructedPhonetic' });
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [title()],
+      original: [original],
+    });
+
+    expect(result.updated).toBe(1);
+    expect(calls.updates[0].patch).toMatchObject({ attestation: null });
+  });
+
+  it('does not treat absent and null attestation as a change', async () => {
+    const calls = emptyCalls();
+    // A row read back from the database can carry an explicit null where the
+    // domain type simply omits the field; that must not look like an edit.
+    const original = { ...title(), attestation: undefined };
+
+    const result = await saveWorkTitles({
+      client: makeFakeClient(calls),
+      workUuid: 'work-1',
+      titles: [title()],
+      original: [original],
+    });
+
+    expect(result).toEqual({ inserted: 0, updated: 0, deleted: 0 });
+    expect(calls.updates).toEqual([]);
   });
 
   it('reports the error and stops when a write is rejected', async () => {

--- a/libs/data-access/src/lib/titles.ts
+++ b/libs/data-access/src/lib/titles.ts
@@ -25,7 +25,12 @@ const byUuid = (titles: Titles) =>
   new Map(titles.map((title) => [title.uuid, title]));
 
 const isSameTitle = (a: Title, b: Title) =>
-  a.title === b.title && a.type === b.type && a.language === b.language;
+  a.title === b.title &&
+  a.type === b.type &&
+  a.language === b.language &&
+  // Absent and null are the same state; normalise so a round trip through the
+  // database does not read as an edit.
+  (a.attestation ?? null) === (b.attestation ?? null);
 
 /**
  * Persist an edited set of titles for a work.
@@ -66,6 +71,7 @@ export const saveWorkTitles = async ({
       content: title.title,
       type: titleTypeToDTO(title.type),
       language: title.language,
+      attestation: title.attestation ?? null,
     }));
 
   const toUpdate = titles.filter((title) => {
@@ -100,6 +106,7 @@ export const saveWorkTitles = async ({
         content: title.title,
         type: titleTypeToDTO(title.type),
         language: title.language,
+        attestation: title.attestation ?? null,
       })
       .eq('uuid', title.uuid)
       .select('uuid');

--- a/libs/data-access/src/lib/titles.ts
+++ b/libs/data-access/src/lib/titles.ts
@@ -1,0 +1,139 @@
+import { DataClient, Title, Titles, titleTypeToDTO } from './types';
+
+/**
+ * The outcome of a title save. `error` is set only when at least one statement
+ * failed; the operation is not atomic, so counts describe what did land.
+ */
+export type SaveTitlesResult = {
+  inserted: number;
+  updated: number;
+  deleted: number;
+  error?: string;
+};
+
+/**
+ * Reported when a write was accepted but changed nothing, which under RLS means
+ * the row was filtered out rather than the statement rejected.
+ */
+const PERMISSION_ERROR =
+  'the change was refused — editing titles requires editor.admin permissions';
+
+/**
+ * A title's identity for save purposes: matching UUIDs mean the same row.
+ */
+const byUuid = (titles: Titles) =>
+  new Map(titles.map((title) => [title.uuid, title]));
+
+const isSameTitle = (a: Title, b: Title) =>
+  a.title === b.title && a.type === b.type && a.language === b.language;
+
+/**
+ * Persist an edited set of titles for a work.
+ *
+ * Titles are global to a work and are live the moment this resolves — they are
+ * not part of the publishing workflow, so there is no draft to review first.
+ * Writes are gated on `editor.admin` by RLS on `public.titles`; a caller
+ * without that permission gets an error back rather than a silent no-op.
+ *
+ * `titles` is the desired end state and `original` is what was loaded, so the
+ * diff decides what to insert, update, and delete. New titles must already
+ * carry a UUID (mint one with `crypto.randomUUID()`), matching how imported
+ * titles are created.
+ *
+ * The three statements do not share a transaction. A partial failure is
+ * reported through `error` with the counts that did apply, so the caller can
+ * refetch rather than assume either outcome.
+ */
+export const saveWorkTitles = async ({
+  client,
+  workUuid,
+  titles,
+  original,
+}: {
+  client: DataClient;
+  workUuid: string;
+  titles: Titles;
+  original: Titles;
+}): Promise<SaveTitlesResult> => {
+  const originalByUuid = byUuid(original);
+  const nextByUuid = byUuid(titles);
+
+  const toInsert = titles
+    .filter((title) => !originalByUuid.has(title.uuid))
+    .map((title) => ({
+      uuid: title.uuid,
+      work_uuid: workUuid,
+      content: title.title,
+      type: titleTypeToDTO(title.type),
+      language: title.language,
+    }));
+
+  const toUpdate = titles.filter((title) => {
+    const previous = originalByUuid.get(title.uuid);
+    return !!previous && !isSameTitle(previous, title);
+  });
+
+  const toDelete = original
+    .filter((title) => !nextByUuid.has(title.uuid))
+    .map((title) => title.uuid);
+
+  const result: SaveTitlesResult = { inserted: 0, updated: 0, deleted: 0 };
+
+  if (toInsert.length > 0) {
+    const { error } = await client.from('titles').insert(toInsert);
+    if (error) {
+      console.error('Error inserting titles:', error);
+      return { ...result, error: error.message };
+    }
+    result.inserted = toInsert.length;
+  }
+
+  // A blocked INSERT raises, but RLS filters UPDATE and DELETE instead of
+  // failing them: a caller without `editor.admin` gets no error and no rows
+  // touched. Both therefore ask for the affected rows back and treat a short
+  // result as a refusal, so a silently ineffective save is never reported as a
+  // successful one.
+  for (const title of toUpdate) {
+    const { data, error } = await client
+      .from('titles')
+      .update({
+        content: title.title,
+        type: titleTypeToDTO(title.type),
+        language: title.language,
+      })
+      .eq('uuid', title.uuid)
+      .select('uuid');
+    if (error) {
+      console.error('Error updating title:', error);
+      return { ...result, error: error.message };
+    }
+    if (!data?.length) {
+      console.error('Title update affected no rows:', title.uuid);
+      return { ...result, error: PERMISSION_ERROR };
+    }
+    result.updated += 1;
+  }
+
+  if (toDelete.length > 0) {
+    const { data, error } = await client
+      .from('titles')
+      .delete()
+      .in('uuid', toDelete)
+      .select('uuid');
+    if (error) {
+      console.error('Error deleting titles:', error);
+      return { ...result, error: error.message };
+    }
+    if ((data?.length ?? 0) < toDelete.length) {
+      console.error('Title delete affected fewer rows than requested');
+      return {
+        ...result,
+        deleted: data?.length ?? 0,
+        error: PERMISSION_ERROR,
+      };
+    }
+    result.deleted = toDelete.length;
+  }
+
+  return result;
+};

--- a/libs/data-access/src/lib/types/title.ts
+++ b/libs/data-access/src/lib/types/title.ts
@@ -45,3 +45,5 @@ export const titleFromDTO = (dto: TitleDTO): Title => {
 export const titlesFromDTO = (dto?: TitlesDTO): Titles => {
   return dto?.map(titleFromDTO) || [];
 };
+
+export const titleTypeToDTO = (type: TitleType): TitleTypeDTO => `eft:${type}`;

--- a/libs/data-access/src/lib/types/title.ts
+++ b/libs/data-access/src/lib/types/title.ts
@@ -13,6 +13,21 @@ export const BO_TITLE_PREFIX = '༄༅།\u00a0\u00a0།' as const;
 
 export type TitleType = (typeof TITLE_TYPES)[number];
 
+/**
+ * How a title's wording is attested. Absent — the overwhelming majority — means
+ * the title is attested directly rather than reconstructed. Unlike `type`, these
+ * are stored without an `eft:` prefix.
+ */
+export const TITLE_ATTESTATIONS = [
+  'reconstructedPhonetic',
+  'reconstructedSemantic',
+] as const;
+
+export type TitleAttestation = (typeof TITLE_ATTESTATIONS)[number];
+
+const isTitleAttestation = (value?: string | null): boolean =>
+  !!value && (TITLE_ATTESTATIONS as readonly string[]).includes(value);
+
 export type TitleTypeDTO = `eft:${TitleType}`;
 
 export type Title = {
@@ -20,6 +35,8 @@ export type Title = {
   title: string;
   language: ExtendedTranslationLanguage;
   type: TitleType;
+  /** Absent when the title is directly attested, which is the normal case. */
+  attestation?: TitleAttestation;
 };
 
 export type Titles = Title[];
@@ -29,6 +46,7 @@ export type TitleDTO = {
   title: string;
   language: ExtendedTranslationLanguage;
   type: TitleTypeDTO;
+  attestation?: string | null;
 };
 
 export type TitlesDTO = TitleDTO[];
@@ -39,6 +57,11 @@ export const titleFromDTO = (dto: TitleDTO): Title => {
     title: dto.title,
     language: dto.language,
     type: (dto.type?.replace('eft:', '') as TitleType) || 'mainTitle',
+    // Anything unrecognised is dropped rather than carried through as a value
+    // the pickers cannot represent and a save would echo back.
+    ...(isTitleAttestation(dto.attestation)
+      ? { attestation: dto.attestation as TitleAttestation }
+      : {}),
   };
 };
 

--- a/libs/data-access/src/lib/work-titles.spec.ts
+++ b/libs/data-access/src/lib/work-titles.spec.ts
@@ -1,0 +1,169 @@
+import { getTranslationTitles, getWorkTitles } from './publications';
+import type { DataClient } from './types';
+
+type Query = {
+  table?: string;
+  columns?: string;
+  filters: [string, unknown][];
+  orders: [string, boolean | undefined][];
+};
+
+/**
+ * Records the query that was built and resolves with whatever rows the test
+ * configured. Titles are read straight from the table now, so the column list,
+ * the alias, and the ordering are all application code — and all things that can
+ * regress silently.
+ */
+const makeFakeClient = (
+  query: Query,
+  result: { data?: unknown; error?: { message: string } } = {},
+): DataClient =>
+  ({
+    from(table: string) {
+      query.table = table;
+      const builder = {
+        select(columns: string) {
+          query.columns = columns;
+          return builder;
+        },
+        eq(column: string, value: unknown) {
+          query.filters.push([column, value]);
+          return builder;
+        },
+        order(column: string, opts?: { ascending?: boolean }) {
+          query.orders.push([column, opts?.ascending]);
+          return builder;
+        },
+        then(
+          resolve: (value: {
+            data: unknown;
+            error: { message: string } | null;
+          }) => void,
+        ) {
+          resolve({
+            data: result.data ?? [],
+            error: result.error ?? null,
+          });
+        },
+      };
+      return builder;
+    },
+  }) as unknown as DataClient;
+
+const emptyQuery = (): Query => ({ filters: [], orders: [] });
+
+describe('getWorkTitles', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reads the titles table rather than the get_work_titles RPC', async () => {
+    const query = emptyQuery();
+
+    await getWorkTitles({ client: makeFakeClient(query), uuid: 'work-1' });
+
+    expect(query.table).toBe('titles');
+    expect(query.filters).toEqual([['work_uuid', 'work-1']]);
+  });
+
+  it('aliases content to title and asks for attestation', async () => {
+    const query = emptyQuery();
+
+    await getWorkTitles({ client: makeFakeClient(query), uuid: 'work-1' });
+
+    // The alias is the only thing the RPC did that a plain select does not, and
+    // attestation is the column whose absence made it invisible to the editor.
+    expect(query.columns).toContain('title:content');
+    expect(query.columns).toContain('attestation');
+    expect(query.columns).toContain('uuid');
+    expect(query.columns).toContain('language');
+    expect(query.columns).toContain('type');
+  });
+
+  it('orders the read so it does not reshuffle after an edit', async () => {
+    const query = emptyQuery();
+
+    await getWorkTitles({ client: makeFakeClient(query), uuid: 'work-1' });
+
+    // An updated row moves to the end of the heap, so the order has to be
+    // explicit and total.
+    expect(query.orders).toEqual([
+      ['type', true],
+      ['language', true],
+      ['uuid', true],
+    ]);
+  });
+
+  it('maps rows through the DTO mapper, stripping the eft: prefix', async () => {
+    const titles = await getWorkTitles({
+      client: makeFakeClient(emptyQuery(), {
+        data: [
+          {
+            uuid: 'title-1',
+            title: 'The Perfection of Wisdom',
+            language: 'en',
+            type: 'eft:mainTitle',
+            attestation: 'reconstructedPhonetic',
+          },
+        ],
+      }),
+      uuid: 'work-1',
+    });
+
+    expect(titles).toEqual([
+      {
+        uuid: 'title-1',
+        title: 'The Perfection of Wisdom',
+        language: 'en',
+        type: 'mainTitle',
+        attestation: 'reconstructedPhonetic',
+      },
+    ]);
+  });
+
+  it('omits an attestation the app does not recognise', async () => {
+    const titles = await getWorkTitles({
+      client: makeFakeClient(emptyQuery(), {
+        data: [
+          {
+            uuid: 'title-1',
+            title: 'A title',
+            language: 'en',
+            type: 'eft:mainTitle',
+            attestation: 'somethingElse',
+          },
+        ],
+      }),
+      uuid: 'work-1',
+    });
+
+    expect(titles[0].attestation).toBeUndefined();
+  });
+
+  it('returns an empty list on error rather than throwing', async () => {
+    const titles = await getWorkTitles({
+      client: makeFakeClient(emptyQuery(), {
+        error: { message: 'permission denied' },
+      }),
+      uuid: 'work-1',
+    });
+
+    expect(titles).toEqual([]);
+  });
+
+  it('getTranslationTitles resolves through the same query', async () => {
+    const query = emptyQuery();
+
+    await getTranslationTitles({
+      client: makeFakeClient(query),
+      uuid: 'work-1',
+    });
+
+    expect(query.table).toBe('titles');
+    expect(query.columns).toContain('attestation');
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/EditorBodyPage.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorBodyPage.tsx
@@ -60,9 +60,16 @@ export const EditorBodyPage = () => {
 
   const renderTitles = useCallback(
     ({ titles, imprint }: TitlesRenderer) => (
-      <TitlesBuilder titles={titles} imprint={imprint} />
+      <TitlesBuilder
+        titles={titles}
+        imprint={imprint}
+        workUuid={work.uuid}
+        // Titles save straight to the database, so the saved list is what is
+        // stored — adopt it rather than refetching.
+        onTitlesSaved={setTitles}
+      />
     ),
-    [],
+    [work.uuid],
   );
 
   const renderTranslation = useCallback(

--- a/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
+++ b/libs/lib-editing/src/lib/components/editor/EditorProvider.tsx
@@ -40,6 +40,12 @@ interface EditorContextState {
   work: Work;
   dirtyStore: DirtyStore;
   canEdit(): Promise<boolean>;
+  /**
+   * Whether the user may make administrative changes to the work — those that
+   * bypass the publishing workflow and go live immediately, such as editing
+   * titles. A stricter bar than `canEdit`.
+   */
+  canAdminister(): Promise<boolean>;
   applyReplacedPassages: (passages: ReplacedPassage[]) => Promise<void>;
   getFragment: (builder: string) => XmlFragment;
   setDoc: (doc: Doc) => void;
@@ -80,6 +86,7 @@ export const EditorContext = createContext<EditorContextState>({
     getSnapshot: () => false,
   },
   canEdit: async () => false,
+  canAdminister: async () => false,
   applyReplacedPassages: async () => {
     // No-op when outside provider
   },
@@ -353,6 +360,10 @@ export const EditorContextProvider = ({
 
   const canEdit = useCallback(async () => {
     return await hasPermission({ client, permission: 'EDITOR_EDIT' });
+  }, [client]);
+
+  const canAdminister = useCallback(async () => {
+    return await hasPermission({ client, permission: 'EDITOR_ADMIN' });
   }, [client]);
 
   const applyReplacedPassages = useCallback(
@@ -629,6 +640,7 @@ export const EditorContextProvider = ({
         doc,
         dirtyStore,
         canEdit,
+        canAdminister,
         applyReplacedPassages,
         getFragment,
         setDoc,

--- a/libs/lib-editing/src/lib/components/editor/TitlesBuilder.tsx
+++ b/libs/lib-editing/src/lib/components/editor/TitlesBuilder.tsx
@@ -9,14 +9,22 @@ import { TranslationSkeleton } from '../shared/TranslationSkeleton';
 export const TitlesBuilder = ({
   titles,
   imprint,
+  workUuid,
+  onTitlesSaved,
 }: {
   titles: TitlesData;
   imprint?: Imprint;
+  workUuid?: string;
+  onTitlesSaved?: (titles: TitlesData) => void;
 }) => {
   const [isEditable, setIsEditable] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  const { canEdit } = useEditorState();
+  // Titles are global to the work and go live immediately, with no publishing
+  // step in between, so editing them takes `editor.admin` — a higher bar than
+  // the `editor.edit` that governs passage content. RLS on `public.titles`
+  // enforces the same rule; this only decides whether the pencil is offered.
+  const { canAdminister } = useEditorState();
 
   useEffect(() => {
     const checkEditable = async () => {
@@ -24,16 +32,22 @@ export const TitlesBuilder = ({
         return;
       }
 
-      const editable = await canEdit();
+      const editable = await canAdminister();
 
       setIsEditable(editable);
       setLoading(false);
     };
     checkEditable();
-  }, [loading, canEdit]);
+  }, [loading, canAdminister]);
 
   return !loading ? (
-    <Titles titles={titles} imprint={imprint} canEdit={isEditable} />
+    <Titles
+      titles={titles}
+      imprint={imprint}
+      canEdit={isEditable}
+      workUuid={workUuid}
+      onTitlesSaved={onTitlesSaved}
+    />
   ) : (
     <TranslationSkeleton />
   );

--- a/libs/lib-editing/src/lib/components/shared/titles/TitleForm.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/TitleForm.tsx
@@ -1,37 +1,222 @@
-import { LANGUAGES, Title, Titles } from '@eightyfourthousand/data-access';
-import { Input, Label } from '@eightyfourthousand/design-system';
+'use client';
 
+import { PlusIcon, Trash2Icon } from 'lucide-react';
+import {
+  type ExtendedTranslationLanguage,
+  TITLE_TYPES,
+  type Title,
+  type Titles,
+  type TitleType,
+} from '@eightyfourthousand/data-access';
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@eightyfourthousand/design-system';
+import { cn } from '@eightyfourthousand/lib-utils';
+
+/**
+ * Human-readable names for the title types stored on `public.titles`. The
+ * picker iterates `TITLE_TYPES`, which fixes the order.
+ */
+export const TITLE_TYPE_LABELS: Record<TitleType, string> = {
+  mainTitle: 'Main title',
+  mainTitleOutsideCatalogueSection: 'Main title outside catalogue section',
+  longTitle: 'Long title',
+  otherTitle: 'Other title',
+  toh: 'Tohoku number',
+  shortcode: 'Short code',
+};
+
+/**
+ * The languages a title may be recorded in, with the labels editors use for
+ * them. Ordered by how much of the corpus each accounts for.
+ */
+export const TITLE_LANGUAGE_LABELS: Record<
+  ExtendedTranslationLanguage,
+  string
+> = {
+  en: 'English',
+  bo: 'Tibetan',
+  'Bo-Ltn': 'Tibetan (Wylie)',
+  'Sa-Ltn': 'Sanskrit (Latin)',
+  zh: 'Chinese',
+  'Zh-Ltn': 'Chinese (Pinyin)',
+  ja: 'Japanese',
+  'Mt-Ltn': 'Mongolian (Latin)',
+  'Pi-Ltn': 'Pali (Latin)',
+};
+
+const TITLE_LANGUAGES = Object.keys(
+  TITLE_LANGUAGE_LABELS,
+) as ExtendedTranslationLanguage[];
+
+/**
+ * The default shape of a title added from an empty row: the type and language
+ * that between them account for most of the corpus.
+ */
+export const NEW_TITLE_TYPE: TitleType = 'mainTitle';
+export const NEW_TITLE_LANGUAGE: ExtendedTranslationLanguage = 'en';
+
+/**
+ * Mint an empty title row. The UUID is generated client-side because the row is
+ * inserted by UUID, the same way imported titles are created.
+ */
+export const emptyTitle = (): Title => ({
+  uuid: crypto.randomUUID(),
+  title: '',
+  type: NEW_TITLE_TYPE,
+  language: NEW_TITLE_LANGUAGE,
+});
+
+/**
+ * Edit a work's titles as a list of rows, one row per title.
+ *
+ * Titles are keyed by type *and* language and a work may carry several of the
+ * same type, so a row — rather than a field per language — is the unit that
+ * matches the data. Edits are held by the caller and only reach the database
+ * when it saves.
+ */
 export const TitleForm = ({
   titles = [],
+  disabled = false,
   onChange,
 }: {
   titles?: Titles;
-  onChange: (title: Title) => void;
+  disabled?: boolean;
+  onChange: (titles: Titles) => void;
 }) => {
-  const titlesByLanguage: { [key: string]: Title } = {};
-  titles.forEach((title) => {
-    titlesByLanguage[title.language] = title;
-  });
+  const replaceAt = (index: number, changes: Partial<Title>) => {
+    onChange(
+      titles.map((title, idx) =>
+        idx === index ? { ...title, ...changes } : title,
+      ),
+    );
+  };
+
+  const removeAt = (index: number) => {
+    onChange(titles.filter((_, idx) => idx !== index));
+  };
 
   return (
-    <div className="flex flex-col gap-4">
-      {LANGUAGES.map((language) => (
-        <div key={language} className="flex flex-col gap-2">
-          <Label className="uppercase">{language}</Label>
-          <Input
-            type="text"
-            placeholder={`Enter ${language} title`}
-            value={titlesByLanguage[language]?.title}
-            onChange={(e) =>
-              onChange({
-                ...titlesByLanguage[language],
-                title: e.target.value,
-                language,
-              })
-            }
-          />
+    <div className="flex flex-col gap-3">
+      <div className="hidden gap-2 px-1 text-xs uppercase text-muted-foreground sm:flex">
+        <span className="grow">Title</span>
+        <span className="w-56 shrink-0">Type</span>
+        <span className="w-44 shrink-0">Language</span>
+        <span className="w-9 shrink-0" />
+      </div>
+
+      {titles.length === 0 && (
+        <p className="px-1 py-6 text-center text-sm text-muted-foreground">
+          This work has no titles yet.
+        </p>
+      )}
+
+      {titles.map((title, index) => (
+        <div
+          key={title.uuid}
+          className="flex flex-col gap-2 sm:flex-row sm:items-center"
+        >
+          <div className="grow">
+            <Label className="sr-only" htmlFor={`title-content-${title.uuid}`}>
+              Title
+            </Label>
+            <Input
+              id={`title-content-${title.uuid}`}
+              type="text"
+              placeholder="Enter title"
+              disabled={disabled}
+              value={title.title}
+              className={cn(title.language === 'bo' && 'font-tibetan')}
+              onChange={(e) => replaceAt(index, { title: e.target.value })}
+            />
+          </div>
+
+          <div className="w-full shrink-0 sm:w-56">
+            <Label className="sr-only" htmlFor={`title-type-${title.uuid}`}>
+              Type
+            </Label>
+            <Select
+              value={title.type}
+              disabled={disabled}
+              onValueChange={(value) =>
+                replaceAt(index, { type: value as TitleType })
+              }
+            >
+              <SelectTrigger id={`title-type-${title.uuid}`} className="w-full">
+                <SelectValue placeholder="Select type" />
+              </SelectTrigger>
+              <SelectContent>
+                {TITLE_TYPES.map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {TITLE_TYPE_LABELS[type]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="w-full shrink-0 sm:w-44">
+            <Label className="sr-only" htmlFor={`title-language-${title.uuid}`}>
+              Language
+            </Label>
+            <Select
+              value={title.language}
+              disabled={disabled}
+              onValueChange={(value) =>
+                replaceAt(index, {
+                  language: value as ExtendedTranslationLanguage,
+                })
+              }
+            >
+              <SelectTrigger
+                id={`title-language-${title.uuid}`}
+                className="w-full"
+              >
+                <SelectValue placeholder="Select language" />
+              </SelectTrigger>
+              <SelectContent>
+                {TITLE_LANGUAGES.map((language) => (
+                  <SelectItem key={language} value={language}>
+                    {TITLE_LANGUAGE_LABELS[language]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            disabled={disabled}
+            className="size-9 shrink-0 self-end text-muted-foreground hover:text-destructive sm:self-auto"
+            aria-label={`Remove ${title.title || 'untitled'} title`}
+            onClick={() => removeAt(index)}
+          >
+            <Trash2Icon />
+          </Button>
         </div>
       ))}
+
+      <div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={disabled}
+          onClick={() => onChange([...titles, emptyTitle()])}
+        >
+          <PlusIcon />
+          Add title
+        </Button>
+      </div>
     </div>
   );
 };

--- a/libs/lib-editing/src/lib/components/shared/titles/TitleForm.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/TitleForm.tsx
@@ -84,42 +84,52 @@ export const emptyTitle = (): Title => ({
 /** The columns the row list can be sorted by. */
 export type TitleSortColumn = 'title' | 'type' | 'language';
 
-// Type and language sort by their canonical sequence rather than by label,
-// because alphabetising the labels would scramble an order that carries
-// meaning: 'Long title' < 'Main title' < 'Tohoku number' is not the order these
-// belong in. TITLE_TYPES is the preferred order the reader already renders in,
-// and the language list runs most to least common.
-const TYPE_ORDER = new Map(TITLE_TYPES.map((type, index) => [type, index]));
-const LANGUAGE_ORDER = new Map(
-  TITLE_LANGUAGES.map((language, index) => [language, index]),
-);
+export type TitleSort = { column: TitleSortColumn; direction: 'asc' | 'desc' };
 
-const compareBy = (column: TitleSortColumn, a: Title, b: Title): number => {
+/**
+ * How the rows are ordered when the dialog opens. Grouping by type is what an
+ * editor scanning the list expects, and a default matters here because the
+ * stored order is arbitrary — `get_work_titles` has no `ORDER BY`, and an edited
+ * row moves to the end of the heap, so an unsorted list would put the title you
+ * just changed at the bottom.
+ */
+export const DEFAULT_TITLE_SORT: TitleSort = {
+  column: 'type',
+  direction: 'asc',
+};
+
+// Every column sorts by the text the editor can actually see: the label in the
+// picker, not the underlying enum value. Ordering type by the canonical
+// TITLE_TYPES sequence would put 'Tohoku number' above 'Main title' for reasons
+// invisible in the dialog, which reads as a broken sort. The canonical order
+// still governs the order options appear *within* each picker.
+const displayedValue = (column: TitleSortColumn, title: Title): string => {
   switch (column) {
     case 'type':
-      return (TYPE_ORDER.get(a.type) ?? -1) - (TYPE_ORDER.get(b.type) ?? -1);
+      return TITLE_TYPE_LABELS[title.type] ?? title.type;
     case 'language':
-      return (
-        (LANGUAGE_ORDER.get(a.language) ?? -1) -
-        (LANGUAGE_ORDER.get(b.language) ?? -1)
-      );
+      return TITLE_LANGUAGE_LABELS[title.language] ?? title.language;
     case 'title':
     default:
-      return a.title.localeCompare(b.title);
+      return title.title;
   }
 };
 
+const compareBy = (column: TitleSortColumn, a: Title, b: Title): number =>
+  displayedValue(column, a).localeCompare(displayedValue(column, b));
+
 /**
- * Order titles by one column, falling back through the remaining ones so the
- * result is total and therefore stable across repeated sorts.
+ * Order titles by one column — comparing the text shown in that column —
+ * falling back through the remaining ones so the result is total and therefore
+ * stable across repeated sorts.
  *
  * Row order is presentation only: nothing persists it, and the save diffs by
  * UUID, so reordering never changes what is written.
  */
 export const sortTitles = (
   titles: Titles,
-  column: TitleSortColumn = 'type',
-  direction: 'asc' | 'desc' = 'asc',
+  column: TitleSortColumn = DEFAULT_TITLE_SORT.column,
+  direction: 'asc' | 'desc' = DEFAULT_TITLE_SORT.direction,
 ): Titles => {
   const factor = direction === 'asc' ? 1 : -1;
   return [...titles].sort(
@@ -132,8 +142,6 @@ export const sortTitles = (
       compareBy('title', a, b),
   );
 };
-
-type TitleSort = { column: TitleSortColumn; direction: 'asc' | 'desc' };
 
 /**
  * A clickable column heading that sorts the row list.
@@ -155,12 +163,12 @@ const SortHeader = ({
 }: {
   column: TitleSortColumn;
   label: string;
-  sort: TitleSort | null;
+  sort: TitleSort;
   disabled?: boolean;
   onSort: (column: TitleSortColumn) => void;
   className?: string;
 }) => {
-  const active = sort?.column === column;
+  const active = sort.column === column;
   const state = active
     ? ` (currently ${sort.direction === 'asc' ? 'ascending' : 'descending'})`
     : '';
@@ -208,7 +216,7 @@ export const TitleForm = ({
   disabled?: boolean;
   onChange: (titles: Titles) => void;
 }) => {
-  const [sort, setSort] = useState<TitleSort | null>(null);
+  const [sort, setSort] = useState<TitleSort>(DEFAULT_TITLE_SORT);
 
   const replaceAt = (index: number, changes: Partial<Title>) => {
     onChange(
@@ -229,7 +237,7 @@ export const TitleForm = ({
   // type: a row that moved mid-edit would take the cursor with it.
   const sortBy = (column: TitleSortColumn) => {
     const direction =
-      sort?.column === column && sort.direction === 'asc' ? 'desc' : 'asc';
+      sort.column === column && sort.direction === 'asc' ? 'desc' : 'asc';
     setSort({ column, direction });
     onChange(sortTitles(titles, column, direction));
   };

--- a/libs/lib-editing/src/lib/components/shared/titles/TitleForm.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/TitleForm.tsx
@@ -10,8 +10,10 @@ import {
 } from 'lucide-react';
 import {
   type ExtendedTranslationLanguage,
+  TITLE_ATTESTATIONS,
   TITLE_TYPES,
   type Title,
+  type TitleAttestation,
   type Titles,
   type TitleType,
 } from '@eightyfourthousand/data-access';
@@ -64,6 +66,24 @@ const TITLE_LANGUAGES = Object.keys(
 ) as ExtendedTranslationLanguage[];
 
 /**
+ * Labels for the attestation values. The absent case is a real choice in the
+ * picker rather than a blank, so an editor can clear one deliberately.
+ */
+export const TITLE_ATTESTATION_LABELS: Record<TitleAttestation, string> = {
+  reconstructedPhonetic: 'Reconstructed phonetic',
+  reconstructedSemantic: 'Reconstructed semantic',
+};
+
+export const NO_ATTESTATION_LABEL = 'None' as const;
+
+/**
+ * Radix's Select cannot hold an empty string as a value, so the absent case
+ * travels through the picker under this sentinel and is mapped back to
+ * `undefined` on the way out.
+ */
+const NO_ATTESTATION = '__none__' as const;
+
+/**
  * The default shape of a title added from an empty row: the type and language
  * that between them account for most of the corpus.
  */
@@ -82,7 +102,7 @@ export const emptyTitle = (): Title => ({
 });
 
 /** The columns the row list can be sorted by. */
-export type TitleSortColumn = 'title' | 'type' | 'language';
+export type TitleSortColumn = 'title' | 'type' | 'language' | 'attestation';
 
 export type TitleSort = { column: TitleSortColumn; direction: 'asc' | 'desc' };
 
@@ -109,6 +129,10 @@ const displayedValue = (column: TitleSortColumn, title: Title): string => {
       return TITLE_TYPE_LABELS[title.type] ?? title.type;
     case 'language':
       return TITLE_LANGUAGE_LABELS[title.language] ?? title.language;
+    case 'attestation':
+      return title.attestation
+        ? TITLE_ATTESTATION_LABELS[title.attestation]
+        : NO_ATTESTATION_LABEL;
     case 'title':
     default:
       return title.title;
@@ -139,7 +163,8 @@ export const sortTitles = (
       factor * compareBy(column, a, b) ||
       compareBy('type', a, b) ||
       compareBy('language', a, b) ||
-      compareBy('title', a, b),
+      compareBy('title', a, b) ||
+      compareBy('attestation', a, b),
   );
 };
 
@@ -259,7 +284,7 @@ export const TitleForm = ({
           sort={sort}
           disabled={disabled}
           onSort={sortBy}
-          className="w-56 shrink-0"
+          className="w-52 shrink-0"
         />
         <SortHeader
           column="language"
@@ -267,7 +292,15 @@ export const TitleForm = ({
           sort={sort}
           disabled={disabled}
           onSort={sortBy}
-          className="w-44 shrink-0"
+          className="w-40 shrink-0"
+        />
+        <SortHeader
+          column="attestation"
+          label="Attestation"
+          sort={sort}
+          disabled={disabled}
+          onSort={sortBy}
+          className="w-52 shrink-0"
         />
         <span className="w-9 shrink-0" />
       </div>
@@ -298,7 +331,7 @@ export const TitleForm = ({
             />
           </div>
 
-          <div className="w-full shrink-0 sm:w-56">
+          <div className="w-full shrink-0 sm:w-52">
             <Label className="sr-only" htmlFor={`title-type-${title.uuid}`}>
               Type
             </Label>
@@ -322,7 +355,7 @@ export const TitleForm = ({
             </Select>
           </div>
 
-          <div className="w-full shrink-0 sm:w-44">
+          <div className="w-full shrink-0 sm:w-40">
             <Label className="sr-only" htmlFor={`title-language-${title.uuid}`}>
               Language
             </Label>
@@ -345,6 +378,44 @@ export const TitleForm = ({
                 {TITLE_LANGUAGES.map((language) => (
                   <SelectItem key={language} value={language}>
                     {TITLE_LANGUAGE_LABELS[language]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="w-full shrink-0 sm:w-52">
+            <Label
+              className="sr-only"
+              htmlFor={`title-attestation-${title.uuid}`}
+            >
+              Attestation
+            </Label>
+            <Select
+              value={title.attestation ?? NO_ATTESTATION}
+              disabled={disabled}
+              onValueChange={(value) =>
+                replaceAt(index, {
+                  attestation:
+                    value === NO_ATTESTATION
+                      ? undefined
+                      : (value as TitleAttestation),
+                })
+              }
+            >
+              <SelectTrigger
+                id={`title-attestation-${title.uuid}`}
+                className="w-full"
+              >
+                <SelectValue placeholder={NO_ATTESTATION_LABEL} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_ATTESTATION}>
+                  {NO_ATTESTATION_LABEL}
+                </SelectItem>
+                {TITLE_ATTESTATIONS.map((attestation) => (
+                  <SelectItem key={attestation} value={attestation}>
+                    {TITLE_ATTESTATION_LABELS[attestation]}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/libs/lib-editing/src/lib/components/shared/titles/TitleForm.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/TitleForm.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { PlusIcon, Trash2Icon } from 'lucide-react';
+import { useState } from 'react';
+import {
+  ArrowDownIcon,
+  ArrowUpDownIcon,
+  ArrowUpIcon,
+  PlusIcon,
+  Trash2Icon,
+} from 'lucide-react';
 import {
   type ExtendedTranslationLanguage,
   TITLE_TYPES,
@@ -74,6 +81,116 @@ export const emptyTitle = (): Title => ({
   language: NEW_TITLE_LANGUAGE,
 });
 
+/** The columns the row list can be sorted by. */
+export type TitleSortColumn = 'title' | 'type' | 'language';
+
+// Type and language sort by their canonical sequence rather than by label,
+// because alphabetising the labels would scramble an order that carries
+// meaning: 'Long title' < 'Main title' < 'Tohoku number' is not the order these
+// belong in. TITLE_TYPES is the preferred order the reader already renders in,
+// and the language list runs most to least common.
+const TYPE_ORDER = new Map(TITLE_TYPES.map((type, index) => [type, index]));
+const LANGUAGE_ORDER = new Map(
+  TITLE_LANGUAGES.map((language, index) => [language, index]),
+);
+
+const compareBy = (column: TitleSortColumn, a: Title, b: Title): number => {
+  switch (column) {
+    case 'type':
+      return (TYPE_ORDER.get(a.type) ?? -1) - (TYPE_ORDER.get(b.type) ?? -1);
+    case 'language':
+      return (
+        (LANGUAGE_ORDER.get(a.language) ?? -1) -
+        (LANGUAGE_ORDER.get(b.language) ?? -1)
+      );
+    case 'title':
+    default:
+      return a.title.localeCompare(b.title);
+  }
+};
+
+/**
+ * Order titles by one column, falling back through the remaining ones so the
+ * result is total and therefore stable across repeated sorts.
+ *
+ * Row order is presentation only: nothing persists it, and the save diffs by
+ * UUID, so reordering never changes what is written.
+ */
+export const sortTitles = (
+  titles: Titles,
+  column: TitleSortColumn = 'type',
+  direction: 'asc' | 'desc' = 'asc',
+): Titles => {
+  const factor = direction === 'asc' ? 1 : -1;
+  return [...titles].sort(
+    (a, b) =>
+      // Only the chosen column reverses; the tie-breakers keep their order so
+      // rows that compare equal do not shuffle between clicks.
+      factor * compareBy(column, a, b) ||
+      compareBy('type', a, b) ||
+      compareBy('language', a, b) ||
+      compareBy('title', a, b),
+  );
+};
+
+type TitleSort = { column: TitleSortColumn; direction: 'asc' | 'desc' };
+
+/**
+ * A clickable column heading that sorts the row list.
+ *
+ * Declared at module scope rather than inside `TitleForm` so it keeps its
+ * identity across renders — a component redefined each render remounts, and the
+ * button would lose focus on the very click that sorted.
+ *
+ * The rows are a flex layout rather than a `<table>`, so `aria-sort` has no
+ * valid host here; the direction goes into the accessible name instead.
+ */
+const SortHeader = ({
+  column,
+  label,
+  sort,
+  disabled,
+  onSort,
+  className,
+}: {
+  column: TitleSortColumn;
+  label: string;
+  sort: TitleSort | null;
+  disabled?: boolean;
+  onSort: (column: TitleSortColumn) => void;
+  className?: string;
+}) => {
+  const active = sort?.column === column;
+  const state = active
+    ? ` (currently ${sort.direction === 'asc' ? 'ascending' : 'descending'})`
+    : '';
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onSort(column)}
+      aria-label={`Sort by ${label.toLowerCase()}${state}`}
+      className={cn(
+        'flex items-center gap-1 text-left uppercase transition-colors hover:text-foreground disabled:cursor-not-allowed',
+        active && 'text-foreground',
+        className,
+      )}
+    >
+      {label}
+      {active ? (
+        sort.direction === 'asc' ? (
+          <ArrowUpIcon className="size-3" />
+        ) : (
+          <ArrowDownIcon className="size-3" />
+        )
+      ) : (
+        <ArrowUpDownIcon className="size-3 opacity-40" />
+      )}
+    </button>
+  );
+};
+
 /**
  * Edit a work's titles as a list of rows, one row per title.
  *
@@ -91,6 +208,8 @@ export const TitleForm = ({
   disabled?: boolean;
   onChange: (titles: Titles) => void;
 }) => {
+  const [sort, setSort] = useState<TitleSort | null>(null);
+
   const replaceAt = (index: number, changes: Partial<Title>) => {
     onChange(
       titles.map((title, idx) =>
@@ -103,12 +222,45 @@ export const TitleForm = ({
     onChange(titles.filter((_, idx) => idx !== index));
   };
 
+  // Sorting reorders the rows the caller holds rather than a display copy,
+  // because rows are edited by index — sorting only the view would send a
+  // keystroke in one row to another. It runs once per click rather than
+  // continuously for the same reason a spreadsheet does not re-sort as you
+  // type: a row that moved mid-edit would take the cursor with it.
+  const sortBy = (column: TitleSortColumn) => {
+    const direction =
+      sort?.column === column && sort.direction === 'asc' ? 'desc' : 'asc';
+    setSort({ column, direction });
+    onChange(sortTitles(titles, column, direction));
+  };
+
   return (
     <div className="flex flex-col gap-3">
-      <div className="hidden gap-2 px-1 text-xs uppercase text-muted-foreground sm:flex">
-        <span className="grow">Title</span>
-        <span className="w-56 shrink-0">Type</span>
-        <span className="w-44 shrink-0">Language</span>
+      <div className="hidden gap-2 px-1 text-xs text-muted-foreground sm:flex">
+        <SortHeader
+          column="title"
+          label="Title"
+          sort={sort}
+          disabled={disabled}
+          onSort={sortBy}
+          className="grow"
+        />
+        <SortHeader
+          column="type"
+          label="Type"
+          sort={sort}
+          disabled={disabled}
+          onSort={sortBy}
+          className="w-56 shrink-0"
+        />
+        <SortHeader
+          column="language"
+          label="Language"
+          sort={sort}
+          disabled={disabled}
+          onSort={sortBy}
+          className="w-44 shrink-0"
+        />
         <span className="w-9 shrink-0" />
       </div>
 

--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
@@ -47,6 +47,14 @@ const TITLES: TitlesData = [
   },
 ];
 
+// A deliberately jumbled set: no column is already in order, so each sort has
+// something to prove.
+const UNSORTED: TitlesData = [
+  { uuid: 'u-1', title: 'Zebra', language: 'Sa-Ltn', type: 'otherTitle' },
+  { uuid: 'u-2', title: 'Apple', language: 'bo', type: 'toh' },
+  { uuid: 'u-3', title: 'Mango', language: 'en', type: 'mainTitle' },
+];
+
 // This project does not load jest-dom, so element state is read directly.
 const saveButton = () =>
   screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
@@ -166,6 +174,129 @@ describe('Titles edit dialog', () => {
     await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
     const { titles } = mockSaveWorkTitles.mock.calls[0][0];
     expect(titles[1].type).toBe('shortcode');
+  });
+
+  describe('column sorting', () => {
+    const sortBy = async (label: RegExp) =>
+      userEvent.click(screen.getByRole('button', { name: label }));
+
+    it('sorts by title text, and reverses on a second click', async () => {
+      await openDialog({ titles: UNSORTED });
+
+      await sortBy(/^sort by title/i);
+      expect(titleInputs().map((i) => i.value)).toEqual([
+        'Apple',
+        'Mango',
+        'Zebra',
+      ]);
+
+      await sortBy(/^sort by title/i);
+      expect(titleInputs().map((i) => i.value)).toEqual([
+        'Zebra',
+        'Mango',
+        'Apple',
+      ]);
+    });
+
+    it('sorts by type in canonical order, not alphabetically by label', async () => {
+      await openDialog({ titles: UNSORTED });
+
+      await sortBy(/^sort by type/i);
+
+      // TITLE_TYPES order is toh, mainTitle, ..., otherTitle — which is not the
+      // order the labels would take alphabetically.
+      expect(titleInputs().map((i) => i.value)).toEqual([
+        'Apple',
+        'Mango',
+        'Zebra',
+      ]);
+    });
+
+    it('sorts by language', async () => {
+      await openDialog({ titles: UNSORTED });
+
+      await sortBy(/^sort by language/i);
+
+      // Language order runs most to least common: en, bo, Bo-Ltn, Sa-Ltn.
+      expect(titleInputs().map((i) => i.value)).toEqual([
+        'Mango',
+        'Apple',
+        'Zebra',
+      ]);
+    });
+
+    it('reports the active direction in the accessible name', async () => {
+      await openDialog({ titles: UNSORTED });
+
+      expect(
+        screen.getByRole('button', { name: 'Sort by title' }),
+      ).toBeTruthy();
+
+      await sortBy(/^sort by title/i);
+      expect(
+        screen.getByRole('button', {
+          name: 'Sort by title (currently ascending)',
+        }),
+      ).toBeTruthy();
+
+      await sortBy(/^sort by title/i);
+      expect(
+        screen.getByRole('button', {
+          name: 'Sort by title (currently descending)',
+        }),
+      ).toBeTruthy();
+    });
+
+    it('does not turn a sort into a pending write', async () => {
+      await openDialog({ titles: UNSORTED });
+
+      await sortBy(/^sort by title/i);
+      await userEvent.click(saveButton());
+
+      // Order is presentation only and the diff is keyed by UUID, so a save
+      // straight after sorting must find nothing to change.
+      await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+      const { titles, original } = mockSaveWorkTitles.mock.calls[0][0];
+      const byUuid = (rows: TitlesData) =>
+        [...rows].sort((a, b) => a.uuid.localeCompare(b.uuid));
+      expect(byUuid(titles)).toEqual(byUuid(original));
+      // ...and the rows really were reordered, so the check above means
+      // something.
+      expect(titles.map((t: { uuid: string }) => t.uuid)).not.toEqual(
+        original.map((t: { uuid: string }) => t.uuid),
+      );
+    });
+
+    it('edits the row that was clicked after a sort', async () => {
+      await openDialog({ titles: UNSORTED });
+
+      await sortBy(/^sort by title/i);
+      // Rows are edited by index, so a sort that moved only the view would send
+      // this keystroke to the wrong title.
+      await userEvent.clear(titleInputs()[0]);
+      await userEvent.type(titleInputs()[0], 'Apricot');
+      await userEvent.click(saveButton());
+
+      await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+      const { titles } = mockSaveWorkTitles.mock.calls[0][0];
+      const edited = titles.find((t: { uuid: string }) => t.uuid === 'u-2');
+      expect(edited.title).toBe('Apricot');
+      expect(titles.find((t: { uuid: string }) => t.uuid === 'u-3').title).toBe(
+        'Mango',
+      );
+    });
+
+    it('leaves a newly added row in place rather than re-sorting it away', async () => {
+      await openDialog({ titles: UNSORTED });
+
+      await sortBy(/^sort by title/i);
+      await userEvent.click(screen.getByRole('button', { name: /add title/i }));
+
+      // Sorting is a one-shot action, so the empty row stays at the end where
+      // the editor can see it instead of jumping to the top.
+      expect(titleInputs()).toHaveLength(4);
+      expect(titleInputs()[3].value).toBe('');
+    });
   });
 
   it('refuses to save a blank title and keeps the dialog open', async () => {

--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
@@ -176,9 +176,9 @@ describe('Titles edit dialog', () => {
   it('changes a title type', async () => {
     await openDialog();
 
-    // Each row contributes a type picker then a language picker, so the second
-    // row's type picker is the third combobox.
-    const typePickerForSecondRow = screen.getAllByRole('combobox')[2];
+    // Each row contributes type, language, then attestation pickers, so the
+    // second row's type picker is the fourth combobox.
+    const typePickerForSecondRow = screen.getAllByRole('combobox')[3];
     await userEvent.click(typePickerForSecondRow);
     await userEvent.click(screen.getByRole('option', { name: 'Short code' }));
     await userEvent.click(saveButton());
@@ -186,6 +186,104 @@ describe('Titles edit dialog', () => {
     await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
     const { titles } = mockSaveWorkTitles.mock.calls[0][0];
     expect(titles[1].type).toBe('shortcode');
+  });
+
+  describe('attestation', () => {
+    const ATTESTED: TitlesData = [
+      {
+        uuid: 'a-1',
+        title: 'Reconstructed one',
+        language: 'Sa-Ltn',
+        type: 'mainTitle',
+        attestation: 'reconstructedPhonetic',
+      },
+      {
+        uuid: 'a-2',
+        title: 'Plain one',
+        language: 'en',
+        type: 'mainTitle',
+      },
+    ];
+
+    // Rows open in the default type-ascending order, and these two share a
+    // type, so the language tie-breaker decides which comes first. Locate rows
+    // by their text rather than assuming a position.
+    const rowOf = (text: string) =>
+      titleInputs().findIndex((input) => input.value === text);
+
+    // Each row contributes type, language, then attestation pickers.
+    const attestationPicker = (row: number) =>
+      screen.getAllByRole('combobox')[row * 3 + 2];
+
+    it('shows the stored attestation, and Directly attested when there is none', async () => {
+      await openDialog({ titles: ATTESTED });
+
+      expect(
+        attestationPicker(rowOf('Reconstructed one')).textContent,
+      ).toContain('Reconstructed phonetic');
+      expect(attestationPicker(rowOf('Plain one')).textContent).toContain(
+        'None',
+      );
+    });
+
+    it('sets an attestation on a title that had none', async () => {
+      await openDialog({ titles: ATTESTED });
+
+      await userEvent.click(attestationPicker(rowOf('Plain one')));
+      await userEvent.click(
+        screen.getByRole('option', { name: 'Reconstructed semantic' }),
+      );
+      await userEvent.click(saveButton());
+
+      await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+      const { titles } = mockSaveWorkTitles.mock.calls[0][0];
+      expect(
+        titles.find((t: { uuid: string }) => t.uuid === 'a-2').attestation,
+      ).toBe('reconstructedSemantic');
+    });
+
+    it('clears an attestation back to undefined rather than a sentinel', async () => {
+      await openDialog({ titles: ATTESTED });
+
+      await userEvent.click(attestationPicker(rowOf('Reconstructed one')));
+      await userEvent.click(screen.getByRole('option', { name: 'None' }));
+      await userEvent.click(saveButton());
+
+      await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+      const { titles } = mockSaveWorkTitles.mock.calls[0][0];
+      const cleared = titles.find((t: { uuid: string }) => t.uuid === 'a-1');
+      // The picker's placeholder value must never reach the database.
+      expect(cleared.attestation).toBeUndefined();
+    });
+
+    it('leaves attestation alone when only the title text is edited', async () => {
+      await openDialog({ titles: ATTESTED });
+
+      const row = rowOf('Reconstructed one');
+      await userEvent.clear(titleInputs()[row]);
+      await userEvent.type(titleInputs()[row], 'Reconstructed one, renamed');
+      await userEvent.click(saveButton());
+
+      await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+      const { titles } = mockSaveWorkTitles.mock.calls[0][0];
+      expect(
+        titles.find((t: { uuid: string }) => t.uuid === 'a-1').attestation,
+      ).toBe('reconstructedPhonetic');
+    });
+
+    it('sorts by attestation label', async () => {
+      await openDialog({ titles: ATTESTED });
+
+      await userEvent.click(
+        screen.getByRole('button', { name: /^sort by attestation/i }),
+      );
+
+      // None, then Reconstructed phonetic.
+      expect(titleInputs().map((i) => i.value)).toEqual([
+        'Plain one',
+        'Reconstructed one',
+      ]);
+    });
   });
 
   describe('column sorting', () => {

--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
@@ -67,6 +67,28 @@ const UNSORTED: TitlesData = [
   { uuid: 'u-3', title: 'Zebra', language: 'Sa-Ltn', type: 'otherTitle' },
 ];
 
+// This suite mounts a dialog whose every row carries three Radix Selects, and
+// it runs roughly four times slower in CI than locally (6s here, 26s there).
+// The default 5s per-test budget is not enough headroom, and a test that times
+// out leaves its async work running to contaminate the next one.
+jest.setTimeout(20000);
+
+/**
+ * Retype a title's text.
+ *
+ * Real keystrokes, because the design-system Input debounces its onChange and a
+ * single synthetic change event never reaches the caller's draft — the value
+ * lands in the DOM and goes no further. Each keystroke costs a render of the
+ * whole dialog, so the strings here are kept short; the assertions are about
+ * what a save writes, and a longer title proved nothing extra.
+ */
+const setText = async (input: HTMLInputElement, text: string) => {
+  await userEvent.clear(input);
+  if (text) {
+    await userEvent.type(input, text);
+  }
+};
+
 // This project does not load jest-dom, so element state is read directly.
 const saveButton = () =>
   screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
@@ -118,8 +140,7 @@ describe('Titles edit dialog', () => {
   it('updates an existing title', async () => {
     const { onTitlesSaved } = await openDialog();
 
-    await userEvent.clear(titleInputs()[0]);
-    await userEvent.type(titleInputs()[0], 'The Noble Perfection of Wisdom');
+    await setText(titleInputs()[0], 'Renamed');
     await userEvent.click(saveButton());
 
     await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
@@ -128,7 +149,7 @@ describe('Titles edit dialog', () => {
     expect(original).toEqual(TITLES);
     expect(titles[0]).toEqual({
       uuid: 'title-1',
-      title: 'The Noble Perfection of Wisdom',
+      title: 'Renamed',
       language: 'en',
       type: 'mainTitle',
     });
@@ -141,14 +162,14 @@ describe('Titles edit dialog', () => {
     await userEvent.click(screen.getByRole('button', { name: /add title/i }));
     expect(titleInputs()).toHaveLength(3);
 
-    await userEvent.type(titleInputs()[2], 'Prajñāpāramitā');
+    await setText(titleInputs()[2], 'Prajna');
     await userEvent.click(saveButton());
 
     await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
     const { titles } = mockSaveWorkTitles.mock.calls[0][0];
     expect(titles).toHaveLength(3);
     expect(titles[2]).toMatchObject({
-      title: 'Prajñāpāramitā',
+      title: 'Prajna',
       type: 'mainTitle',
       language: 'en',
     });
@@ -260,8 +281,7 @@ describe('Titles edit dialog', () => {
       await openDialog({ titles: ATTESTED });
 
       const row = rowOf('Reconstructed one');
-      await userEvent.clear(titleInputs()[row]);
-      await userEvent.type(titleInputs()[row], 'Reconstructed one, renamed');
+      await setText(titleInputs()[row], 'Renamed');
       await userEvent.click(saveButton());
 
       await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
@@ -402,8 +422,7 @@ describe('Titles edit dialog', () => {
       await sortBy(/^sort by title/i);
       // Rows are edited by index, so a sort that moved only the view would send
       // this keystroke to the wrong title.
-      await userEvent.clear(titleInputs()[0]);
-      await userEvent.type(titleInputs()[0], 'Apricot');
+      await setText(titleInputs()[0], 'Apricot');
       await userEvent.click(saveButton());
 
       await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
@@ -431,7 +450,7 @@ describe('Titles edit dialog', () => {
   it('refuses to save a blank title and keeps the dialog open', async () => {
     await openDialog();
 
-    await userEvent.clear(titleInputs()[0]);
+    await setText(titleInputs()[0], '');
     await userEvent.click(saveButton());
 
     expect(await screen.findByRole('alert')).toBeTruthy();
@@ -448,8 +467,7 @@ describe('Titles edit dialog', () => {
     });
     const { onTitlesSaved } = await openDialog();
 
-    await userEvent.clear(titleInputs()[0]);
-    await userEvent.type(titleInputs()[0], 'Renamed');
+    await setText(titleInputs()[0], 'Renamed');
     await userEvent.click(saveButton());
 
     const alert = await screen.findByRole('alert');
@@ -461,8 +479,7 @@ describe('Titles edit dialog', () => {
   it('discards edits when the dialog is cancelled', async () => {
     await openDialog();
 
-    await userEvent.clear(titleInputs()[0]);
-    await userEvent.type(titleInputs()[0], 'Discarded');
+    await setText(titleInputs()[0], 'Discarded');
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());

--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
@@ -1,0 +1,215 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Titles as TitlesData } from '@eightyfourthousand/data-access';
+import { Titles } from './Titles';
+
+const mockSaveWorkTitles = jest.fn();
+
+jest.mock('@eightyfourthousand/data-access', () => ({
+  ...jest.requireActual('@eightyfourthousand/data-access'),
+  createBrowserClient: () => ({}),
+  saveWorkTitles: (args: unknown) => mockSaveWorkTitles(args),
+}));
+
+// Radix's Select relies on pointer capture, scrollIntoView, and ResizeObserver,
+// none of which jsdom implements. Without these the dropdown never opens and
+// the type/language pickers cannot be exercised at all.
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => undefined;
+  Element.prototype.releasePointerCapture = () => undefined;
+  Element.prototype.scrollIntoView = () => undefined;
+  global.ResizeObserver = class {
+    observe() {
+      return undefined;
+    }
+    unobserve() {
+      return undefined;
+    }
+    disconnect() {
+      return undefined;
+    }
+  };
+});
+
+const TITLES: TitlesData = [
+  {
+    uuid: 'title-1',
+    title: 'The Perfection of Wisdom',
+    language: 'en',
+    type: 'mainTitle',
+  },
+  {
+    uuid: 'title-2',
+    title: 'Toh 12',
+    language: 'en',
+    type: 'toh',
+  },
+];
+
+// This project does not load jest-dom, so element state is read directly.
+const saveButton = () =>
+  screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+
+const titleInputs = () =>
+  screen.getAllByPlaceholderText('Enter title') as HTMLInputElement[];
+
+const openDialog = async (
+  props: Partial<React.ComponentProps<typeof Titles>> = {},
+) => {
+  const onTitlesSaved = jest.fn();
+  render(
+    <Titles
+      titles={TITLES}
+      canEdit
+      workUuid="work-1"
+      onTitlesSaved={onTitlesSaved}
+      {...props}
+    />,
+  );
+  await userEvent.click(screen.getByRole('button', { name: 'Edit titles' }));
+  await screen.findByRole('dialog');
+  return { onTitlesSaved };
+};
+
+describe('Titles edit dialog', () => {
+  beforeEach(() => {
+    mockSaveWorkTitles.mockReset();
+    mockSaveWorkTitles.mockResolvedValue({
+      inserted: 0,
+      updated: 0,
+      deleted: 0,
+    });
+  });
+
+  it('does not offer the pencil when the user may not edit', () => {
+    render(<Titles titles={TITLES} workUuid="work-1" />);
+    expect(screen.queryByRole('button', { name: 'Edit titles' })).toBeNull();
+  });
+
+  it('shows one row per title, not one per language', async () => {
+    await openDialog();
+    expect(titleInputs().map((input) => input.value)).toEqual([
+      'The Perfection of Wisdom',
+      'Toh 12',
+    ]);
+  });
+
+  it('updates an existing title', async () => {
+    const { onTitlesSaved } = await openDialog();
+
+    await userEvent.clear(titleInputs()[0]);
+    await userEvent.type(titleInputs()[0], 'The Noble Perfection of Wisdom');
+    await userEvent.click(saveButton());
+
+    await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+    const { titles, original, workUuid } = mockSaveWorkTitles.mock.calls[0][0];
+    expect(workUuid).toBe('work-1');
+    expect(original).toEqual(TITLES);
+    expect(titles[0]).toEqual({
+      uuid: 'title-1',
+      title: 'The Noble Perfection of Wisdom',
+      language: 'en',
+      type: 'mainTitle',
+    });
+    expect(onTitlesSaved).toHaveBeenCalledWith(titles);
+  });
+
+  it('adds a title', async () => {
+    await openDialog();
+
+    await userEvent.click(screen.getByRole('button', { name: /add title/i }));
+    expect(titleInputs()).toHaveLength(3);
+
+    await userEvent.type(titleInputs()[2], 'Prajñāpāramitā');
+    await userEvent.click(saveButton());
+
+    await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+    const { titles } = mockSaveWorkTitles.mock.calls[0][0];
+    expect(titles).toHaveLength(3);
+    expect(titles[2]).toMatchObject({
+      title: 'Prajñāpāramitā',
+      type: 'mainTitle',
+      language: 'en',
+    });
+    // A new row carries a client-minted UUID so it can be inserted by key.
+    expect(titles[2].uuid).toEqual(expect.any(String));
+    expect(titles[2].uuid).not.toBe('');
+  });
+
+  it('removes a title', async () => {
+    await openDialog();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /remove Toh 12 title/i }),
+    );
+    expect(titleInputs()).toHaveLength(1);
+
+    await userEvent.click(saveButton());
+
+    await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+    const { titles, original } = mockSaveWorkTitles.mock.calls[0][0];
+    expect(titles.map((t: { uuid: string }) => t.uuid)).toEqual(['title-1']);
+    expect(original).toHaveLength(2);
+  });
+
+  it('changes a title type', async () => {
+    await openDialog();
+
+    // Each row contributes a type picker then a language picker, so the second
+    // row's type picker is the third combobox.
+    const typePickerForSecondRow = screen.getAllByRole('combobox')[2];
+    await userEvent.click(typePickerForSecondRow);
+    await userEvent.click(screen.getByRole('option', { name: 'Short code' }));
+    await userEvent.click(saveButton());
+
+    await waitFor(() => expect(mockSaveWorkTitles).toHaveBeenCalled());
+    const { titles } = mockSaveWorkTitles.mock.calls[0][0];
+    expect(titles[1].type).toBe('shortcode');
+  });
+
+  it('refuses to save a blank title and keeps the dialog open', async () => {
+    await openDialog();
+
+    await userEvent.clear(titleInputs()[0]);
+    await userEvent.click(saveButton());
+
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(mockSaveWorkTitles).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('surfaces a rejected write instead of reporting success', async () => {
+    mockSaveWorkTitles.mockResolvedValue({
+      inserted: 0,
+      updated: 0,
+      deleted: 0,
+      error: 'new row violates row-level security policy',
+    });
+    const { onTitlesSaved } = await openDialog();
+
+    await userEvent.clear(titleInputs()[0]);
+    await userEvent.type(titleInputs()[0], 'Renamed');
+    await userEvent.click(saveButton());
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('row-level security policy');
+    expect(onTitlesSaved).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('discards edits when the dialog is cancelled', async () => {
+    await openDialog();
+
+    await userEvent.clear(titleInputs()[0]);
+    await userEvent.type(titleInputs()[0], 'Discarded');
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    await userEvent.click(screen.getByRole('button', { name: 'Edit titles' }));
+    await screen.findByRole('dialog');
+
+    expect(titleInputs()[0].value).toBe('The Perfection of Wisdom');
+    expect(mockSaveWorkTitles).not.toHaveBeenCalled();
+  });
+});

--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.spec.tsx
@@ -47,12 +47,24 @@ const TITLES: TitlesData = [
   },
 ];
 
-// A deliberately jumbled set: no column is already in order, so each sort has
-// something to prove.
+// A deliberately jumbled set, chosen so each of the three columns sorts into a
+// *different* order — otherwise the per-column tests below could all pass on
+// one shared accident.
+//
+//                 title    type (label)      language (label)
+//   u-1           Mango    Tohoku number     English
+//   u-2           Apple    Main title        Tibetan
+//   u-3           Zebra    Other title       Sanskrit (Latin)
+//
+//   by title:     Apple, Mango, Zebra        → u-2, u-1, u-3
+//   by type:      Main title, Other title, Tohoku number
+//                                            → u-2, u-3, u-1
+//   by language:  English, Sanskrit (Latin), Tibetan
+//                                            → u-1, u-3, u-2
 const UNSORTED: TitlesData = [
-  { uuid: 'u-1', title: 'Zebra', language: 'Sa-Ltn', type: 'otherTitle' },
-  { uuid: 'u-2', title: 'Apple', language: 'bo', type: 'toh' },
-  { uuid: 'u-3', title: 'Mango', language: 'en', type: 'mainTitle' },
+  { uuid: 'u-1', title: 'Mango', language: 'en', type: 'toh' },
+  { uuid: 'u-2', title: 'Apple', language: 'bo', type: 'mainTitle' },
+  { uuid: 'u-3', title: 'Zebra', language: 'Sa-Ltn', type: 'otherTitle' },
 ];
 
 // This project does not load jest-dom, so element state is read directly.
@@ -198,36 +210,55 @@ describe('Titles edit dialog', () => {
       ]);
     });
 
-    it('sorts by type in canonical order, not alphabetically by label', async () => {
+    it('opens sorted by type ascending', async () => {
+      await openDialog({ titles: UNSORTED });
+
+      // Main title, Other title, Tohoku number — alphabetical by what the
+      // editor sees, not by the underlying TITLE_TYPES sequence, which would
+      // have put Tohoku number first.
+      expect(titleInputs().map((i) => i.value)).toEqual([
+        'Apple',
+        'Zebra',
+        'Mango',
+      ]);
+      expect(
+        screen.getByRole('button', {
+          name: 'Sort by type (currently ascending)',
+        }),
+      ).toBeTruthy();
+    });
+
+    it('reverses to descending when the already-active type column is clicked', async () => {
       await openDialog({ titles: UNSORTED });
 
       await sortBy(/^sort by type/i);
 
-      // TITLE_TYPES order is toh, mainTitle, ..., otherTitle — which is not the
-      // order the labels would take alphabetically.
       expect(titleInputs().map((i) => i.value)).toEqual([
-        'Apple',
         'Mango',
         'Zebra',
+        'Apple',
       ]);
     });
 
-    it('sorts by language', async () => {
+    it('sorts by the language label shown in the picker', async () => {
       await openDialog({ titles: UNSORTED });
 
       await sortBy(/^sort by language/i);
 
-      // Language order runs most to least common: en, bo, Bo-Ltn, Sa-Ltn.
+      // English, Sanskrit (Latin), Tibetan — alphabetical by label rather than
+      // by the picker's most-to-least-common ordering, which would have put
+      // Tibetan second.
       expect(titleInputs().map((i) => i.value)).toEqual([
         'Mango',
-        'Apple',
         'Zebra',
+        'Apple',
       ]);
     });
 
     it('reports the active direction in the accessible name', async () => {
       await openDialog({ titles: UNSORTED });
 
+      // Title is not the active column on open, so it carries no state.
       expect(
         screen.getByRole('button', { name: 'Sort by title' }),
       ).toBeTruthy();
@@ -281,7 +312,7 @@ describe('Titles edit dialog', () => {
       const { titles } = mockSaveWorkTitles.mock.calls[0][0];
       const edited = titles.find((t: { uuid: string }) => t.uuid === 'u-2');
       expect(edited.title).toBe('Apricot');
-      expect(titles.find((t: { uuid: string }) => t.uuid === 'u-3').title).toBe(
+      expect(titles.find((t: { uuid: string }) => t.uuid === 'u-1').title).toBe(
         'Mango',
       );
     });

--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.tsx
@@ -18,7 +18,7 @@ import {
   DialogTitle,
 } from '@eightyfourthousand/design-system';
 import { TitlesCard } from './TitlesCard';
-import { TitleForm } from './TitleForm';
+import { sortTitles, TitleForm } from './TitleForm';
 
 export type TitlesVariant =
   | 'english'
@@ -48,7 +48,7 @@ export const Titles = ({
   onTitlesSaved?: (titles: TitlesData) => void;
 }) => {
   const [isEditOpen, setIsEditOpen] = useState(false);
-  const [draft, setDraft] = useState<TitlesData>(titles);
+  const [draft, setDraft] = useState<TitlesData>(() => sortTitles(titles));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
 
@@ -57,7 +57,9 @@ export const Titles = ({
   // stored — without a second render to clear the previous draft.
   const setDialogOpen = (open: boolean) => {
     if (open) {
-      setDraft(titles);
+      // Sorted on the way in: the stored order is arbitrary, so the rows would
+      // otherwise appear in whatever order Postgres returned them.
+      setDraft(sortTitles(titles));
       setError(undefined);
     }
     setIsEditOpen(open);

--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.tsx
@@ -185,7 +185,7 @@ export const Titles = ({
         onEdit={() => setDialogOpen(true)}
       />
       <Dialog open={isEditOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="max-w-4xl" showCloseButton={false}>
+        <DialogContent className="max-w-6xl" showCloseButton={false}>
           <DialogTitle>Edit titles</DialogTitle>
           <DialogDescription>
             Titles are global to this work and go live as soon as they are

--- a/libs/lib-editing/src/lib/components/shared/titles/Titles.tsx
+++ b/libs/lib-editing/src/lib/components/shared/titles/Titles.tsx
@@ -3,33 +3,65 @@
 import { useState } from 'react';
 import {
   BO_TITLE_PREFIX,
+  createBrowserClient,
   Imprint,
+  saveWorkTitles,
   Titles as TitlesData,
   TitleType,
 } from '@eightyfourthousand/data-access';
 import {
+  Button,
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogTitle,
 } from '@eightyfourthousand/design-system';
 import { TitlesCard } from './TitlesCard';
 import { TitleForm } from './TitleForm';
 
-export type TitlesVariant = 'english' | 'tibetan' | 'comparison' | 'front' | 'other';
+export type TitlesVariant =
+  | 'english'
+  | 'tibetan'
+  | 'comparison'
+  | 'front'
+  | 'other';
 
 export const Titles = ({
   titles,
   variant = 'english',
   imprint,
   canEdit = false,
+  workUuid,
+  onTitlesSaved,
 }: {
   titles: TitlesData;
   imprint?: Imprint;
   variant?: TitlesVariant;
   canEdit?: boolean;
+  /**
+   * The work the titles belong to. Required to save; without it the dialog
+   * opens read-only, since a new title cannot be attached to anything.
+   */
+  workUuid?: string;
+  /** Called with the saved titles so the surrounding page can re-render. */
+  onTitlesSaved?: (titles: TitlesData) => void;
 }) => {
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const [draft, setDraft] = useState<TitlesData>(titles);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  // Seed the draft on open rather than in an effect, so a cancelled edit is
+  // really discarded and a reopened dialog starts from what is currently
+  // stored — without a second render to clear the previous draft.
+  const setDialogOpen = (open: boolean) => {
+    if (open) {
+      setDraft(titles);
+      setError(undefined);
+    }
+    setIsEditOpen(open);
+  };
 
   const titlesByType = titles.reduce(
     (acc, title) => {
@@ -94,6 +126,48 @@ export const Titles = ({
       break;
   }
 
+  const save = async () => {
+    if (!workUuid) {
+      setError('Cannot save titles: no work is associated with this view.');
+      return;
+    }
+
+    const cleaned = draft.map((title) => ({
+      ...title,
+      title: title.title.trim(),
+    }));
+    if (cleaned.some((title) => !title.title)) {
+      setError('Every title needs text. Remove any blank rows before saving.');
+      return;
+    }
+
+    setSaving(true);
+    setError(undefined);
+
+    const result = await saveWorkTitles({
+      client: createBrowserClient(),
+      workUuid,
+      titles: cleaned,
+      original: titles,
+    });
+
+    setSaving(false);
+
+    if (result.error) {
+      // The writes are not atomic, so some may have landed. Report what did
+      // and leave the dialog open rather than implying nothing changed.
+      const applied =
+        result.inserted + result.updated + result.deleted > 0
+          ? ' Some changes were applied; reload before trying again.'
+          : '';
+      setError(`Failed to save titles: ${result.error}.${applied}`);
+      return;
+    }
+
+    onTitlesSaved?.(cleaned);
+    setDialogOpen(false);
+  };
+
   return (
     <>
       <TitlesCard
@@ -106,18 +180,36 @@ export const Titles = ({
         attribution={imprint?.isAuthorContested ? 'attributed to' : 'by'}
         authorsJoiner={imprint?.isAuthorContested ? ' or' : ','}
         canEdit={canEdit}
-        onEdit={() => setIsEditOpen(true)}
+        onEdit={() => setDialogOpen(true)}
       />
-      <Dialog open={isEditOpen} onOpenChange={setIsEditOpen}>
+      <Dialog open={isEditOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-4xl" showCloseButton={false}>
-          <DialogTitle className="hidden">Edit Titles</DialogTitle>
-          <DialogDescription className="hidden">Edit Titles</DialogDescription>
-          <TitleForm
-            titles={titles}
-            onChange={(title) => {
-              console.log('TODO: save title', title);
-            }}
-          />
+          <DialogTitle>Edit titles</DialogTitle>
+          <DialogDescription>
+            Titles are global to this work and go live as soon as they are
+            saved. They are not part of the publishing workflow.
+          </DialogDescription>
+          <div className="max-h-[60vh] overflow-y-auto px-1">
+            <TitleForm titles={draft} disabled={saving} onChange={setDraft} />
+          </div>
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={saving}
+              onClick={() => setDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" disabled={saving} onClick={save}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
### Summary

Makes the titles dialog work: it now adds, updates, and removes individual titles — including `attestation` — gated on `editor.admin`. Previously it saved nothing (`onChange` was a `console.log` TODO) and the form under it keyed titles by language alone, dropping `type`.

### Linear

- [DEV-148](https://linear.app/84000/issue/DEV-148/edit-and-save-titles)

### Notes

Titles are keyed by type and language, and a work often carries several of the same type — 4-8 titles typically, 24 at the extreme in production. `TitleForm` is now one row per title (title, type, language, attestation, remove) plus "Add title". Edits are held in draft and reach the database only on Save, so Cancel really discards; that matters because a saved title is public immediately, with no publishing step behind it.

Editing takes `editor.admin` rather than the `editor.edit` that governs passage content, for the same reason. `EditorProvider` gains `canAdminister()`