### PR TITLE
Add mention entry points to the editor slash and bubble menus

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.integration.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.integration.spec.ts
@@ -1,0 +1,111 @@
+import { Editor, Extension, Node, Range } from '@tiptap/core';
+import Suggestion from '@tiptap/suggestion';
+import {
+  mentionSuggestion,
+  mentionSuggestionPluginKey,
+} from './MentionSuggestion';
+import { MentionCommandSuggestion } from './MentionCommandSuggestion';
+
+// MentionSuggestion imports MentionList for its popup, which reaches
+// lib-search -> data-access/ssr -> next/server and needs a `Request` global
+// jsdom does not provide. The list is irrelevant here — this asserts on plugin
+// state, which `apply` computes before any rendering — so stub it out and keep
+// the real suggestion config (char, allowSpaces, allowedPrefixes) under test.
+// Hoisted above the imports above by the jest transform.
+jest.mock('./MentionList', () => ({ __esModule: true, default: () => null }));
+
+const Doc = Node.create({ name: 'doc', topNode: true, content: 'block+' });
+const Paragraph = Node.create({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+  parseHTML: () => [{ tag: 'p' }],
+  renderHTML: () => ['p', 0],
+});
+const TextNode = Node.create({ name: 'text', group: 'inline' });
+
+/**
+ * Drives the real `mentionSuggestion` config — its `char`, `allowSpaces`, and
+ * default `allowedPrefixes` are the parts under test. Only `render` is stubbed,
+ * to keep tippy and the React renderer out of jsdom; the plugin state this
+ * asserts on is computed in `apply`, before `render` is consulted.
+ */
+const MentionTrigger = Extension.create({
+  name: 'mentionTrigger',
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...mentionSuggestion,
+        render: () => ({}),
+      }),
+    ];
+  },
+});
+
+const createEditor = (html: string) =>
+  new Editor({
+    element: document.createElement('div'),
+    extensions: [Doc, Paragraph, TextNode, MentionTrigger],
+    content: html,
+  });
+
+const suggestionState = (editor: Editor) =>
+  mentionSuggestionPluginKey.getState(editor.state);
+
+describe('MentionCommandSuggestion end to end', () => {
+  it('leaves the mention dropdown open where the slash trigger was', () => {
+    const editor = createEditor('<p>see /mention</p>');
+    // "see /mention" starts at pos 1, so the slash sits at 5 and the trigger
+    // text runs to 13 — the range the slash plugin would hand the command.
+    expect(editor.state.doc.textContent).toBe('see /mention');
+    const range: Range = { from: 5, to: 13 };
+
+    // No caret placed: the command must target range.from itself rather than
+    // inherit wherever the selection happens to sit.
+    expect(suggestionState(editor)?.active).toBe(false);
+
+    MentionCommandSuggestion.command({ editor, range });
+
+    const state = suggestionState(editor);
+    expect(state?.active).toBe(true);
+    // Empty query: the dropdown opens in its "Type to search entities…" state,
+    // exactly as it does for a hand-typed `@`.
+    expect(state?.query).toBe('');
+    expect(state?.range).toEqual({ from: 5, to: 6 });
+    expect(editor.state.doc.textContent).toBe('see @');
+
+    editor.destroy();
+  });
+
+  it('does not open when the slash trigger is mid-word', () => {
+    // allowedPrefixes defaults to [' '], so a trigger glued to a preceding word
+    // is refused — the same rule that governs a typed `@`.
+    const editor = createEditor('<p>see/mention</p>');
+
+    MentionCommandSuggestion.command({ editor, range: { from: 4, to: 12 } });
+
+    expect(suggestionState(editor)?.active).toBe(false);
+    editor.destroy();
+  });
+
+  it('carries a multi-word query, since the config allows spaces', () => {
+    // Relevant to seeding the dropdown from a selection: allowSpaces means the
+    // query survives the first space instead of ending the match there.
+    const editor = createEditor('<p>see</p>');
+    // Built by typing rather than parsed from HTML: the parser trims a trailing
+    // space, and the space before `@` is what allowedPrefixes requires.
+    editor
+      .chain()
+      .focus()
+      .setTextSelection(4)
+      .insertContent(' @the Great Vehicle')
+      .run();
+
+    const state = suggestionState(editor);
+    expect(state?.active).toBe(true);
+    expect(state?.query).toBe('the Great Vehicle');
+
+    editor.destroy();
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.spec.ts
@@ -1,13 +1,8 @@
 import { Editor, Range } from '@tiptap/core';
 import { MentionCommandSuggestion } from './MentionCommandSuggestion';
-import type { MentionAdvancedPayload } from './Mention';
 
-/**
- * A stub editor recording the chained calls the command makes, plus the storage
- * the command reads. Only `focus`/`deleteRange`/`run` are chained here — enough
- * for this command, which does no other editing.
- */
-const createEditor = (openAdvanced?: (p: MentionAdvancedPayload) => void) => {
+/** A stub editor recording the chained calls the command makes. */
+const createEditor = (storage: Record<string, unknown> = { mention: {} }) => {
   const calls: string[] = [];
   const chain = {
     focus: () => {
@@ -18,54 +13,44 @@ const createEditor = (openAdvanced?: (p: MentionAdvancedPayload) => void) => {
       calls.push(`deleteRange(${range.from},${range.to})`);
       return chain;
     },
+    insertContentAt: (pos: number, content: string) => {
+      calls.push(`insertContentAt(${pos},${content})`);
+      return chain;
+    },
     run: () => {
       calls.push('run');
       return true;
     },
   };
 
-  const editor = {
-    chain: () => chain,
-    storage: { mention: { openAdvanced } },
-  } as unknown as Editor;
-
-  return { editor, calls };
+  return { editor: { chain: () => chain, storage } as unknown as Editor, calls };
 };
 
 describe('MentionCommandSuggestion', () => {
   const range: Range = { from: 4, to: 12 };
 
-  it('is unavailable until the advanced overlay registers its callback', () => {
+  it('is available when the Mention extension is loaded', () => {
     const { editor } = createEditor();
-    expect(MentionCommandSuggestion.isAvailable?.(editor)).toBe(false);
-
-    const { editor: ready } = createEditor(() => undefined);
-    expect(MentionCommandSuggestion.isAvailable?.(ready)).toBe(true);
+    expect(MentionCommandSuggestion.isAvailable?.(editor)).toBe(true);
   });
 
-  it('is unavailable when the mention extension is absent entirely', () => {
-    const editor = { storage: {} } as unknown as Editor;
+  it('is unavailable when the Mention extension is absent', () => {
+    const { editor } = createEditor({});
     expect(MentionCommandSuggestion.isAvailable?.(editor)).toBe(false);
   });
 
-  it('removes the trigger and opens the picker at its start position', () => {
-    const opened: MentionAdvancedPayload[] = [];
-    const { editor, calls } = createEditor((p) => opened.push(p));
-
-    MentionCommandSuggestion.command({ editor, range });
-
-    expect(calls).toEqual(['focus', 'deleteRange(4,12)', 'run']);
-    // `pos` is the trigger's start, captured before the delete, so the mention
-    // lands where the user typed `/`. The query is empty: the text after the
-    // slash is the command name, not a search term.
-    expect(opened).toEqual([{ pos: 4, query: '' }]);
-  });
-
-  it('leaves the document untouched when the picker cannot be opened', () => {
+  it('swaps the slash trigger for an `@` so the mention dropdown takes over', () => {
     const { editor, calls } = createEditor();
 
     MentionCommandSuggestion.command({ editor, range });
 
-    expect(calls).toEqual([]);
+    // Deleting the trigger first puts the `@` where the `/` was, which is a
+    // position the suggestion plugin's allowedPrefixes already accepted.
+    expect(calls).toEqual([
+      'focus',
+      'deleteRange(4,12)',
+      'insertContentAt(4,@)',
+      'run',
+    ]);
   });
 });

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.spec.ts
@@ -1,0 +1,71 @@
+import { Editor, Range } from '@tiptap/core';
+import { MentionCommandSuggestion } from './MentionCommandSuggestion';
+import type { MentionAdvancedPayload } from './Mention';
+
+/**
+ * A stub editor recording the chained calls the command makes, plus the storage
+ * the command reads. Only `focus`/`deleteRange`/`run` are chained here — enough
+ * for this command, which does no other editing.
+ */
+const createEditor = (openAdvanced?: (p: MentionAdvancedPayload) => void) => {
+  const calls: string[] = [];
+  const chain = {
+    focus: () => {
+      calls.push('focus');
+      return chain;
+    },
+    deleteRange: (range: Range) => {
+      calls.push(`deleteRange(${range.from},${range.to})`);
+      return chain;
+    },
+    run: () => {
+      calls.push('run');
+      return true;
+    },
+  };
+
+  const editor = {
+    chain: () => chain,
+    storage: { mention: { openAdvanced } },
+  } as unknown as Editor;
+
+  return { editor, calls };
+};
+
+describe('MentionCommandSuggestion', () => {
+  const range: Range = { from: 4, to: 12 };
+
+  it('is unavailable until the advanced overlay registers its callback', () => {
+    const { editor } = createEditor();
+    expect(MentionCommandSuggestion.isAvailable?.(editor)).toBe(false);
+
+    const { editor: ready } = createEditor(() => undefined);
+    expect(MentionCommandSuggestion.isAvailable?.(ready)).toBe(true);
+  });
+
+  it('is unavailable when the mention extension is absent entirely', () => {
+    const editor = { storage: {} } as unknown as Editor;
+    expect(MentionCommandSuggestion.isAvailable?.(editor)).toBe(false);
+  });
+
+  it('removes the trigger and opens the picker at its start position', () => {
+    const opened: MentionAdvancedPayload[] = [];
+    const { editor, calls } = createEditor((p) => opened.push(p));
+
+    MentionCommandSuggestion.command({ editor, range });
+
+    expect(calls).toEqual(['focus', 'deleteRange(4,12)', 'run']);
+    // `pos` is the trigger's start, captured before the delete, so the mention
+    // lands where the user typed `/`. The query is empty: the text after the
+    // slash is the command name, not a search term.
+    expect(opened).toEqual([{ pos: 4, query: '' }]);
+  });
+
+  it('leaves the document untouched when the picker cannot be opened', () => {
+    const { editor, calls } = createEditor();
+
+    MentionCommandSuggestion.command({ editor, range });
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.ts
@@ -1,0 +1,39 @@
+import { AtSignIcon } from 'lucide-react';
+import { CommandSuggestionItem } from '../SlashCommand/SuggestionList';
+
+/**
+ * Slash-command entry point for inserting a mention.
+ *
+ * Picking an entity needs a focusable search field, which cannot live in the
+ * slash menu's suggestion popup (focusing it closes the popup) — the same
+ * constraint the `@` dropdown works around with its "Advanced search…" button.
+ * So this item does what that button does: it removes the `/…` trigger and
+ * hands off to the MentionAdvancedOverlay dialog, which owns its own focus and
+ * inserts the chosen mention back at the trigger's position.
+ *
+ * Named `MentionCommandSuggestion` — not `MentionSuggestion` — to stay clearly
+ * distinct from `mentionSuggestion`, the `@`-triggered TipTap suggestion plugin
+ * config in this same directory.
+ */
+export const MentionCommandSuggestion: CommandSuggestionItem = {
+  title: 'Mention',
+  description: 'Link to a passage, folio, work, glossary term, or source.',
+  keywords: ['mention', 'reference', 'cite', 'citation'],
+  icon: AtSignIcon,
+  // The overlay that hosts the picker is a React component mounted alongside
+  // the editor; without it the command would have nothing to open.
+  isAvailable: (editor) => !!editor.storage.mention?.openAdvanced,
+  command: ({ editor, range }) => {
+    const openAdvanced = editor.storage.mention?.openAdvanced;
+    if (!openAdvanced) {
+      return;
+    }
+
+    // Capture the insertion point before deleting the trigger, then hand off.
+    const pos = range.from;
+    editor.chain().focus().deleteRange(range).run();
+    // The typed slash query is the command name ("mention"), not something
+    // worth searching for, so the picker opens with an empty query.
+    openAdvanced({ pos, query: '' });
+  },
+};

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.ts
@@ -20,7 +20,7 @@ import { CommandSuggestionItem } from '../SlashCommand/SuggestionList';
  */
 export const MentionCommandSuggestion: CommandSuggestionItem = {
   title: 'Mention',
-  description: 'Link to a passage, folio, work, glossary term, or source.',
+  description: 'Link to internal resources',
   keywords: ['mention', 'reference', 'cite', 'citation'],
   icon: AtSignIcon,
   // The dropdown this hands off to belongs to the Mention extension. Without it

--- a/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/Mention/MentionCommandSuggestion.ts
@@ -4,36 +4,40 @@ import { CommandSuggestionItem } from '../SlashCommand/SuggestionList';
 /**
  * Slash-command entry point for inserting a mention.
  *
- * Picking an entity needs a focusable search field, which cannot live in the
- * slash menu's suggestion popup (focusing it closes the popup) — the same
- * constraint the `@` dropdown works around with its "Advanced search…" button.
- * So this item does what that button does: it removes the `/…` trigger and
- * hands off to the MentionAdvancedOverlay dialog, which owns its own focus and
- * inserts the chosen mention back at the trigger's position.
+ * Rather than reimplementing the picker, this re-enters the `@` flow: it swaps
+ * the `/…` trigger for an `@`, and the Mention extension's suggestion plugin
+ * takes over from there, showing the same caret-anchored dropdown — debounced
+ * search, grouped results, arrow-key navigation, and its own "Advanced search…"
+ * button for the cases that need a work/toh field.
  *
- * Named `MentionCommandSuggestion` — not `MentionSuggestion` — to stay clearly
- * distinct from `mentionSuggestion`, the `@`-triggered TipTap suggestion plugin
- * config in this same directory.
+ * Two details make the swap reliable. The plugin recomputes its match inside
+ * `apply`, so a programmatic `@` triggers it exactly like a typed one; and the
+ * default `allowedPrefixes` ([' ']) that let the `/` match in the first place
+ * are satisfied by the `@` landing at that same position.
+ *
+ * Named MentionCommandSuggestion, not MentionSuggestion, to stay distinct from
+ * `mentionSuggestion` — the `@`-triggered plugin config in this directory.
  */
 export const MentionCommandSuggestion: CommandSuggestionItem = {
   title: 'Mention',
   description: 'Link to a passage, folio, work, glossary term, or source.',
   keywords: ['mention', 'reference', 'cite', 'citation'],
   icon: AtSignIcon,
-  // The overlay that hosts the picker is a React component mounted alongside
-  // the editor; without it the command would have nothing to open.
-  isAvailable: (editor) => !!editor.storage.mention?.openAdvanced,
+  // The dropdown this hands off to belongs to the Mention extension. Without it
+  // the command would leave a bare `@` and nothing would open, so the item stays
+  // out of menus built from an extension list that omits Mention.
+  isAvailable: (editor) => !!editor.storage.mention,
   command: ({ editor, range }) => {
-    const openAdvanced = editor.storage.mention?.openAdvanced;
-    if (!openAdvanced) {
-      return;
-    }
-
-    // Capture the insertion point before deleting the trigger, then hand off.
-    const pos = range.from;
-    editor.chain().focus().deleteRange(range).run();
-    // The typed slash query is the command name ("mention"), not something
-    // worth searching for, so the picker opens with an empty query.
-    openAdvanced({ pos, query: '' });
+    // `insertContentAt(range.from, …)` rather than `insertContent`: the latter
+    // inserts at whatever the selection happens to be. In the real flow the
+    // caret sits inside the trigger and collapses to `range.from` on delete, so
+    // both agree — but naming the position keeps it correct regardless, and
+    // leaves the caret after the `@` where the plugin needs it.
+    editor
+      .chain()
+      .focus()
+      .deleteRange(range)
+      .insertContentAt(range.from, '@')
+      .run();
   },
 };

--- a/libs/lib-editing/src/lib/components/editor/extensions/SlashCommand/SuggestionList.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/SlashCommand/SuggestionList.tsx
@@ -94,7 +94,13 @@ const SuggestionList = forwardRef<SuggestionListHandle, SuggestionListProps>(
                 props.command(item);
               }}
             >
-              <div className="size-10 flex items-center justify-center border bg-popover rounded-md">
+              {/*
+                `shrink-0`: `size-10` sets a width, but this is a flex child and
+                flex-shrink still defaults to 1, so a long title/description
+                could squeeze the box and leave one item's icon narrower than
+                the rest.
+              */}
+              <div className="size-10 shrink-0 flex items-center justify-center border bg-popover rounded-md">
                 <item.icon className="size-4" />
               </div>
               <div className="flex flex-col">

--- a/libs/lib-editing/src/lib/components/editor/extensions/SlashCommand/SuggestionList.tsx
+++ b/libs/lib-editing/src/lib/components/editor/extensions/SlashCommand/SuggestionList.tsx
@@ -2,12 +2,21 @@
 
 import { SlashCommandNodeAttributes, SuggestionItem } from './SlashCommand';
 import { cn } from '@eightyfourthousand/lib-utils';
+import { Editor } from '@tiptap/core';
 import { SuggestionKeyDownProps, SuggestionProps } from '@tiptap/suggestion';
 import { LucideIcon } from 'lucide-react';
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 
 export interface CommandSuggestionItem extends SuggestionItem {
   icon: LucideIcon;
+  /**
+   * Whether this item can run against the given editor. Items whose command
+   * depends on something the host has to provide — an extension, or a React
+   * overlay registered through `editor.storage` — use this to stay out of the
+   * menu where that dependency is absent, rather than appearing and no-opping.
+   * Omitted means always available.
+   */
+  isAvailable?: (editor: Editor) => boolean;
 }
 
 export interface SuggestionListHandle {

--- a/libs/lib-editing/src/lib/components/editor/extensions/SlashCommand/Suggestions.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/SlashCommand/Suggestions.spec.ts
@@ -1,0 +1,73 @@
+import { Editor } from '@tiptap/core';
+import { CircleIcon } from 'lucide-react';
+import { getSuggestion } from './Suggestions';
+import { CommandSuggestionItem } from './SuggestionList';
+
+const item = (
+  title: string,
+  keywords: string[],
+  isAvailable?: CommandSuggestionItem['isAvailable'],
+): CommandSuggestionItem => ({
+  title,
+  description: title,
+  keywords,
+  icon: CircleIcon,
+  ...(isAvailable ? { isAvailable } : {}),
+  command: () => undefined,
+});
+
+// `items` only reads `editor` to pass it to each item's `isAvailable`, so a
+// stub with the storage those predicates consult is enough.
+const editorWith = (storage: Record<string, unknown>) =>
+  ({ storage }) as unknown as Editor;
+
+const listItems = (
+  suggestions: CommandSuggestionItem[],
+  query: string,
+  editor: Editor = editorWith({}),
+) => {
+  const items = getSuggestion(suggestions).items;
+  if (!items) {
+    throw new Error('getSuggestion did not provide an items function');
+  }
+  const result = items({ query, editor });
+  if (result instanceof Promise) {
+    throw new Error('items is expected to resolve synchronously');
+  }
+  return result.map((i) => i.title);
+};
+
+describe('getSuggestion items', () => {
+  const heading = item('Heading', ['heading', 'title']);
+  const quote = item('Quote', ['blockquote']);
+
+  it('matches items on any keyword prefix, case-insensitively', () => {
+    expect(listItems([heading, quote], 'Head')).toEqual(['Heading']);
+    expect(listItems([heading, quote], 'ti')).toEqual(['Heading']);
+    expect(listItems([heading, quote], 'block')).toEqual(['Quote']);
+  });
+
+  it('returns every item for an empty query', () => {
+    expect(listItems([heading, quote], '')).toEqual(['Heading', 'Quote']);
+  });
+
+  it('omits an item whose isAvailable predicate rejects the editor', () => {
+    const mention = item('Mention', ['mention'], (editor) =>
+      Boolean((editor.storage.mention as { openAdvanced?: unknown } | undefined)
+        ?.openAdvanced),
+    );
+
+    expect(listItems([heading, mention], 'mention')).toEqual([]);
+    expect(
+      listItems(
+        [heading, mention],
+        'mention',
+        editorWith({ mention: { openAdvanced: () => undefined } }),
+      ),
+    ).toEqual(['Mention']);
+  });
+
+  it('keeps items that declare no availability predicate', () => {
+    expect(listItems([heading], 'heading')).toEqual(['Heading']);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/SlashCommand/Suggestions.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/SlashCommand/Suggestions.ts
@@ -126,8 +126,11 @@ export const getSuggestion = (
   suggestions: CommandSuggestionItem[] = defaultSuggestions,
 ): SuggestionType => {
   return {
-    items: ({ query }) => {
+    items: ({ query, editor }) => {
       return suggestions.filter((item: CommandSuggestionItem) => {
+        if (item.isAvailable && !item.isAvailable(editor)) {
+          return false;
+        }
         return item.keywords.some((kwd) => kwd.startsWith(query.toLowerCase()));
       });
     },

--- a/libs/lib-editing/src/lib/components/editor/hooks/useTranslationExtensions.ts
+++ b/libs/lib-editing/src/lib/components/editor/hooks/useTranslationExtensions.ts
@@ -43,6 +43,7 @@ import { InternalLink } from '../extensions/InternalLink';
 import { ForeignMark } from '../extensions/Foreign/Foreign';
 import { MantraMark } from '../extensions/Mantra/Mantra';
 import { Mention } from '../extensions/Mention/Mention';
+import { MentionCommandSuggestion } from '../extensions/Mention/MentionCommandSuggestion';
 import { EndNoteLinkMark } from '../extensions/EndNoteLink/EndNoteLinkMark';
 import { GlossaryInstanceNode } from '../extensions/GlossaryInstance/GlossaryInstanceNode';
 import {
@@ -87,6 +88,7 @@ export const useTranslationExtensions = ({
     Heading2Suggestion,
     Heading3Suggestion,
     AbbreviationSuggestion,
+    MentionCommandSuggestion,
     BulletListSuggestion,
     NumberListSuggestion,
     QuoteSuggestion,

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/MentionSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/MentionSelector.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { cn } from '@eightyfourthousand/lib-utils';
+import { Editor } from '@tiptap/core';
+import { useEditorState } from '@tiptap/react';
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@eightyfourthousand/design-system';
+import { AtSignIcon } from 'lucide-react';
+import { useState } from 'react';
+import { MentionSearch } from '../../extensions/Mention/MentionSearch';
+
+/**
+ * Bubble-menu entry point for inserting a mention over the selection. Mirrors
+ * GlossarySelector: the selected text seeds the entity search, so selecting the
+ * reference an author typed by hand ("2.25", "Introduction") and clicking `@`
+ * opens the picker already querying for it.
+ *
+ * A mention is an inline atom that renders its own label, not a mark that wraps
+ * text, so inserting one replaces the selection — the hand-typed reference gives
+ * way to a live label that tracks its target.
+ */
+export const MentionSelector = ({ editor }: { editor: Editor }) => {
+  const [open, setOpen] = useState(false);
+  const editorState = useEditorState({
+    editor,
+    selector: (instance) => ({
+      isActive: instance.editor.isActive('mention'),
+    }),
+  });
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="px-2 rounded-none flex-shrink-0"
+        >
+          <AtSignIcon
+            className={cn(
+              'size-4',
+              editorState.isActive
+                ? 'text-foreground'
+                : 'text-muted-foreground',
+            )}
+            strokeWidth={2.5}
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-72 shadow-xl rounded-md border p-2"
+        align="end"
+        noPortal
+      >
+        <MentionSearch
+          initialQuery={editor.state.doc.textBetween(
+            editor.state.selection.from,
+            editor.state.selection.to,
+            ' ',
+          )}
+          onSelect={({ entity, linkType, label, isSameWork }) => {
+            // `setMention` inserts over the live selection, replacing it. The
+            // label is passed for immediate display only; it is not persisted,
+            // so the canonical value resolves on load.
+            editor
+              .chain()
+              .focus()
+              .setMention(entity, linkType, label, isSameWork)
+              .run();
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/MentionSelector.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/MentionSelector.tsx
@@ -51,8 +51,15 @@ export const MentionSelector = ({ editor }: { editor: Editor }) => {
           />
         </Button>
       </PopoverTrigger>
+      {/*
+        `w-fit`, not a fixed width: MentionSearch carries its own `w-72` (it is
+        shared with the mention hover card and the advanced dialog), so pinning
+        a width here leaves that rigid child overflowing the padded content box
+        — `w-72` with `p-2` gives it only 17rem to sit in. LinkSelector wraps a
+        self-sizing child the same way.
+      */}
       <PopoverContent
-        className="w-72 shadow-xl rounded-md border p-2"
+        className="w-fit shadow-xl rounded-md border p-2"
         align="end"
         noPortal
       >

--- a/libs/lib-editing/src/lib/components/editor/menus/selectors/TranslationTextButtons.tsx
+++ b/libs/lib-editing/src/lib/components/editor/menus/selectors/TranslationTextButtons.tsx
@@ -17,6 +17,7 @@ import { LinkSelector } from './LinkSelector';
 import { MantraSelector } from './MantraSelector';
 import { EndNoteSelector } from './EndNoteSelector';
 import { GlossarySelector } from './GlossarySelector';
+import { MentionSelector } from './MentionSelector';
 
 interface SelectorResult {
   isBold: boolean;
@@ -120,6 +121,7 @@ export const TranslationTextButtons = ({ editor }: { editor: Editor }) => {
       <MantraSelector editor={editor} />
       <Separator orientation="vertical" className="h-10" />
       <GlossarySelector editor={editor} />
+      <MentionSelector editor={editor} />
       <LinkSelector editor={editor} />
       <EndNoteSelector editor={editor} />
     </>


### PR DESCRIPTION
### Summary

Adds two entry points for inserting a mention: a `Mention` item in the slash menu, and an `@` button in the translation bubble menu that seeds the entity search with the selected text.

### Linear

- [DEV-722](https://linear.app/84000/issue/DEV-722)