### PR TITLE
Fix italic dandas in the readers

### DIFF
--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/PipeNotItalic.integration.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/PipeNotItalic.integration.spec.ts
@@ -1,0 +1,71 @@
+import type { JSONContent } from '@tiptap/core';
+import { Editor, Node } from '@tiptap/core';
+
+import { ForeignMark } from '../Foreign/Foreign';
+import { Italic } from '../Italic';
+import { PipeNotItalic } from './PipeNotItalic';
+
+const Doc = Node.create({ name: 'doc', topNode: true, content: 'block+' });
+const Paragraph = Node.create({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+  parseHTML: () => [{ tag: 'p' }],
+  renderHTML: () => ['p', 0],
+});
+const TextNode = Node.create({ name: 'text', group: 'inline' });
+
+/**
+ * Mounts a real editor and reads the rendered DOM, so this covers the
+ * decorations themselves rather than just the predicate behind them.
+ *
+ * Content goes in as JSON rather than HTML on purpose: `ForeignMark` defines
+ * no `parseHTML` for `lang`, so an HTML fixture silently loses it and every
+ * foreign run would look like the default. Passages reach the editor as JSON
+ * from the annotation transformers, which is what this mirrors.
+ */
+const editorHtml = (...content: JSONContent[]): string => {
+  const editor = new Editor({
+    element: document.createElement('div'),
+    extensions: [Doc, Paragraph, TextNode, Italic, ForeignMark, PipeNotItalic],
+    content: { type: 'doc', content: [{ type: 'paragraph', content }] },
+  });
+  const html = editor.view.dom.innerHTML;
+  editor.destroy();
+  return html;
+};
+
+describe('PipeNotItalic', () => {
+  it('decorates dandas inside an italic mark', () => {
+    const html = editorHtml({
+      type: 'text',
+      text: 'gang gi | blo gros',
+      marks: [{ type: 'italic' }],
+    });
+    expect(html).toContain('not-italic');
+  });
+
+  it('decorates dandas inside a foreign mark, which carries no italic mark', () => {
+    const html = editorHtml({
+      type: 'text',
+      text: 'oṃ | āḥ',
+      marks: [{ type: 'foreign', attrs: { lang: 'Sa-Ltn' } }],
+    });
+    expect(html).toContain('not-italic');
+  });
+
+  it('leaves dandas under a lang the design system does not italicise', () => {
+    const html = editorHtml({
+      type: 'text',
+      text: '大 | 乘',
+      marks: [{ type: 'foreign', attrs: { lang: 'zh' } }],
+    });
+    expect(html).not.toContain('not-italic');
+  });
+
+  it('leaves dandas in plain text undecorated', () => {
+    expect(editorHtml({ type: 'text', text: 'plain | text' })).not.toContain(
+      'not-italic',
+    );
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/PipeNotItalic.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/PipeNotItalic.ts
@@ -1,13 +1,23 @@
 import { Extension } from '@tiptap/core';
-import type { Node, Mark } from '@tiptap/pm/model';
+import type { Node } from '@tiptap/pm/model';
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
+
+import {
+  hasItalicizingMark,
+  UPRIGHT_PIPE_CLASS,
+  UPRIGHT_PIPE_STYLE,
+} from './italicizingMarks';
 
 const pluginKey = new PluginKey('pipeNotItalic');
 
 /**
- * Scans a region of the document for italic text nodes containing `|`
+ * Scans a region of the document for italicised text nodes containing `|`
  * and returns an array of inline Decorations for each match.
+ *
+ * This only covers live editors. Decorations belong to the view, so the
+ * readers — which serialise through `@tiptap/static-renderer` and never build
+ * an EditorView — get the same rule from `renderTextToHTMLString` instead.
  */
 function findPipeDecorations(doc: Node, from: number, to: number) {
   const decorations: Decoration[] = [];
@@ -15,17 +25,15 @@ function findPipeDecorations(doc: Node, from: number, to: number) {
   doc.nodesBetween(from, to, (node, pos) => {
     if (!node.isText) return;
 
-    const isItalic = node.marks.some(
-      (mark: Mark) => mark.type.name === 'italic' || mark.type.name === 'em',
-    );
-    if (!isItalic) return;
+    if (!hasItalicizingMark(node.marks)) return;
 
     const text = node.text ?? '';
     let index = text.indexOf('|');
     while (index !== -1) {
       decorations.push(
         Decoration.inline(pos + index, pos + index + 1, {
-          class: 'not-italic',
+          class: UPRIGHT_PIPE_CLASS,
+          style: UPRIGHT_PIPE_STYLE,
         }),
       );
       index = text.indexOf('|', index + 1);

--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/index.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/index.ts
@@ -1,0 +1,9 @@
+export { PipeNotItalic } from './PipeNotItalic';
+export { renderTextToHTMLString } from './pipeNotItalicSSRMapping';
+export {
+  hasItalicizingMark,
+  isItalicizingMark,
+  UPRIGHT_LANGS,
+  UPRIGHT_PIPE_CLASS,
+  UPRIGHT_PIPE_STYLE,
+} from './italicizingMarks';

--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/italicizingMarks.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/italicizingMarks.spec.ts
@@ -1,0 +1,29 @@
+import { isItalicizingMark } from './italicizingMarks';
+
+describe('isItalicizingMark', () => {
+  it('treats the italic mark and its em alias as italicising', () => {
+    expect(isItalicizingMark('italic')).toBe(true);
+    expect(isItalicizingMark('em')).toBe(true);
+  });
+
+  it('treats a mark rendering a transliteration lang as italicising', () => {
+    // `foreign` and `mantra` carry no italic mark; the design system's
+    // `[lang]:not(...)` rule is what italicises them.
+    expect(isItalicizingMark('foreign', { lang: 'Sa-Ltn' })).toBe(true);
+    expect(isItalicizingMark('foreign', { lang: 'Bo-Ltn' })).toBe(true);
+    expect(isItalicizingMark('mantra', { lang: 'Sa-Ltn' })).toBe(true);
+    expect(isItalicizingMark('foreign', { lang: 'foreign' })).toBe(true);
+  });
+
+  it('leaves the langs that rule excludes upright', () => {
+    for (const lang of ['en', 'bo', 'ja', 'zh']) {
+      expect(isItalicizingMark('foreign', { lang })).toBe(false);
+    }
+  });
+
+  it('does not italicise marks with no lang and no italic', () => {
+    expect(isItalicizingMark('bold')).toBe(false);
+    expect(isItalicizingMark('smallCaps', {})).toBe(false);
+    expect(isItalicizingMark('underline', { lang: undefined })).toBe(false);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/italicizingMarks.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/italicizingMarks.ts
@@ -1,0 +1,42 @@
+import type { Mark } from '@tiptap/pm/model';
+
+/**
+ * The design system italicises any element carrying a `lang` attribute apart
+ * from these four (`[lang]:not([lang='en'], [lang='bo'], [lang='ja'],
+ * [lang='zh'])` in `components.css`). `foreign` and `mantra` both render a
+ * `lang`, so their text comes out italic without ever carrying an italic mark.
+ * Keep this list in step with that rule.
+ */
+export const UPRIGHT_LANGS = new Set(['en', 'bo', 'ja', 'zh']);
+
+/**
+ * Whether a mark renders its text in italics — either because it is the italic
+ * mark itself, or because the `lang` it renders trips the rule above.
+ *
+ * Takes the name and attributes rather than a mark so that both callers can
+ * use it: the ProseMirror plugin holds `Mark` instances, while the static
+ * renderer's node mapping sees whatever the schema handed it.
+ */
+export const isItalicizingMark = (
+  name: string,
+  attrs?: Record<string, unknown> | null,
+): boolean => {
+  if (name === 'italic' || name === 'em') {
+    return true;
+  }
+
+  const lang = attrs?.lang;
+  return typeof lang === 'string' && !UPRIGHT_LANGS.has(lang);
+};
+
+export const hasItalicizingMark = (marks: readonly Mark[]): boolean =>
+  marks.some((mark) => isItalicizingMark(mark.type.name, mark.attrs));
+
+/**
+ * Applied to each `|` so it stays upright inside italic text. The class is the
+ * themable hook; the inline style is what actually guarantees the result,
+ * since the three apps that render translations build their CSS separately and
+ * a Tailwind utility is only present where that app's build emitted it.
+ */
+export const UPRIGHT_PIPE_CLASS = 'not-italic';
+export const UPRIGHT_PIPE_STYLE = 'font-style:normal';

--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/pipeNotItalicSSRMapping.spec.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/pipeNotItalicSSRMapping.spec.ts
@@ -1,0 +1,96 @@
+import type { JSONContent } from '@tiptap/core';
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string';
+
+import { translationSSRExtensions } from '../translationSSRExtensions';
+import { renderTextToHTMLString } from './pipeNotItalicSSRMapping';
+
+const render = (content: JSONContent) =>
+  renderToHTMLString({
+    content,
+    extensions: translationSSRExtensions,
+    options: { nodeMapping: { text: renderTextToHTMLString } },
+  });
+
+const para = (...content: JSONContent[]): JSONContent => ({
+  type: 'doc',
+  content: [{ type: 'paragraph', content }],
+});
+
+const UPRIGHT = '<span class="not-italic" style="font-style:normal">|</span>';
+
+describe('renderTextToHTMLString', () => {
+  it('keeps the danda upright inside an italic mark', () => {
+    const html = render(
+      para({
+        type: 'text',
+        text: 'gang gi | blo gros',
+        marks: [{ type: 'italic', attrs: { textStyle: 'emphasis' } }],
+      }),
+    );
+    expect(html).toContain(`gang gi ${UPRIGHT} blo gros`);
+  });
+
+  it('keeps the danda upright inside a foreign mark, which has no italic mark', () => {
+    const html = render(
+      para({
+        type: 'text',
+        text: 'oṃ | āḥ hūṃ',
+        marks: [
+          { type: 'foreign', attrs: { lang: 'Sa-Ltn', textStyle: 'foreign' } },
+        ],
+      }),
+    );
+    expect(html).toContain(`oṃ ${UPRIGHT} āḥ hūṃ`);
+  });
+
+  it('keeps the danda upright inside a mantra mark', () => {
+    const html = render(
+      para({
+        type: 'text',
+        text: 'tadyathā | svāhā',
+        marks: [{ type: 'mantra', attrs: { lang: 'Sa-Ltn' } }],
+      }),
+    );
+    expect(html).toContain(`tadyathā ${UPRIGHT} svāhā`);
+  });
+
+  it('wraps every danda in a run, including a doubled one', () => {
+    const html = render(
+      para({
+        type: 'text',
+        text: 'a | b ||',
+        marks: [{ type: 'italic' }],
+      }),
+    );
+    expect(html).toContain(`a ${UPRIGHT} b ${UPRIGHT}${UPRIGHT}`);
+  });
+
+  it('leaves dandas in upright text alone', () => {
+    const html = render(para({ type: 'text', text: 'plain | text' }));
+    expect(html).toContain('plain | text');
+    expect(html).not.toContain(UPRIGHT);
+  });
+
+  it('leaves dandas alone under a lang the design system does not italicise', () => {
+    const html = render(
+      para({
+        type: 'text',
+        text: '大 | 乘',
+        marks: [{ type: 'foreign', attrs: { lang: 'zh', textStyle: 'foreign' } }],
+      }),
+    );
+    expect(html).toContain('大 | 乘');
+    expect(html).not.toContain(UPRIGHT);
+  });
+
+  it('still escapes html in the surrounding text', () => {
+    const html = render(
+      para({
+        type: 'text',
+        text: '<b>&x</b> | y',
+        marks: [{ type: 'italic' }],
+      }),
+    );
+    expect(html).toContain(`&lt;b&gt;&amp;x&lt;/b&gt; ${UPRIGHT} y`);
+  });
+});

--- a/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/pipeNotItalicSSRMapping.ts
+++ b/libs/lib-editing/src/lib/components/editor/extensions/PipeNotItalic/pipeNotItalicSSRMapping.ts
@@ -1,0 +1,38 @@
+import type { Node as PMNode } from '@tiptap/pm/model';
+import { escapeHtml } from '@eightyfourthousand/lib-utils';
+
+import {
+  hasItalicizingMark,
+  UPRIGHT_PIPE_CLASS,
+  UPRIGHT_PIPE_STYLE,
+} from './italicizingMarks';
+
+/**
+ * `nodeMapping.text` override for `renderToHTMLString`, wrapping every `|` in
+ * italicised text so the danda stays upright.
+ *
+ * `PipeNotItalic` expresses the same rule as ProseMirror decorations, which
+ * exist only where there is an EditorView. The readers serialise statically,
+ * so without this the dandas render italic there (ED-1458).
+ *
+ * The renderer hands this the text node with its marks still attached and
+ * wraps the result in them afterwards, so the marks are readable here. It also
+ * escapes text itself, but only in the default `text` handler this replaces,
+ * so escaping happens here instead.
+ */
+export const renderTextToHTMLString = ({ node }: { node: PMNode }): string => {
+  const text = node.text ?? '';
+
+  if (!text.includes('|') || !hasItalicizingMark(node.marks)) {
+    return escapeHtml(text);
+  }
+
+  // Splitting on the pipe covers runs like `||` too: the empty string between
+  // two pipes rejoins as a second wrapped separator.
+  return text
+    .split('|')
+    .map(escapeHtml)
+    .join(
+      `<span class="${UPRIGHT_PIPE_CLASS}" style="${UPRIGHT_PIPE_STYLE}">|</span>`,
+    );
+};

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.spec.tsx
@@ -674,6 +674,55 @@ describe('TranslationSSRContent', () => {
     );
   });
 
+  it('keeps dandas upright in italic and foreign runs (ED-1458)', () => {
+    // The rule lives in the PipeNotItalic plugin as decorations, which never
+    // run here; this asserts the static renderer applies it too.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'passage',
+          attrs: { uuid: 'p-1', label: '1.1', sort: 0 },
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'hūṁ | picu',
+                  marks: [{ type: 'italic', attrs: { textStyle: 'emphasis' } }],
+                },
+                { type: 'text', text: ' — ' },
+                {
+                  type: 'text',
+                  text: 'oṃ | āḥ',
+                  marks: [
+                    {
+                      type: 'foreign',
+                      attrs: { lang: 'Sa-Ltn', textStyle: 'foreign' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const el = TranslationSSRContent({
+      content: doc,
+    }) as ReactElement<DangerousProps>;
+    const html = renderedHtml(el);
+    const upright = '<span class="not-italic" style="font-style:normal">|</span>';
+
+    expect(html).toContain(`hūṁ ${upright} picu`);
+    expect(html).toContain(`oṃ ${upright} āḥ`);
+    // The surrounding marks still wrap the run they came from.
+    expect(html).toContain('<em');
+    expect(html).toContain('lang="Sa-Ltn"');
+  });
+
   it('exposes the default SSR extension set including passage and bold', () => {
     const names = translationSSRExtensions.map((e) => e.name);
     expect(names).toEqual(expect.arrayContaining(['passage', 'bold']));

--- a/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
+++ b/libs/lib-editing/src/lib/components/reader/TranslationSSRContent.tsx
@@ -1,9 +1,14 @@
 import type { Extensions, JSONContent } from '@tiptap/core';
 import { getSchema } from '@tiptap/core';
 import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string';
-import { cn } from '@eightyfourthousand/lib-utils';
+import {
+  cn,
+  escapeHtml,
+  escapeHtmlAttribute,
+} from '@eightyfourthousand/lib-utils';
 import { translationSSRExtensions } from '../editor/extensions/translationSSRExtensions';
 import { renderMentionToHTMLString } from '../editor/extensions/Mention/mentionSSRMapping';
+import { renderTextToHTMLString } from '../editor/extensions/PipeNotItalic';
 import { extractPlainText } from './ssr-text-fallback';
 
 type EndNoteItem = {
@@ -19,11 +24,6 @@ const isEndNoteItem = (value: unknown): value is EndNoteItem => {
   const v = value as Record<string, unknown>;
   return typeof v.uuid === 'string' && typeof v.endNote === 'string';
 };
-
-const escapeHTML = (value: string) =>
-  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-const escapeHTMLAttribute = (value: string) =>
-  escapeHTML(value).replace(/"/g, '&quot;');
 
 const renderEndNoteLinkMark = ({
   mark,
@@ -43,19 +43,19 @@ const renderEndNoteLinkMark = ({
 
   const supHtml = (n: EndNoteItem, marginClass: string) => {
     const cls = cn('end-note-link', marginClass);
-    const tohAttr = n.toh ? ` data-toh="${escapeHTMLAttribute(n.toh)}"` : '';
-    const itemLabel = escapeHTML(n.label?.split('.').pop() || '');
+    const tohAttr = n.toh ? ` data-toh="${escapeHtmlAttribute(n.toh)}"` : '';
+    const itemLabel = escapeHtml(n.label?.split('.').pop() || '');
     // Glue the marker to the text it's attached to with a word joiner (U+2060)
     // so it never wraps to a new line away from its content: after the text for
     // start notes, before it for end notes.
     const joined =
       n.location === 'start' ? `${itemLabel}⁠` : `⁠${itemLabel}`;
     return (
-      `<sup class="${escapeHTMLAttribute(cls)}"` +
+      `<sup class="${escapeHtmlAttribute(cls)}"` +
       tohAttr +
       ` type="endNoteLink"` +
-      ` endNote="${escapeHTMLAttribute(n.endNote)}"` +
-      ` uuid="${escapeHTMLAttribute(n.uuid)}">` +
+      ` endNote="${escapeHtmlAttribute(n.endNote)}"` +
+      ` uuid="${escapeHtmlAttribute(n.uuid)}">` +
       `${joined}</sup>`
     );
   };
@@ -154,7 +154,10 @@ export const TranslationSSRContent = ({
       extensions: exts,
       options: {
         markMapping: { endNoteLink: renderEndNoteLinkMark },
-        nodeMapping: { mention: renderMentionToHTMLString },
+        nodeMapping: {
+          mention: renderMentionToHTMLString,
+          text: renderTextToHTMLString,
+        },
       },
     });
   } catch (err) {

--- a/libs/lib-editing/src/lib/components/stack/PassageStackController.ts
+++ b/libs/lib-editing/src/lib/components/stack/PassageStackController.ts
@@ -22,6 +22,7 @@ import type { TranslationEditorContentItem } from '@eightyfourthousand/data-acce
 
 import { incrementLabel } from '../editor/extensions/Passage/label';
 import { renderMentionToHTMLString } from '../editor/extensions/Mention/mentionSSRMapping';
+import { renderTextToHTMLString } from '../editor/extensions/PipeNotItalic';
 import {
   buildStackEditorExtensions,
   buildStackSchemaExtensions,
@@ -162,7 +163,12 @@ export class PassageStackController {
       html = renderToHTMLString({
         content: this.getDocJSON(uuid),
         extensions: buildStackSchemaExtensions(),
-        options: { nodeMapping: { mention: renderMentionToHTMLString } },
+        options: {
+          nodeMapping: {
+            mention: renderMentionToHTMLString,
+            text: renderTextToHTMLString,
+          },
+        },
       });
     } catch (error) {
       console.error('failed to statically render passage', error);

--- a/libs/lib-utils/src/lib/string.spec.ts
+++ b/libs/lib-utils/src/lib/string.spec.ts
@@ -1,5 +1,7 @@
 import {
   compareIgnoringArticles,
+  escapeHtml,
+  escapeHtmlAttribute,
   parseToh,
   stripLeadingArticles,
 } from './string';
@@ -61,5 +63,31 @@ describe('compareIgnoringArticles', () => {
 
   it('ignores case and diacritics', () => {
     expect(compareIgnoringArticles('āpple', 'Apple')).toBe(0);
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes the characters that break out of a text node', () => {
+    expect(escapeHtml('<b>a & b</b>')).toBe('&lt;b&gt;a &amp; b&lt;/b&gt;');
+  });
+
+  it('escapes ampersands before the entities it introduces', () => {
+    expect(escapeHtml('&lt;')).toBe('&amp;lt;');
+  });
+
+  it('leaves quotes alone, since a text node may hold them', () => {
+    expect(escapeHtml('say "hi"')).toBe('say "hi"');
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(escapeHtml('oṃ | āḥ hūṃ')).toBe('oṃ | āḥ hūṃ');
+  });
+});
+
+describe('escapeHtmlAttribute', () => {
+  it('escapes double quotes as well', () => {
+    expect(escapeHtmlAttribute('say "hi" & <bye>')).toBe(
+      'say &quot;hi&quot; &amp; &lt;bye&gt;',
+    );
   });
 });

--- a/libs/lib-utils/src/lib/string.ts
+++ b/libs/lib-utils/src/lib/string.ts
@@ -36,3 +36,16 @@ export const isUuid = (str: string) =>
 
 export const isXmlId = (str: string) =>
   /^UT\d+-\d+-\d+(-[\w]+)*$/.test(str);
+
+/**
+ * Escapes text for interpolation into HTML markup.
+ *
+ * Only the three characters that can break out of a text node — an attribute
+ * value needs `escapeHtmlAttribute` instead.
+ */
+export const escapeHtml = (str: string) =>
+  str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/** Escapes text for interpolation into a double-quoted HTML attribute. */
+export const escapeHtmlAttribute = (str: string) =>
+  escapeHtml(str).replace(/"/g, '&quot;');


### PR DESCRIPTION
### Summary

The bar used for dandas rendered italic in the readers. `PipeNotItalic` is built from ProseMirror decorations, so it never ran where content is statically rendered, and it only matched `italic`/`em` marks — missing the `foreign` spans that most italics in the corpus actually come from.

### Linear

- [ED-1458](https://linear.app/84000/issue/ED-1458)
